### PR TITLE
feat: Add admin notifications for SMS/Email delivery failures

### DIFF
--- a/backend/src/admin_notifications.rs
+++ b/backend/src/admin_notifications.rs
@@ -84,6 +84,50 @@ impl AdminNotifications {
         }
     }
 
+    /// Notify admin when a notification provider (SMS/Email) has consecutive delivery failures.
+    pub async fn notify_provider_failure(
+        &self,
+        provider_name: &str,
+        consecutive_failures: u32,
+        error_category: &str,
+        last_error: Option<&str>,
+        suggested_action: &str,
+    ) {
+        if let Some(topic) = &self.topic {
+            let error_info = last_error.unwrap_or("Unknown error");
+            let message = format!(
+                "🚨 Provider: {}\n📊 Consecutive failures: {}\n🏷️ Error type: {}\n📝 Last error: {}\n\n💡 Suggested action: {}\n\n⚠️ {} notifications are not being delivered until this is resolved.",
+                provider_name, consecutive_failures, error_category, error_info, suggested_action, provider_name
+            );
+
+            self.send_notification(
+                topic,
+                &format!("{} Delivery Failed", provider_name),
+                &message,
+                "warning",
+            )
+            .await;
+        }
+    }
+
+    /// Notify admin when a notification provider recovers after failures.
+    pub async fn notify_provider_recovery(&self, provider_name: &str) {
+        if let Some(topic) = &self.topic {
+            let message = format!(
+                "✅ {} is working again.\n📡 Notifications will be delivered normally.",
+                provider_name
+            );
+
+            self.send_notification(
+                topic,
+                &format!("{} Delivery Restored", provider_name),
+                &message,
+                "white_check_mark",
+            )
+            .await;
+        }
+    }
+
     async fn send_notification(&self, topic: &str, title: &str, message: &str, tag: &str) {
         let ntfy_url = format!("https://ntfy.sh/{}", topic);
 

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -38,13 +38,17 @@ pub struct CreateWalletRequest {
     /// The multipath output descriptor for the wallet or extended public key (XPUB)
     pub descriptor: String,
     /// The user's preferred language for notifications (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]    pub preferred_language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preferred_language: Option<String>,
     /// Whether this is a fresh wallet with no transaction history (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]    pub is_fresh_wallet: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_fresh_wallet: Option<bool>,
     /// Script type for XPUB wallets (required when is_fresh_wallet=true and descriptor is XPUB, optional for advanced settings)
-    #[serde(skip_serializing_if = "Option::is_none")]    pub script_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub script_type: Option<String>,
     /// Stop gap for advanced users (auto, 250, 500, 750, 1000)
-    #[serde(skip_serializing_if = "Option::is_none")]    pub stop_gap: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_gap: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -177,9 +181,18 @@ impl AppServices {
         if is_admin {
             tracing::info!("🎯 Applying unlimited limits for admin user {}", user_id);
         } else if !is_subscription_active {
-            tracing::info!("🎯 Deactivating all wallets for user {} (status: {})", user_id, subscription_status);
+            tracing::info!(
+                "🎯 Deactivating all wallets for user {} (status: {})",
+                user_id,
+                subscription_status
+            );
         } else {
-            tracing::info!("🎯 Applying {} tier limits for user {} (status: {})", tier, user_id, subscription_status);
+            tracing::info!(
+                "🎯 Applying {} tier limits for user {} (status: {})",
+                tier,
+                user_id,
+                subscription_status
+            );
         }
 
         // Get all wallets for this user ordered by creation time (oldest first)
@@ -3412,7 +3425,8 @@ pub async fn demo_login(
             return (
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse {
-                    error: "Demo user not found. Please ensure backend is running in dev mode.".to_string(),
+                    error: "Demo user not found. Please ensure backend is running in dev mode."
+                        .to_string(),
                 }),
             )
                 .into_response();
@@ -4990,7 +5004,8 @@ pub async fn create_wallet_balance_alert(
 
     // Validate threshold type: exactly one must be provided (BTC OR fiat, not both or neither)
     let is_btc_threshold = request.threshold_sats.is_some();
-    let is_fiat_threshold = request.threshold_currency.is_some() && request.threshold_fiat_amount.is_some();
+    let is_fiat_threshold =
+        request.threshold_currency.is_some() && request.threshold_fiat_amount.is_some();
 
     if is_btc_threshold == is_fiat_threshold {
         return (
@@ -5023,7 +5038,8 @@ pub async fn create_wallet_balance_alert(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
-                    error: "Cannot create alert for 'below 0' - balance cannot go below zero".to_string(),
+                    error: "Cannot create alert for 'below 0' - balance cannot go below zero"
+                        .to_string(),
                 }),
             )
                 .into_response();
@@ -5051,7 +5067,11 @@ pub async fn create_wallet_balance_alert(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
-                    error: format!("Unsupported currency: {}. Supported currencies: {}", currency, crate::exchange_rates::SUPPORTED_CURRENCIES.join(", ")),
+                    error: format!(
+                        "Unsupported currency: {}. Supported currencies: {}",
+                        currency,
+                        crate::exchange_rates::SUPPORTED_CURRENCIES.join(", ")
+                    ),
                 }),
             )
                 .into_response();
@@ -5092,7 +5112,10 @@ pub async fn create_wallet_balance_alert(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
-                    error: format!("Fiat amount {} {} is too small to convert to satoshis", fiat_amount, currency),
+                    error: format!(
+                        "Fiat amount {} {} is too small to convert to satoshis",
+                        fiat_amount, currency
+                    ),
                 }),
             )
                 .into_response();
@@ -5198,9 +5221,7 @@ pub async fn create_wallet_balance_alert(
 
             return (
                 StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: error_msg,
-                }),
+                Json(ErrorResponse { error: error_msg }),
             )
                 .into_response();
         }
@@ -5209,7 +5230,13 @@ pub async fn create_wallet_balance_alert(
     // Create the balance alert
     match app_services
         .metadata_db
-        .create_balance_alert(&checksum, threshold_sats, request.alert_type, threshold_currency, threshold_fiat_amount)
+        .create_balance_alert(
+            &checksum,
+            threshold_sats,
+            request.alert_type,
+            threshold_currency,
+            threshold_fiat_amount,
+        )
         .await
     {
         Ok(alert) => Json(alert).into_response(),

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -324,7 +324,13 @@ impl AuthService {
         contact_email.to_lowercase() == user_email.to_lowercase()
     }
 
-    pub fn generate_token(&self, user_id: &str, email: &str, is_admin: bool, is_demo: bool) -> Result<String> {
+    pub fn generate_token(
+        &self,
+        user_id: &str,
+        email: &str,
+        is_admin: bool,
+        is_demo: bool,
+    ) -> Result<String> {
         let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as usize;
 
         // Generate unique JWT ID using nanosecond timestamp to prevent token collision

--- a/backend/src/electrum.rs
+++ b/backend/src/electrum.rs
@@ -417,9 +417,15 @@ impl ElectrumClientManager {
         };
 
         if has_client {
-            info!("ElectrumClientManager: Initial connection successful to {}", url);
+            info!(
+                "ElectrumClientManager: Initial connection successful to {}",
+                url
+            );
         } else {
-            warn!("ElectrumClientManager: Initial connection failed to {}, will retry on first sync", url);
+            warn!(
+                "ElectrumClientManager: Initial connection failed to {}, will retry on first sync",
+                url
+            );
         }
 
         Ok(manager)
@@ -483,7 +489,10 @@ impl ElectrumClientManager {
         }
 
         // We have the reconnection lock
-        info!("ElectrumClientManager: Attempting reconnection to {}", self.url);
+        info!(
+            "ElectrumClientManager: Attempting reconnection to {}",
+            self.url
+        );
 
         let result = match ElectrumClient::new(&self.url) {
             Ok(new_client) => {
@@ -564,10 +573,16 @@ mod tests {
     fn test_is_transport_error() {
         // Should be detected as transport errors
         assert!(ElectrumClientManager::is_transport_error("Broken pipe"));
-        assert!(ElectrumClientManager::is_transport_error("broken pipe (os error 32)"));
-        assert!(ElectrumClientManager::is_transport_error("connection reset by peer"));
+        assert!(ElectrumClientManager::is_transport_error(
+            "broken pipe (os error 32)"
+        ));
+        assert!(ElectrumClientManager::is_transport_error(
+            "connection reset by peer"
+        ));
         assert!(ElectrumClientManager::is_transport_error("unexpected eof"));
-        assert!(ElectrumClientManager::is_transport_error("Connection closed"));
+        assert!(ElectrumClientManager::is_transport_error(
+            "Connection closed"
+        ));
         assert!(ElectrumClientManager::is_transport_error("stream closed"));
         assert!(ElectrumClientManager::is_transport_error("write error"));
         assert!(ElectrumClientManager::is_transport_error("I/O error"));
@@ -577,7 +592,9 @@ mod tests {
         // Should NOT be detected as transport errors
         assert!(!ElectrumClientManager::is_transport_error("timeout"));
         assert!(!ElectrumClientManager::is_transport_error("server error"));
-        assert!(!ElectrumClientManager::is_transport_error("invalid response"));
+        assert!(!ElectrumClientManager::is_transport_error(
+            "invalid response"
+        ));
         assert!(!ElectrumClientManager::is_transport_error("parse error"));
     }
 }

--- a/backend/src/email_provider.rs
+++ b/backend/src/email_provider.rs
@@ -110,8 +110,10 @@ impl NotificationProvider for EmailProvider {
                         (html_body, text_body)
                     }
                     TransactionNotification::BalanceAlert(_) => {
-                        let html_body = Self::build_balance_alert_html(wallet_name, &contact.name, &message);
-                        let text_body = Self::build_balance_alert_text(wallet_name, &contact.name, &message);
+                        let html_body =
+                            Self::build_balance_alert_html(wallet_name, &contact.name, &message);
+                        let text_body =
+                            Self::build_balance_alert_text(wallet_name, &contact.name, &message);
                         (html_body, text_body)
                     }
                 };
@@ -136,13 +138,15 @@ impl NotificationProvider for EmailProvider {
         }
 
         // Extract batch requests for queuing
-        let batch_requests: Vec<BatchEmailRequest> = batch_data.iter().map(|(_, _, req)| req.clone()).collect();
+        let batch_requests: Vec<BatchEmailRequest> =
+            batch_data.iter().map(|(_, _, req)| req.clone()).collect();
 
         // Queue emails for background sending (with rate limiting and retries)
         let batch_results = email_service.send_batch_emails(batch_requests).await;
 
         // Process results and return
-        for ((method, message, _), result) in batch_data.into_iter().zip(batch_results.into_iter()) {
+        for ((method, message, _), result) in batch_data.into_iter().zip(batch_results.into_iter())
+        {
             match result {
                 Ok(_) => {
                     // Email queued successfully

--- a/backend/src/email_queue.rs
+++ b/backend/src/email_queue.rs
@@ -156,7 +156,10 @@ async fn send_batch_with_rate_limit(
             let failure_count = results.len() - success_count;
 
             if failure_count > 0 {
-                println!("📧 Sent batch: {} succeeded, {} failed", success_count, failure_count);
+                println!(
+                    "📧 Sent batch: {} succeeded, {} failed",
+                    success_count, failure_count
+                );
             }
 
             // Handle individual failures - retry if possible
@@ -280,8 +283,15 @@ async fn send_batch_to_resend(
             }
         }
     } else {
-        let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
-        Err(anyhow!("Batch send failed with status {}: {}", status, error_text))
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        Err(anyhow!(
+            "Batch send failed with status {}: {}",
+            status,
+            error_text
+        ))
     }
 }
 

--- a/backend/src/email_service.rs
+++ b/backend/src/email_service.rs
@@ -1,8 +1,8 @@
+use crate::email_queue;
 use anyhow::{anyhow, Result};
 use rand::Rng;
 use resend_rs::types::{ContactData, CreateEmailBaseOptions};
 use resend_rs::Resend;
-use crate::email_queue;
 
 #[derive(Debug, Clone)]
 pub struct EmailConfig {
@@ -465,10 +465,7 @@ View subscription plans: {billing_url}
     /// Queue multiple emails for background sending via the global email queue
     /// Returns Vec of Results - all success since emails are queued, not sent immediately
     /// Actual sending happens asynchronously with rate limiting and retries
-    pub async fn send_batch_emails(
-        &self,
-        emails: Vec<BatchEmailRequest>,
-    ) -> Vec<Result<String>> {
+    pub async fn send_batch_emails(&self, emails: Vec<BatchEmailRequest>) -> Vec<Result<String>> {
         if emails.is_empty() {
             return Vec::new();
         }

--- a/backend/src/exchange_rates.rs
+++ b/backend/src/exchange_rates.rs
@@ -34,9 +34,7 @@ pub struct ExchangeRateService {
 
 impl ExchangeRateService {
     pub fn new(metadata_db: Arc<MetadataDb>) -> Self {
-        Self {
-            metadata_db,
-        }
+        Self { metadata_db }
     }
 
     /// Map browser locale to appropriate fiat currency

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -13,6 +13,7 @@ pub mod exchange_rates;
 pub mod message_formatter;
 pub mod metadata;
 pub mod migrations;
+pub mod notification_failure_tracker;
 pub mod notifications;
 pub mod ntfy_provider;
 pub mod stripe_billing;
@@ -34,6 +35,7 @@ pub use metadata::{
     WalletDetailResponse, WalletMetadata, WalletsListResponse,
 };
 pub use migrations::MigrationRunner;
+pub use notification_failure_tracker::{NotificationFailureTracker, ProviderErrorCategory};
 pub use notifications::{
     NotificationManager, NotificationProvider, NotificationResult, ProviderInfo,
 };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -10,6 +10,7 @@ mod exchange_rates;
 mod message_formatter;
 mod metadata;
 mod migrations;
+mod notification_failure_tracker;
 mod notifications;
 mod ntfy_provider;
 mod stripe_billing;
@@ -204,7 +205,8 @@ async fn main() -> anyhow::Result<()> {
             // Start the email queue worker before registering the provider
             match email_queue::EmailQueueConfig::from_env() {
                 Ok(email_queue_config) => {
-                    if let Err(e) = email_queue::start_email_queue_worker(email_queue_config).await {
+                    if let Err(e) = email_queue::start_email_queue_worker(email_queue_config).await
+                    {
                         println!("⚠️  Failed to start email queue worker: {}", e);
                         println!("   Email notifications will not work");
                     } else {
@@ -213,7 +215,10 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
                 Err(e) => {
-                    println!("⚠️  Email provider enabled but missing configuration: {}", e);
+                    println!(
+                        "⚠️  Email provider enabled but missing configuration: {}",
+                        e
+                    );
                 }
             }
         }
@@ -258,64 +263,97 @@ async fn main() -> anyhow::Result<()> {
 
         if let Some(descriptor) = bacon_descriptor {
             // Get demo user from database
-            let demo_user_result = app_services.metadata_db.get_user_by_email("demo@canarybitcoin.com").await;
+            let demo_user_result = app_services
+                .metadata_db
+                .get_user_by_email("demo@canarybitcoin.com")
+                .await;
 
             if let Ok(Some(demo_user)) = demo_user_result {
                 // Check if demo user already has a "Bacon Wallet" by name
                 // (checking by name instead of descriptor to avoid BDK normalization issues)
-                let existing_wallets = app_services.metadata_db.get_wallets_for_user(Some(&demo_user.id)).await.unwrap_or_default();
+                let existing_wallets = app_services
+                    .metadata_db
+                    .get_wallets_for_user(Some(&demo_user.id))
+                    .await
+                    .unwrap_or_default();
                 let bacon_exists = existing_wallets.iter().any(|w| w.name == "Bacon Wallet");
 
                 if !bacon_exists {
                     // Create bacon wallet through normal wallet creation flow
-                    match app_services.wallet_creation_service.create_wallet_non_blocking(
-                        "Bacon Wallet",
-                        descriptor,
-                        &demo_user.id,
-                        false, // not a fresh wallet
-                        None,  // auto-detect script type
-                        None,  // default stop gap
-                    ).await {
+                    match app_services
+                        .wallet_creation_service
+                        .create_wallet_non_blocking(
+                            "Bacon Wallet",
+                            descriptor,
+                            &demo_user.id,
+                            false, // not a fresh wallet
+                            None,  // auto-detect script type
+                            None,  // default stop gap
+                        )
+                        .await
+                    {
                         Ok(wallet_metadata) => {
-                            println!("✅ Created Bacon wallet for demo user (network: {:?})", config.network());
+                            println!(
+                                "✅ Created Bacon wallet for demo user (network: {:?})",
+                                config.network()
+                            );
 
                             // Add "Canary" contact with email notification
                             use metadata::{Language, ProviderType};
-                            match app_services.metadata_db.insert_contact_with_notification_methods(
-                                &wallet_metadata.checksum,
-                                "Canary",
-                                &Language::English,
-                                vec![(ProviderType::Email, "contact@canarybitcoin.com".to_string())],
-                            ).await {
+                            match app_services
+                                .metadata_db
+                                .insert_contact_with_notification_methods(
+                                    &wallet_metadata.checksum,
+                                    "Canary",
+                                    &Language::English,
+                                    vec![(
+                                        ProviderType::Email,
+                                        "contact@canarybitcoin.com".to_string(),
+                                    )],
+                                )
+                                .await
+                            {
                                 Ok(_) => println!("✅ Added Canary contact to Bacon wallet"),
                                 Err(e) => println!("❌ Failed to add Canary contact: {}", e),
                             }
 
                             // Create balance alert: when balance equals 0 BTC
                             use metadata::BalanceAlertType;
-                            match app_services.metadata_db.create_balance_alert(
-                                &wallet_metadata.checksum,
-                                0, // 0 sats
-                                BalanceAlertType::Equals,
-                                None, // BTC threshold
-                                None,
-                            ).await {
+                            match app_services
+                                .metadata_db
+                                .create_balance_alert(
+                                    &wallet_metadata.checksum,
+                                    0, // 0 sats
+                                    BalanceAlertType::Equals,
+                                    None, // BTC threshold
+                                    None,
+                                )
+                                .await
+                            {
                                 Ok(_) => println!("✅ Added 0 BTC balance alert to Bacon wallet"),
                                 Err(e) => println!("❌ Failed to add 0 BTC balance alert: {}", e),
                             }
 
                             // Create balance alert: when balance is above 0.21 BTC (21,000,000 sats)
-                            match app_services.metadata_db.create_balance_alert(
-                                &wallet_metadata.checksum,
-                                21_000_000, // 0.21 BTC in sats
-                                BalanceAlertType::Above,
-                                None, // BTC threshold
-                                None,
-                            ).await {
-                                Ok(_) => println!("✅ Added >0.21 BTC balance alert to Bacon wallet"),
-                                Err(e) => println!("❌ Failed to add >0.21 BTC balance alert: {}", e),
+                            match app_services
+                                .metadata_db
+                                .create_balance_alert(
+                                    &wallet_metadata.checksum,
+                                    21_000_000, // 0.21 BTC in sats
+                                    BalanceAlertType::Above,
+                                    None, // BTC threshold
+                                    None,
+                                )
+                                .await
+                            {
+                                Ok(_) => {
+                                    println!("✅ Added >0.21 BTC balance alert to Bacon wallet")
+                                }
+                                Err(e) => {
+                                    println!("❌ Failed to add >0.21 BTC balance alert: {}", e)
+                                }
                             }
-                        },
+                        }
                         Err(e) => println!("❌ Failed to create Bacon wallet: {}", e),
                     }
                 }
@@ -424,7 +462,10 @@ async fn main() -> anyhow::Result<()> {
 
                 // In FOSS mode, all wallets belong to the hardcoded "team" tier user
                 // No need to sync Personal tier since no FOSS wallets use that tier
-                if let Err(e) = foss_wallet_manager.sync_tier_parallel(SubscriptionTier::Team).await {
+                if let Err(e) = foss_wallet_manager
+                    .sync_tier_parallel(SubscriptionTier::Team)
+                    .await
+                {
                     eprintln!("❌ Failed to sync FOSS wallets: {}", e);
                 }
 
@@ -452,7 +493,10 @@ async fn main() -> anyhow::Result<()> {
                 interval.tick().await;
 
                 // Sync Team tier wallets
-                if let Err(e) = team_wallet_manager.sync_tier_parallel(SubscriptionTier::Team).await {
+                if let Err(e) = team_wallet_manager
+                    .sync_tier_parallel(SubscriptionTier::Team)
+                    .await
+                {
                     eprintln!("Team tier sync failed: {}", e);
                 }
             }
@@ -471,7 +515,10 @@ async fn main() -> anyhow::Result<()> {
                 interval.tick().await;
 
                 // Sync Personal tier wallets
-                if let Err(e) = personal_wallet_manager.sync_tier_parallel(SubscriptionTier::Personal).await {
+                if let Err(e) = personal_wallet_manager
+                    .sync_tier_parallel(SubscriptionTier::Personal)
+                    .await
+                {
                     eprintln!("Personal tier sync failed: {}", e);
                 }
             }
@@ -483,23 +530,42 @@ async fn main() -> anyhow::Result<()> {
             // Wait a moment for sync tasks to start
             tokio::time::sleep(Duration::from_secs(2)).await;
 
-            if let Ok(non_syncing_summary) = startup_wallet_manager.metadata_db.get_non_syncing_wallets_summary().await {
+            if let Ok(non_syncing_summary) = startup_wallet_manager
+                .metadata_db
+                .get_non_syncing_wallets_summary()
+                .await
+            {
                 if non_syncing_summary.total_non_syncing > 0 {
                     let mut reasons = Vec::new();
                     if non_syncing_summary.expired_trials > 0 {
-                        reasons.push(format!("{} expired trials", non_syncing_summary.expired_trials));
+                        reasons.push(format!(
+                            "{} expired trials",
+                            non_syncing_summary.expired_trials
+                        ));
                     }
                     if non_syncing_summary.cancelled_subscriptions > 0 {
-                        reasons.push(format!("{} cancelled", non_syncing_summary.cancelled_subscriptions));
+                        reasons.push(format!(
+                            "{} cancelled",
+                            non_syncing_summary.cancelled_subscriptions
+                        ));
                     }
                     if non_syncing_summary.expired_subscriptions > 0 {
-                        reasons.push(format!("{} expired", non_syncing_summary.expired_subscriptions));
+                        reasons.push(format!(
+                            "{} expired",
+                            non_syncing_summary.expired_subscriptions
+                        ));
                     }
                     if non_syncing_summary.past_due_subscriptions > 0 {
-                        reasons.push(format!("{} past_due", non_syncing_summary.past_due_subscriptions));
+                        reasons.push(format!(
+                            "{} past_due",
+                            non_syncing_summary.past_due_subscriptions
+                        ));
                     }
                     if non_syncing_summary.inactive_wallets > 0 {
-                        reasons.push(format!("{} inactive (tier limits)", non_syncing_summary.inactive_wallets));
+                        reasons.push(format!(
+                            "{} inactive (tier limits)",
+                            non_syncing_summary.inactive_wallets
+                        ));
                     }
 
                     println!(
@@ -574,9 +640,8 @@ async fn main() -> anyhow::Result<()> {
                                     );
 
                                     // Store in database
-                                    if let Err(e) = metadata_db
-                                        .upsert_current_block_header(&block_header)
-                                        .await
+                                    if let Err(e) =
+                                        metadata_db.upsert_current_block_header(&block_header).await
                                     {
                                         eprintln!("Failed to store block header: {}", e);
                                     }
@@ -593,7 +658,9 @@ async fn main() -> anyhow::Result<()> {
                                         current_height, error_msg
                                     );
                                     // Check if transport error and trigger reconnection
-                                    if electrum::ElectrumClientManager::is_transport_error(&error_msg) {
+                                    if electrum::ElectrumClientManager::is_transport_error(
+                                        &error_msg,
+                                    ) {
                                         electrum_mgr.mark_disconnected(&error_msg).await;
                                         let _ = electrum_mgr.reconnect().await;
                                     }
@@ -628,7 +695,11 @@ async fn main() -> anyhow::Result<()> {
         loop {
             interval.tick().await;
 
-            match session_cleanup_manager.metadata_db.cleanup_expired_sessions().await {
+            match session_cleanup_manager
+                .metadata_db
+                .cleanup_expired_sessions()
+                .await
+            {
                 Ok(deleted) => {
                     if deleted > 0 {
                         println!("Cleaned up {} expired sessions", deleted);
@@ -647,6 +718,12 @@ async fn main() -> anyhow::Result<()> {
     let notification_event_rx = notification_tx.subscribe();
     tokio::spawn(async move {
         let mut rx = notification_event_rx;
+
+        // Initialize failure trackers for SMS and Email providers
+        let sms_failure_tracker =
+            notification_failure_tracker::NotificationFailureTracker::new("twilio");
+        let email_failure_tracker =
+            notification_failure_tracker::NotificationFailureTracker::new("email");
 
         while let Ok(notification) = rx.recv().await {
             let manager = notification_worker_manager.lock().await;
@@ -757,6 +834,55 @@ async fn main() -> anyhow::Result<()> {
                                         total_sent += 1;
                                     } else {
                                         failed_count += 1;
+                                    }
+
+                                    // Track failures for SMS and Email providers and send admin alerts
+                                    if provider_name == "twilio" || provider_name == "email" {
+                                        let tracker = if provider_name == "twilio" {
+                                            &sms_failure_tracker
+                                        } else {
+                                            &email_failure_tracker
+                                        };
+
+                                        let display_name = if provider_name == "twilio" {
+                                            "SMS (Twilio)"
+                                        } else {
+                                            "Email (Resend)"
+                                        };
+
+                                        if result.success {
+                                            // Check if we should send recovery notification
+                                            if tracker.record_success() {
+                                                let admin =
+                                                    admin_notifications::AdminNotifications::new();
+                                                if admin.is_enabled() {
+                                                    admin
+                                                        .notify_provider_recovery(display_name)
+                                                        .await;
+                                                }
+                                            }
+                                        } else {
+                                            // Record failure and check if we should alert
+                                            let (should_alert, failures, category) = tracker
+                                                .record_failure(result.error_message.as_deref())
+                                                .await;
+                                            if should_alert {
+                                                let admin =
+                                                    admin_notifications::AdminNotifications::new();
+                                                if admin.is_enabled() {
+                                                    admin
+                                                        .notify_provider_failure(
+                                                            display_name,
+                                                            failures,
+                                                            &category.to_string(),
+                                                            result.error_message.as_deref(),
+                                                            category.suggested_action(),
+                                                        )
+                                                        .await;
+                                                }
+                                                tracker.mark_alert_sent();
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/backend/src/message_formatter.rs
+++ b/backend/src/message_formatter.rs
@@ -141,17 +141,29 @@ impl MessageFormatter {
         language: &Language,
     ) -> String {
         // Check if this is a fiat threshold alert
-        let threshold_display = if let (Some(ref currency), Some(fiat_amount), Some(rate)) = (&alert.threshold_currency, alert.threshold_fiat_amount, alert.exchange_rate_snapshot) {
+        let threshold_display = if let (Some(ref currency), Some(fiat_amount), Some(rate)) = (
+            &alert.threshold_currency,
+            alert.threshold_fiat_amount,
+            alert.exchange_rate_snapshot,
+        ) {
             // Fiat threshold: show fiat amount with BTC equivalent
             let fiat_str = Self::format_fiat_amount(fiat_amount, currency, language);
             let btc_str = Self::format_btc_amount(alert.threshold_sats, language);
-            format!("{} (≈ {} BTC at {:.0} {}/BTC)", fiat_str, btc_str, rate, currency)
+            format!(
+                "{} (≈ {} BTC at {:.0} {}/BTC)",
+                fiat_str, btc_str, rate, currency
+            )
         } else {
             // BTC threshold: show only BTC
-            format!("{} BTC", Self::format_btc_amount(alert.threshold_sats, language))
+            format!(
+                "{} BTC",
+                Self::format_btc_amount(alert.threshold_sats, language)
+            )
         };
 
-        let current_display = if let (Some(ref currency), Some(rate)) = (&alert.threshold_currency, alert.exchange_rate_snapshot) {
+        let current_display = if let (Some(ref currency), Some(rate)) =
+            (&alert.threshold_currency, alert.exchange_rate_snapshot)
+        {
             // Calculate current balance in fiat
             let current_btc = alert.current_balance_sats as f64 / 100_000_000.0;
             let current_fiat = current_btc * rate;
@@ -159,7 +171,10 @@ impl MessageFormatter {
             let btc_str = Self::format_btc_amount(alert.current_balance_sats, language);
             format!("{} (≈ {} BTC)", fiat_str, btc_str)
         } else {
-            format!("{} BTC", Self::format_btc_amount(alert.current_balance_sats, language))
+            format!(
+                "{} BTC",
+                Self::format_btc_amount(alert.current_balance_sats, language)
+            )
         };
 
         match alert.alert_type {

--- a/backend/src/metadata.rs
+++ b/backend/src/metadata.rs
@@ -2568,10 +2568,7 @@ impl MetadataDb {
 
         spawn_blocking(move || -> Result<()> {
             let conn = pool.get()?;
-            conn.execute(
-                "DELETE FROM sessions WHERE user_id = ?1",
-                params![&user_id],
-            )?;
+            conn.execute("DELETE FROM sessions WHERE user_id = ?1", params![&user_id])?;
             Ok(())
         })
         .await?
@@ -3306,7 +3303,6 @@ impl MetadataDb {
         })
         .await?
     }
-
 
     #[allow(dead_code)] // Used in system tests
     pub async fn deactivate_balance_alert(&self, alert_id: &str) -> Result<()> {

--- a/backend/src/notification_failure_tracker.rs
+++ b/backend/src/notification_failure_tracker.rs
@@ -1,0 +1,371 @@
+//! Notification provider failure tracking with throttled admin alerts.
+//!
+//! Tracks consecutive delivery failures for SMS (Twilio) and Email (Resend) providers,
+//! sending admin notifications after a threshold is reached. Follows the pattern
+//! established by `ElectrumClientManager` for failure tracking and alerting.
+
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+/// Number of consecutive failures before sending an admin alert
+const ALERT_FAILURE_THRESHOLD: u32 = 3;
+
+/// Duration after which failure counter resets if no new failures occur (1 hour)
+const FAILURE_RESET_DURATION: Duration = Duration::from_secs(3600);
+
+/// Categories of notification provider errors for actionable admin alerts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderErrorCategory {
+    /// 401 - Bad credentials or invalid API key
+    Authentication,
+    /// 402 - Account needs funding (common with Twilio)
+    InsufficientFunds,
+    /// 429 - Too many requests, rate limited
+    RateLimit,
+    /// Bad email/phone format or undeliverable address
+    InvalidRecipient,
+    /// 5xx from provider
+    ServerError,
+    /// Connection/timeout/DNS errors
+    NetworkError,
+    /// Unrecognized error pattern
+    Unknown,
+}
+
+impl ProviderErrorCategory {
+    /// Parse an error message to determine its category.
+    pub fn from_error(error_msg: &str) -> Self {
+        let msg_lower = error_msg.to_lowercase();
+
+        // Authentication errors (401, invalid credentials)
+        if msg_lower.contains("401")
+            || msg_lower.contains("authenticate")
+            || msg_lower.contains("invalid api key")
+            || msg_lower.contains("unauthorized")
+            || msg_lower.contains("authentication")
+            || msg_lower.contains("credential")
+        {
+            return Self::Authentication;
+        }
+
+        // Insufficient funds (402, balance issues)
+        if msg_lower.contains("402")
+            || msg_lower.contains("insufficient")
+            || msg_lower.contains("balance")
+            || msg_lower.contains("payment required")
+        {
+            return Self::InsufficientFunds;
+        }
+
+        // Rate limiting (429)
+        if msg_lower.contains("429")
+            || msg_lower.contains("rate limit")
+            || msg_lower.contains("too many")
+            || msg_lower.contains("throttl")
+        {
+            return Self::RateLimit;
+        }
+
+        // Invalid recipient (400, format issues)
+        if msg_lower.contains("undeliverable")
+            || msg_lower.contains("not valid")
+            || msg_lower.contains("bad request")
+            || msg_lower.contains("400")
+        {
+            return Self::InvalidRecipient;
+        }
+
+        // "invalid" can mean many things - check if it's for recipient
+        if msg_lower.contains("invalid") {
+            // Distinguish from auth errors that also contain "invalid"
+            if !msg_lower.contains("api key") && !msg_lower.contains("credential") {
+                return Self::InvalidRecipient;
+            }
+        }
+
+        // Server errors (5xx)
+        if msg_lower.contains("500")
+            || msg_lower.contains("502")
+            || msg_lower.contains("503")
+            || msg_lower.contains("504")
+            || msg_lower.contains("server error")
+            || msg_lower.contains("internal error")
+        {
+            return Self::ServerError;
+        }
+
+        // Network errors
+        if msg_lower.contains("timeout")
+            || msg_lower.contains("connection")
+            || msg_lower.contains("network")
+            || msg_lower.contains("dns")
+            || msg_lower.contains("unreachable")
+        {
+            return Self::NetworkError;
+        }
+
+        Self::Unknown
+    }
+
+    /// Get a suggested action for resolving this error category.
+    pub fn suggested_action(&self) -> &'static str {
+        match self {
+            Self::Authentication => "Check credentials in environment variables",
+            Self::InsufficientFunds => "Add funds to your provider account",
+            Self::RateLimit => "Reduce notification frequency or upgrade plan",
+            Self::InvalidRecipient => "Check contact phone/email format",
+            Self::ServerError => "Provider experiencing issues, retry later",
+            Self::NetworkError => "Check network connectivity",
+            Self::Unknown => "Review error logs for details",
+        }
+    }
+}
+
+impl fmt::Display for ProviderErrorCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Authentication => write!(f, "Authentication"),
+            Self::InsufficientFunds => write!(f, "Insufficient Funds"),
+            Self::RateLimit => write!(f, "Rate Limit"),
+            Self::InvalidRecipient => write!(f, "Invalid Recipient"),
+            Self::ServerError => write!(f, "Server Error"),
+            Self::NetworkError => write!(f, "Network Error"),
+            Self::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+/// Tracks consecutive notification delivery failures for a single provider.
+///
+/// This tracker implements throttled alerting:
+/// - Alerts are sent only after `ALERT_FAILURE_THRESHOLD` consecutive failures
+/// - Only one alert is sent per outage (until recovery)
+/// - Recovery alerts are sent when notifications succeed after a failure period
+/// - Failure counter resets after `FAILURE_RESET_DURATION` of inactivity
+pub struct NotificationFailureTracker {
+    /// Provider identifier for logging/display
+    #[allow(dead_code)]
+    provider_name: String,
+    /// Counter for consecutive failures
+    consecutive_failures: AtomicU32,
+    /// Flag to track if an alert has been sent for the current outage
+    alert_sent: AtomicBool,
+    /// Last error message for diagnostics
+    last_error: RwLock<Option<String>>,
+    /// Timestamp of last failure for time-based reset
+    last_failure_time: RwLock<Option<Instant>>,
+}
+
+impl NotificationFailureTracker {
+    /// Create a new tracker for the specified provider.
+    pub fn new(provider_name: &str) -> Self {
+        Self {
+            provider_name: provider_name.to_string(),
+            consecutive_failures: AtomicU32::new(0),
+            alert_sent: AtomicBool::new(false),
+            last_error: RwLock::new(None),
+            last_failure_time: RwLock::new(None),
+        }
+    }
+
+    /// Get the provider name.
+    #[allow(dead_code)]
+    pub fn provider_name(&self) -> &str {
+        &self.provider_name
+    }
+
+    /// Record a failed notification delivery.
+    ///
+    /// Returns a tuple of:
+    /// - `should_alert`: true if an admin alert should be sent
+    /// - `failure_count`: current number of consecutive failures
+    /// - `category`: categorized error type for the alert
+    pub async fn record_failure(
+        &self,
+        error_msg: Option<&str>,
+    ) -> (bool, u32, ProviderErrorCategory) {
+        // Check for time-based reset
+        let should_reset = {
+            let last_time = self.last_failure_time.read().await;
+            if let Some(last) = *last_time {
+                last.elapsed() > FAILURE_RESET_DURATION
+            } else {
+                false
+            }
+        };
+
+        if should_reset {
+            self.consecutive_failures.store(0, Ordering::SeqCst);
+            self.alert_sent.store(false, Ordering::SeqCst);
+        }
+
+        // Increment failure counter
+        let failures = self.consecutive_failures.fetch_add(1, Ordering::SeqCst) + 1;
+
+        // Update last error and timestamp
+        *self.last_error.write().await = error_msg.map(|s| s.to_string());
+        *self.last_failure_time.write().await = Some(Instant::now());
+
+        // Categorize the error
+        let category = error_msg
+            .map(ProviderErrorCategory::from_error)
+            .unwrap_or(ProviderErrorCategory::Unknown);
+
+        // Determine if we should alert
+        let should_alert =
+            failures >= ALERT_FAILURE_THRESHOLD && !self.alert_sent.load(Ordering::SeqCst);
+
+        (should_alert, failures, category)
+    }
+
+    /// Record a successful notification delivery.
+    ///
+    /// Returns true if a recovery alert should be sent (i.e., we had previous failures
+    /// and an alert was sent).
+    pub fn record_success(&self) -> bool {
+        // Reset failure counter
+        self.consecutive_failures.store(0, Ordering::SeqCst);
+
+        // Atomically check if alert was sent and reset it
+        // Returns true if an alert was previously sent (meaning we should send recovery)
+        self.alert_sent
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    /// Mark that an alert has been sent for the current outage.
+    pub fn mark_alert_sent(&self) {
+        self.alert_sent.store(true, Ordering::SeqCst);
+    }
+
+    /// Get the last error message.
+    #[allow(dead_code)]
+    pub async fn last_error(&self) -> Option<String> {
+        self.last_error.read().await.clone()
+    }
+
+    /// Get the current consecutive failure count.
+    #[allow(dead_code)]
+    pub fn get_consecutive_failures(&self) -> u32 {
+        self.consecutive_failures.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_categorization() {
+        assert_eq!(
+            ProviderErrorCategory::from_error("HTTP 401: Unauthorized"),
+            ProviderErrorCategory::Authentication
+        );
+        assert_eq!(
+            ProviderErrorCategory::from_error(
+                "HTTP 401: {\"code\": 20003, \"message\": \"Authenticate\"}"
+            ),
+            ProviderErrorCategory::Authentication
+        );
+        assert_eq!(
+            ProviderErrorCategory::from_error("Invalid API key"),
+            ProviderErrorCategory::Authentication
+        );
+        assert_eq!(
+            ProviderErrorCategory::from_error("HTTP 402: Insufficient funds"),
+            ProviderErrorCategory::InsufficientFunds
+        );
+        assert_eq!(
+            ProviderErrorCategory::from_error("HTTP 429: Rate limit exceeded"),
+            ProviderErrorCategory::RateLimit
+        );
+        assert_eq!(
+            ProviderErrorCategory::from_error("HTTP 400: Phone number is not valid"),
+            ProviderErrorCategory::InvalidRecipient
+        );
+        assert_eq!(
+            ProviderErrorCategory::from_error("HTTP 500: Internal server error"),
+            ProviderErrorCategory::ServerError
+        );
+        assert_eq!(
+            ProviderErrorCategory::from_error("Connection timeout"),
+            ProviderErrorCategory::NetworkError
+        );
+        assert_eq!(
+            ProviderErrorCategory::from_error("Some unknown error"),
+            ProviderErrorCategory::Unknown
+        );
+    }
+
+    #[test]
+    fn test_suggested_actions() {
+        assert!(ProviderErrorCategory::Authentication
+            .suggested_action()
+            .contains("credentials"));
+        assert!(ProviderErrorCategory::InsufficientFunds
+            .suggested_action()
+            .contains("funds"));
+        assert!(ProviderErrorCategory::RateLimit
+            .suggested_action()
+            .contains("frequency"));
+    }
+
+    #[tokio::test]
+    async fn test_failure_tracking() {
+        let tracker = NotificationFailureTracker::new("test");
+
+        // First two failures should not trigger alert
+        let (should_alert, count, _) = tracker.record_failure(Some("HTTP 401")).await;
+        assert!(!should_alert);
+        assert_eq!(count, 1);
+
+        let (should_alert, count, _) = tracker.record_failure(Some("HTTP 401")).await;
+        assert!(!should_alert);
+        assert_eq!(count, 2);
+
+        // Third failure should trigger alert
+        let (should_alert, count, category) = tracker.record_failure(Some("HTTP 401")).await;
+        assert!(should_alert);
+        assert_eq!(count, 3);
+        assert_eq!(category, ProviderErrorCategory::Authentication);
+
+        // Mark alert sent
+        tracker.mark_alert_sent();
+
+        // Fourth failure should NOT trigger alert (already sent)
+        let (should_alert, count, _) = tracker.record_failure(Some("HTTP 401")).await;
+        assert!(!should_alert);
+        assert_eq!(count, 4);
+    }
+
+    #[tokio::test]
+    async fn test_recovery_notification() {
+        let tracker = NotificationFailureTracker::new("test");
+
+        // Simulate failures and alert
+        for _ in 0..3 {
+            tracker.record_failure(Some("error")).await;
+        }
+        tracker.mark_alert_sent();
+
+        // Success should trigger recovery notification
+        assert!(tracker.record_success());
+
+        // Second success should not trigger recovery (already sent)
+        assert!(!tracker.record_success());
+    }
+
+    #[test]
+    fn test_display_formatting() {
+        assert_eq!(
+            format!("{}", ProviderErrorCategory::Authentication),
+            "Authentication"
+        );
+        assert_eq!(
+            format!("{}", ProviderErrorCategory::InsufficientFunds),
+            "Insufficient Funds"
+        );
+    }
+}

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -913,10 +913,16 @@ impl StripeBilling {
                                     if current_status == Some("trialing") {
                                         should_update = true;
                                         if reason.is_empty() {
-                                            if let Some(current_trial_end) = subscription.get("trial_end").and_then(|t| t.as_i64()) {
-                                                let new_date = chrono::DateTime::from_timestamp(current_trial_end, 0)
-                                                    .map(|dt| dt.format("%B %d, %Y").to_string())
-                                                    .unwrap_or_else(|| "unknown".to_string());
+                                            if let Some(current_trial_end) = subscription
+                                                .get("trial_end")
+                                                .and_then(|t| t.as_i64())
+                                            {
+                                                let new_date = chrono::DateTime::from_timestamp(
+                                                    current_trial_end,
+                                                    0,
+                                                )
+                                                .map(|dt| dt.format("%B %d, %Y").to_string())
+                                                .unwrap_or_else(|| "unknown".to_string());
                                                 reason = format!("Trial active until {}", new_date);
                                             }
                                         }
@@ -946,11 +952,14 @@ impl StripeBilling {
 
                                         // Extract trial_end for trialing subscriptions
                                         let trial_ends_at = if current_status == Some("trialing") {
-                                            subscription.get("trial_end").and_then(|t| t.as_i64()).map(|ts| {
-                                                chrono::DateTime::from_timestamp(ts, 0)
-                                                    .map(|dt| dt.to_rfc3339())
-                                                    .unwrap_or_default()
-                                            })
+                                            subscription
+                                                .get("trial_end")
+                                                .and_then(|t| t.as_i64())
+                                                .map(|ts| {
+                                                    chrono::DateTime::from_timestamp(ts, 0)
+                                                        .map(|dt| dt.to_rfc3339())
+                                                        .unwrap_or_default()
+                                                })
                                         } else {
                                             None
                                         };

--- a/backend/src/subscription.rs
+++ b/backend/src/subscription.rs
@@ -163,7 +163,9 @@ pub fn is_subscription_active(subscription_status: &str, trial_ends_at: Option<&
     if subscription_status == "trialing" {
         if let Some(trial_ends_at_str) = trial_ends_at {
             // Parse trial_ends_at and check if it's in the future
-            if let Ok(trial_ends_at) = chrono::NaiveDateTime::parse_from_str(trial_ends_at_str, "%Y-%m-%d %H:%M:%S") {
+            if let Ok(trial_ends_at) =
+                chrono::NaiveDateTime::parse_from_str(trial_ends_at_str, "%Y-%m-%d %H:%M:%S")
+            {
                 let now = chrono::Utc::now().naive_utc();
                 trial_ends_at > now // Active if trial hasn't ended yet
             } else {
@@ -180,10 +182,15 @@ pub fn is_subscription_active(subscription_status: &str, trial_ends_at: Option<&
 /// Get the effective subscription status for display
 ///
 /// Returns "expired" if trial has ended, otherwise returns the original status
-pub fn get_effective_subscription_status(subscription_status: &str, trial_ends_at: Option<&str>) -> String {
+pub fn get_effective_subscription_status(
+    subscription_status: &str,
+    trial_ends_at: Option<&str>,
+) -> String {
     if subscription_status == "trialing" {
         if let Some(trial_ends_at_str) = trial_ends_at {
-            if let Ok(trial_ends_at) = chrono::NaiveDateTime::parse_from_str(trial_ends_at_str, "%Y-%m-%d %H:%M:%S") {
+            if let Ok(trial_ends_at) =
+                chrono::NaiveDateTime::parse_from_str(trial_ends_at_str, "%Y-%m-%d %H:%M:%S")
+            {
                 let now = chrono::Utc::now().naive_utc();
                 if trial_ends_at < now {
                     return "expired".to_string();
@@ -230,7 +237,10 @@ mod tests {
     #[test]
     fn test_is_subscription_active_with_active_status() {
         assert!(is_subscription_active("active", None));
-        assert!(is_subscription_active("active", Some("2025-01-01 00:00:00")));
+        assert!(is_subscription_active(
+            "active",
+            Some("2025-01-01 00:00:00")
+        ));
     }
 
     #[test]
@@ -284,8 +294,14 @@ mod tests {
 
     #[test]
     fn test_get_effective_subscription_status_other_statuses() {
-        assert_eq!(get_effective_subscription_status("expired", None), "expired");
-        assert_eq!(get_effective_subscription_status("canceled", None), "canceled");
+        assert_eq!(
+            get_effective_subscription_status("expired", None),
+            "expired"
+        );
+        assert_eq!(
+            get_effective_subscription_status("canceled", None),
+            "canceled"
+        );
     }
 }
 

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -78,7 +78,9 @@ impl WalletSyncService {
                                 if manager.should_send_reconnected_notification() {
                                     let admin_notifications = AdminNotifications::new();
                                     if admin_notifications.is_enabled() {
-                                        admin_notifications.notify_electrum_reconnected(manager.url()).await;
+                                        admin_notifications
+                                            .notify_electrum_reconnected(manager.url())
+                                            .await;
                                     }
                                 }
                                 match manager.get_client().await {
@@ -104,14 +106,18 @@ impl WalletSyncService {
                                 error!("[{}] Reconnection failed: {}", wallet_checksum, e);
                                 // Check if we should send an alert
                                 let failures = manager.get_consecutive_failures();
-                                if failures >= ALERT_FAILURE_THRESHOLD && !manager.has_alert_been_sent() {
+                                if failures >= ALERT_FAILURE_THRESHOLD
+                                    && !manager.has_alert_been_sent()
+                                {
                                     let admin_notifications = AdminNotifications::new();
                                     if admin_notifications.is_enabled() {
-                                        admin_notifications.notify_electrum_disconnect(
-                                            manager.url(),
-                                            failures,
-                                            Some(&e.to_string()),
-                                        ).await;
+                                        admin_notifications
+                                            .notify_electrum_disconnect(
+                                                manager.url(),
+                                                failures,
+                                                Some(&e.to_string()),
+                                            )
+                                            .await;
                                         manager.mark_alert_sent();
                                         warn!(
                                             "[{}] Sent admin alert for {} consecutive Electrum failures",
@@ -175,7 +181,9 @@ impl WalletSyncService {
                                     if manager.should_send_reconnected_notification() {
                                         let admin_notifications = AdminNotifications::new();
                                         if admin_notifications.is_enabled() {
-                                            admin_notifications.notify_electrum_reconnected(manager.url()).await;
+                                            admin_notifications
+                                                .notify_electrum_reconnected(manager.url())
+                                                .await;
                                         }
                                     }
                                 }
@@ -192,14 +200,18 @@ impl WalletSyncService {
                                     );
                                     // Check if we should send an alert
                                     let failures = manager.get_consecutive_failures();
-                                    if failures >= ALERT_FAILURE_THRESHOLD && !manager.has_alert_been_sent() {
+                                    if failures >= ALERT_FAILURE_THRESHOLD
+                                        && !manager.has_alert_been_sent()
+                                    {
                                         let admin_notifications = AdminNotifications::new();
                                         if admin_notifications.is_enabled() {
-                                            admin_notifications.notify_electrum_disconnect(
-                                                manager.url(),
-                                                failures,
-                                                Some(&reconnect_err.to_string()),
-                                            ).await;
+                                            admin_notifications
+                                                .notify_electrum_disconnect(
+                                                    manager.url(),
+                                                    failures,
+                                                    Some(&reconnect_err.to_string()),
+                                                )
+                                                .await;
                                             manager.mark_alert_sent();
                                             warn!(
                                                 "[{}] Sent admin alert for {} consecutive Electrum failures",
@@ -1195,7 +1207,12 @@ impl WalletSyncService {
         for alert in active_alerts {
             // Determine threshold to compare against
             // For fiat thresholds, convert current balance to fiat using current exchange rate
-            let (comparison_threshold, exchange_rate_snapshot) = if let (Some(ref currency), Some(fiat_amount)) = (&alert.threshold_currency, alert.threshold_fiat_amount) {
+            let (comparison_threshold, exchange_rate_snapshot) = if let (
+                Some(ref currency),
+                Some(fiat_amount),
+            ) =
+                (&alert.threshold_currency, alert.threshold_fiat_amount)
+            {
                 // Fiat threshold - need to convert current balance to fiat
                 match self.metadata_db.get_exchange_rates().await {
                     Ok(rates) => {
@@ -1266,15 +1283,18 @@ impl WalletSyncService {
                 match alert.alert_type {
                     crate::metadata::BalanceAlertType::Above => {
                         // Fire when crossing from at-or-below to above
-                        previous_value <= comparison_threshold && current_value > comparison_threshold
+                        previous_value <= comparison_threshold
+                            && current_value > comparison_threshold
                     }
                     crate::metadata::BalanceAlertType::Below => {
                         // Fire when crossing from at-or-above to below
-                        previous_value >= comparison_threshold && current_value < comparison_threshold
+                        previous_value >= comparison_threshold
+                            && current_value < comparison_threshold
                     }
                     crate::metadata::BalanceAlertType::Equals => {
                         // Fire when crossing to equals (from any non-equals value)
-                        previous_value != comparison_threshold && current_value == comparison_threshold
+                        previous_value != comparison_threshold
+                            && current_value == comparison_threshold
                     }
                 }
             } else {
@@ -1309,8 +1329,13 @@ impl WalletSyncService {
             }
 
             if should_trigger {
-                let threshold_desc = if let (Some(ref currency), Some(fiat_amount)) = (&alert.threshold_currency, alert.threshold_fiat_amount) {
-                    format!("{} {} (≈ {} sats)", fiat_amount, currency, alert.threshold_sats)
+                let threshold_desc = if let (Some(ref currency), Some(fiat_amount)) =
+                    (&alert.threshold_currency, alert.threshold_fiat_amount)
+                {
+                    format!(
+                        "{} {} (≈ {} sats)",
+                        fiat_amount, currency, alert.threshold_sats
+                    )
                 } else {
                     format!("{} sats", alert.threshold_sats)
                 };
@@ -1361,7 +1386,12 @@ impl WalletSyncService {
 
                 // Send balance alert notification via existing notification system
                 if let Err(e) = self
-                    .send_balance_alert_notification(&alert, wallet_checksum, current_balance_sats, exchange_rate_snapshot)
+                    .send_balance_alert_notification(
+                        &alert,
+                        wallet_checksum,
+                        current_balance_sats,
+                        exchange_rate_snapshot,
+                    )
                     .await
                 {
                     warn!(

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -839,16 +839,28 @@ impl WalletManager {
             if non_syncing_summary.total_non_syncing > 0 {
                 let mut reasons = Vec::new();
                 if non_syncing_summary.expired_trials > 0 {
-                    reasons.push(format!("{} expired trials", non_syncing_summary.expired_trials));
+                    reasons.push(format!(
+                        "{} expired trials",
+                        non_syncing_summary.expired_trials
+                    ));
                 }
                 if non_syncing_summary.cancelled_subscriptions > 0 {
-                    reasons.push(format!("{} cancelled", non_syncing_summary.cancelled_subscriptions));
+                    reasons.push(format!(
+                        "{} cancelled",
+                        non_syncing_summary.cancelled_subscriptions
+                    ));
                 }
                 if non_syncing_summary.expired_subscriptions > 0 {
-                    reasons.push(format!("{} expired", non_syncing_summary.expired_subscriptions));
+                    reasons.push(format!(
+                        "{} expired",
+                        non_syncing_summary.expired_subscriptions
+                    ));
                 }
                 if non_syncing_summary.past_due_subscriptions > 0 {
-                    reasons.push(format!("{} past_due", non_syncing_summary.past_due_subscriptions));
+                    reasons.push(format!(
+                        "{} past_due",
+                        non_syncing_summary.past_due_subscriptions
+                    ));
                 }
                 if non_syncing_summary.inactive_wallets > 0 {
                     reasons.push(format!("{} inactive", non_syncing_summary.inactive_wallets));
@@ -1056,9 +1068,18 @@ impl WalletManager {
         if is_admin {
             tracing::info!("🎯 Applying unlimited limits for admin user {}", user_id);
         } else if !is_subscription_active {
-            tracing::info!("🎯 Deactivating all wallets for user {} (status: {})", user_id, subscription_status);
+            tracing::info!(
+                "🎯 Deactivating all wallets for user {} (status: {})",
+                user_id,
+                subscription_status
+            );
         } else {
-            tracing::info!("🎯 Applying {} tier limits for user {} (status: {})", tier, user_id, subscription_status);
+            tracing::info!(
+                "🎯 Applying {} tier limits for user {} (status: {})",
+                tier,
+                user_id,
+                subscription_status
+            );
         }
 
         // Get all wallets for this user ordered by creation time (oldest first)
@@ -1171,7 +1192,6 @@ impl WalletManager {
     ) -> Result<Option<crate::metadata::WalletMetadata>, anyhow::Error> {
         self.metadata_db.get_wallet_by_checksum(checksum).await
     }
-
 
     /// Load all active wallets from disk into memory
     /// This is called on startup to pre-load wallets with active subscriptions

--- a/backend/tests/balance_alerts_system_tests.rs
+++ b/backend/tests/balance_alerts_system_tests.rs
@@ -52,10 +52,7 @@ async fn create_test_user_and_wallet(metadata_db: &MetadataDb) -> (String, Strin
 }
 
 /// Test helper to create a sync service for balance alert checking
-fn create_sync_service(
-    metadata_db: &MetadataDb,
-    config: &AppConfig,
-) -> WalletSyncService {
+fn create_sync_service(metadata_db: &MetadataDb, config: &AppConfig) -> WalletSyncService {
     let (notification_sender, _) = broadcast::channel::<TransactionNotification>(100);
     WalletSyncService::new(metadata_db.clone(), notification_sender, config.clone())
 }
@@ -67,7 +64,13 @@ async fn test_balance_alert_database_operations() {
 
     // Test 1: Create balance alert
     let alert = metadata_db
-        .create_balance_alert(&wallet_checksum, 100_000_000, BalanceAlertType::Below, None, None) // 1 BTC
+        .create_balance_alert(
+            &wallet_checksum,
+            100_000_000,
+            BalanceAlertType::Below,
+            None,
+            None,
+        ) // 1 BTC
         .await
         .unwrap();
 
@@ -102,7 +105,10 @@ async fn test_balance_alert_database_operations() {
         .get_all_balance_alerts_for_wallet(&wallet_checksum)
         .await
         .unwrap();
-    assert_eq!(updated_alert[0].last_checked_balance_sats, Some(150_000_000));
+    assert_eq!(
+        updated_alert[0].last_checked_balance_sats,
+        Some(150_000_000)
+    );
 
     // Test 5: Delete balance alert
     metadata_db.delete_balance_alert(&alert.id).await.unwrap();
@@ -121,12 +127,24 @@ async fn test_balance_alert_types() {
 
     // Test all alert types
     let _below_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, 50_000_000, BalanceAlertType::Below, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            50_000_000,
+            BalanceAlertType::Below,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
     let _above_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, 200_000_000, BalanceAlertType::Above, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            200_000_000,
+            BalanceAlertType::Above,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -159,12 +177,24 @@ async fn test_balance_alert_edge_cases() {
 
     // Test 1: Multiple alerts of same type
     let alert1 = metadata_db
-        .create_balance_alert(&wallet_checksum, 100_000_000, BalanceAlertType::Below, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            100_000_000,
+            BalanceAlertType::Below,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
     let alert2 = metadata_db
-        .create_balance_alert(&wallet_checksum, 50_000_000, BalanceAlertType::Below, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            50_000_000,
+            BalanceAlertType::Below,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -186,7 +216,13 @@ async fn test_balance_alert_edge_cases() {
 
     // Test 3: Very large threshold values
     let large_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, i64::MAX, BalanceAlertType::Above, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            i64::MAX,
+            BalanceAlertType::Above,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -218,12 +254,24 @@ async fn test_balance_alert_wallet_isolation() {
 
     // Create alerts for each wallet
     let alert1 = metadata_db
-        .create_balance_alert(&wallet1_checksum, 100_000_000, BalanceAlertType::Below, None, None)
+        .create_balance_alert(
+            &wallet1_checksum,
+            100_000_000,
+            BalanceAlertType::Below,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
     let alert2 = metadata_db
-        .create_balance_alert(&wallet2_checksum, 200_000_000, BalanceAlertType::Above, None, None)
+        .create_balance_alert(
+            &wallet2_checksum,
+            200_000_000,
+            BalanceAlertType::Above,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -314,7 +362,13 @@ async fn test_duplicate_balance_alert_checking() {
 
     // Test 1: Create initial alert
     let alert = metadata_db
-        .create_balance_alert(&wallet_checksum, 100_000_000, BalanceAlertType::Below, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            100_000_000,
+            BalanceAlertType::Below,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -371,17 +425,35 @@ async fn test_duplicate_alert_all_types() {
     let threshold = 50_000_000;
 
     let below_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, threshold, BalanceAlertType::Below, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            threshold,
+            BalanceAlertType::Below,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
     let above_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, threshold, BalanceAlertType::Above, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            threshold,
+            BalanceAlertType::Above,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
     let equals_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, threshold, BalanceAlertType::Equals, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            threshold,
+            BalanceAlertType::Equals,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -628,7 +700,13 @@ async fn test_balance_alert_threshold_crossing_detection() {
 
     // Test 1: "Below" alert crossing detection
     let below_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, 100_000_000, BalanceAlertType::Below, None, None) // 1 BTC threshold
+        .create_balance_alert(
+            &wallet_checksum,
+            100_000_000,
+            BalanceAlertType::Below,
+            None,
+            None,
+        ) // 1 BTC threshold
         .await
         .unwrap();
 
@@ -637,42 +715,71 @@ async fn test_balance_alert_threshold_crossing_detection() {
         .check_balance_alerts(&wallet_checksum, 150_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 0, "First check should initialize without firing");
+    assert_eq!(
+        triggered.len(),
+        0,
+        "First check should initialize without firing"
+    );
 
     // Second check at 90 sats (below threshold) - should fire (crossed from above to below)
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 90_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 1, "Alert should fire when crossing from above to below");
+    assert_eq!(
+        triggered.len(),
+        1,
+        "Alert should fire when crossing from above to below"
+    );
 
     // Third check at 80 sats (still below threshold) - should NOT fire (already below)
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 80_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 0, "Alert should not fire when staying below threshold");
+    assert_eq!(
+        triggered.len(),
+        0,
+        "Alert should not fire when staying below threshold"
+    );
 
     // Fourth check at 110 sats (back above threshold) - should NOT fire (crossing wrong direction)
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 110_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 0, "Below alert should not fire when crossing from below to above");
+    assert_eq!(
+        triggered.len(),
+        0,
+        "Below alert should not fire when crossing from below to above"
+    );
 
     // Fifth check at 95 sats (below again) - should fire again (crossed from above to below)
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 95_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 1, "Alert should fire again when crossing from above to below");
+    assert_eq!(
+        triggered.len(),
+        1,
+        "Alert should fire again when crossing from above to below"
+    );
 
     // Clean up
-    metadata_db.delete_balance_alert(&below_alert.id).await.unwrap();
+    metadata_db
+        .delete_balance_alert(&below_alert.id)
+        .await
+        .unwrap();
 
     // Test 2: "Above" alert crossing detection
     let above_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, 100_000_000, BalanceAlertType::Above, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            100_000_000,
+            BalanceAlertType::Above,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -681,28 +788,49 @@ async fn test_balance_alert_threshold_crossing_detection() {
         .check_balance_alerts(&wallet_checksum, 90_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 0, "First check should initialize without firing");
+    assert_eq!(
+        triggered.len(),
+        0,
+        "First check should initialize without firing"
+    );
 
     // Cross to 110 sats (above threshold) - should fire
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 110_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 1, "Above alert should fire when crossing from below to above");
+    assert_eq!(
+        triggered.len(),
+        1,
+        "Above alert should fire when crossing from below to above"
+    );
 
     // Stay at 120 sats (still above) - should NOT fire
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 120_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 0, "Above alert should not fire when staying above threshold");
+    assert_eq!(
+        triggered.len(),
+        0,
+        "Above alert should not fire when staying above threshold"
+    );
 
     // Clean up
-    metadata_db.delete_balance_alert(&above_alert.id).await.unwrap();
+    metadata_db
+        .delete_balance_alert(&above_alert.id)
+        .await
+        .unwrap();
 
     // Test 3: "Equals" alert crossing detection
     let equals_alert = metadata_db
-        .create_balance_alert(&wallet_checksum, 100_000_000, BalanceAlertType::Equals, None, None)
+        .create_balance_alert(
+            &wallet_checksum,
+            100_000_000,
+            BalanceAlertType::Equals,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -711,36 +839,59 @@ async fn test_balance_alert_threshold_crossing_detection() {
         .check_balance_alerts(&wallet_checksum, 90_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 0, "First check should initialize without firing");
+    assert_eq!(
+        triggered.len(),
+        0,
+        "First check should initialize without firing"
+    );
 
     // Cross to exactly 100 sats - should fire
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 100_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 1, "Equals alert should fire when crossing to exact value");
+    assert_eq!(
+        triggered.len(),
+        1,
+        "Equals alert should fire when crossing to exact value"
+    );
 
     // Stay at 100 sats - should NOT fire
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 100_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 0, "Equals alert should not fire when staying at exact value");
+    assert_eq!(
+        triggered.len(),
+        0,
+        "Equals alert should not fire when staying at exact value"
+    );
 
     // Move away to 110 sats - should NOT fire
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 110_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 0, "Equals alert should not fire when moving away from value");
+    assert_eq!(
+        triggered.len(),
+        0,
+        "Equals alert should not fire when moving away from value"
+    );
 
     // Come back to 100 sats - should fire again (crossed back to equals)
     let triggered = sync_service
         .check_balance_alerts(&wallet_checksum, 100_000_000)
         .await
         .unwrap();
-    assert_eq!(triggered.len(), 1, "Equals alert should fire again when crossing back to exact value");
+    assert_eq!(
+        triggered.len(),
+        1,
+        "Equals alert should fire again when crossing back to exact value"
+    );
 
     // Clean up
-    metadata_db.delete_balance_alert(&equals_alert.id).await.unwrap();
+    metadata_db
+        .delete_balance_alert(&equals_alert.id)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
## Summary
- Implements Issue #20: Admin notifications when SMS (Twilio) or Email (Resend) delivery fails
- New `NotificationFailureTracker` module with thread-safe failure tracking
- Alerts sent via ntfy.sh after 3 consecutive failures (throttled)
- Recovery notifications when providers start working again

## Test plan
- [ ] Set invalid `TWILIO_AUTH_TOKEN`, trigger 3+ SMS notifications, verify admin alert received
- [ ] Set invalid `RESEND_API_KEY`, trigger 3+ email notifications, verify admin alert received
- [ ] Verify only ONE alert per outage (throttling works)
- [ ] Fix credentials, send successful notification, verify recovery alert
- [ ] Verify SMS and Email trackers are independent

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)