### PR TITLE
feat: Simplify language handling - use account language for notifications

### DIFF
--- a/backend/migrations/018_remove_contact_language.sql
+++ b/backend/migrations/018_remove_contact_language.sql
@@ -1,0 +1,63 @@
+-- Migration 018: Remove language column from contacts and pending_contact_verifications
+-- Language is now determined by the user's preferred_language setting (in users table)
+-- instead of being stored per-contact
+
+-- SQLite doesn't support ALTER TABLE DROP COLUMN in older versions
+-- We need to recreate the tables without the language column
+
+-- IMPORTANT: Disable foreign keys to prevent CASCADE DELETE when dropping contacts table
+-- (contact_notification_methods has ON DELETE CASCADE referencing contacts)
+PRAGMA foreign_keys = OFF;
+
+-- Step 1: Recreate contacts table without language column
+DROP TABLE IF EXISTS contacts_new;
+CREATE TABLE contacts_new (
+    id TEXT PRIMARY KEY,
+    wallet_checksum TEXT NOT NULL,
+    name TEXT NOT NULL,
+    is_active BOOLEAN DEFAULT true,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (wallet_checksum) REFERENCES wallets(checksum) ON DELETE CASCADE
+);
+
+-- Copy existing data (excluding language column)
+INSERT INTO contacts_new (id, wallet_checksum, name, is_active, created_at)
+SELECT id, wallet_checksum, name, is_active, created_at FROM contacts;
+
+-- Drop old table and rename new one
+DROP TABLE contacts;
+ALTER TABLE contacts_new RENAME TO contacts;
+
+-- Recreate index on contacts table
+CREATE INDEX idx_contacts_wallet_checksum ON contacts(wallet_checksum);
+
+-- Step 2: Recreate pending_contact_verifications table without language column
+DROP TABLE IF EXISTS pending_contact_verifications_new;
+CREATE TABLE pending_contact_verifications_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    wallet_checksum TEXT NOT NULL,
+    provider_type TEXT NOT NULL CHECK (provider_type IN ('sms', 'email')),
+    notification_target TEXT NOT NULL,
+    contact_name TEXT NOT NULL,
+    verification_code TEXT,
+    expires_at DATETIME NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    verified_at DATETIME DEFAULT NULL,
+    FOREIGN KEY (wallet_checksum) REFERENCES wallets(checksum) ON DELETE CASCADE
+);
+
+-- Copy existing data (excluding language column)
+INSERT INTO pending_contact_verifications_new (id, wallet_checksum, provider_type, notification_target, contact_name, verification_code, expires_at, created_at, verified_at)
+SELECT id, wallet_checksum, provider_type, notification_target, contact_name, verification_code, expires_at, created_at, verified_at FROM pending_contact_verifications;
+
+-- Drop old table and rename new one
+DROP TABLE pending_contact_verifications;
+ALTER TABLE pending_contact_verifications_new RENAME TO pending_contact_verifications;
+
+-- Recreate indexes on pending_contact_verifications table
+CREATE INDEX idx_pending_verifications_wallet ON pending_contact_verifications(wallet_checksum);
+CREATE INDEX idx_pending_verifications_expires ON pending_contact_verifications(expires_at);
+CREATE INDEX idx_pending_verifications_lookup ON pending_contact_verifications(wallet_checksum, notification_target, verified_at);
+
+-- Re-enable foreign keys
+PRAGMA foreign_keys = ON;

--- a/backend/src/email_provider.rs
+++ b/backend/src/email_provider.rs
@@ -37,6 +37,7 @@ impl NotificationProvider for EmailProvider {
         notification: &TransactionNotification,
         wallet_name: &str,
         contacts: &[Contact],
+        user_language: &Language,
     ) -> Vec<(NotificationMethod, NotificationResult, String)> {
         let mut results = Vec::new();
 
@@ -52,7 +53,7 @@ impl NotificationProvider for EmailProvider {
                     let message = MessageFormatter::create_localized_message(
                         notification,
                         wallet_name,
-                        &contact.language,
+                        user_language,
                     );
                     results.push((
                         method.clone(),
@@ -82,14 +83,14 @@ impl NotificationProvider for EmailProvider {
                 let message = MessageFormatter::create_localized_message(
                     notification,
                     wallet_name,
-                    &contact.language,
+                    user_language,
                 );
 
                 // Build email subject and body based on notification type
                 let subject = MessageFormatter::create_localized_email_subject(
                     notification,
                     wallet_name,
-                    &contact.language,
+                    user_language,
                 );
 
                 let (html_body, text_body) = match notification {
@@ -105,14 +106,14 @@ impl NotificationProvider for EmailProvider {
                             emoji,
                             &contact.name,
                             &message,
-                            &contact.language,
+                            user_language,
                         );
 
                         let text_body = Self::build_transaction_text(
                             &subject,
                             &contact.name,
                             &message,
-                            &contact.language,
+                            user_language,
                         );
 
                         (html_body, text_body)
@@ -122,13 +123,13 @@ impl NotificationProvider for EmailProvider {
                             wallet_name,
                             &contact.name,
                             &message,
-                            &contact.language,
+                            user_language,
                         );
                         let text_body = Self::build_balance_alert_text(
                             wallet_name,
                             &contact.name,
                             &message,
-                            &contact.language,
+                            user_language,
                         );
                         (html_body, text_body)
                     }

--- a/backend/src/handlers/contact.rs
+++ b/backend/src/handlers/contact.rs
@@ -3,7 +3,7 @@
 use crate::api::AppServicesState;
 use crate::config::AppConfig;
 use crate::extractors::{require_non_demo, AuthenticatedUser};
-use crate::metadata::{Language, ProviderType};
+use crate::metadata::ProviderType;
 use crate::models::{
     validate_phone_number, CreateContactResponse, CreateContactWithMethodsRequest, ErrorResponse,
     NotificationMethodRequest, UpdateContactRequest,
@@ -18,30 +18,23 @@ use axum::{
 use std::sync::Arc;
 use tracing::info;
 
-/// Generates an ntfy topic from contact name, language, and wallet descriptor
-fn generate_ntfy_topic(name: &str, language: &Language, descriptor: &str) -> String {
-    // Extract checksum from descriptor
-    let checksum = descriptor
-        .rfind('#')
-        .map(|i| &descriptor[i + 1..])
-        .unwrap_or("unknown");
-
-    // Sanitize name for topic
-    let sanitized_name = name
-        .to_lowercase()
-        .chars()
-        .map(|c| if c.is_alphanumeric() { c } else { '-' })
-        .collect::<String>()
-        .trim_matches('-')
-        .to_string();
-
-    // Combine into topic (max 64 chars)
-    let topic = format!("{}-{}-{}", sanitized_name, language.as_str(), checksum);
-    if topic.len() > 64 {
-        topic[..64].to_string()
-    } else {
-        topic
+/// Validates an ntfy topic (1-64 chars, alphanumeric and dashes)
+fn validate_ntfy_topic(topic: &str) -> Result<String, String> {
+    let topic = topic.trim();
+    if topic.is_empty() {
+        return Err("ntfy topic cannot be empty".to_string());
     }
+    if topic.len() > 64 {
+        return Err("ntfy topic must be at most 64 characters".to_string());
+    }
+    // Allow alphanumeric, dashes, and underscores
+    if !topic
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err("ntfy topic can only contain letters, numbers, dashes, and underscores".to_string());
+    }
+    Ok(topic.to_string())
 }
 
 /// Type alias for Stripe billing state
@@ -65,7 +58,7 @@ pub async fn create_wallet_contact(
     }
 
     // Direct metadata access - no mutex blocking!
-    let wallet = match app_services
+    let _wallet = match app_services
         .metadata_db
         .get_wallet_by_checksum(&wallet_checksum)
         .await
@@ -227,10 +220,17 @@ pub async fn create_wallet_contact(
             }
             ProviderType::Ntfy => {
                 // Push notifications are always allowed (ntfy is free)
-                // Auto-generate ntfy topic
-                let topic =
-                    generate_ntfy_topic(&payload.name, &payload.language, &wallet.descriptor);
-                processed_methods.push((ProviderType::Ntfy, topic));
+                // Use user-provided topic from request
+                match validate_ntfy_topic(&method.notification_target) {
+                    Ok(topic) => processed_methods.push((ProviderType::Ntfy, topic)),
+                    Err(e) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(ErrorResponse { error: e }),
+                        )
+                            .into_response();
+                    }
+                }
             }
             ProviderType::Email => {
                 // Basic email validation
@@ -328,7 +328,6 @@ pub async fn create_wallet_contact(
         .insert_contact_with_notification_methods(
             &wallet_checksum,
             &payload.name,
-            &payload.language,
             processed_methods,
         )
         .await;
@@ -465,7 +464,7 @@ pub async fn update_wallet_contact(
     }
 
     // Check if wallet exists and user has access
-    let wallet = match app_services
+    let _wallet = match app_services
         .metadata_db
         .get_wallet_by_checksum(&wallet_checksum)
         .await
@@ -628,10 +627,17 @@ pub async fn update_wallet_contact(
             }
             ProviderType::Ntfy => {
                 // Push notifications are always allowed (ntfy is free)
-                // Auto-generate ntfy topic
-                let topic =
-                    generate_ntfy_topic(&payload.name, &payload.language, &wallet.descriptor);
-                processed_methods.push((ProviderType::Ntfy, topic));
+                // Use user-provided topic from request
+                match validate_ntfy_topic(&method.notification_target) {
+                    Ok(topic) => processed_methods.push((ProviderType::Ntfy, topic)),
+                    Err(e) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(ErrorResponse { error: e }),
+                        )
+                            .into_response();
+                    }
+                }
             }
             ProviderType::Email => {
                 // Basic email validation
@@ -740,7 +746,6 @@ pub async fn update_wallet_contact(
             &contact_id,
             &wallet_checksum,
             &payload.name,
-            &payload.language,
             processed_methods,
         )
         .await

--- a/backend/src/handlers/contact_verification.rs
+++ b/backend/src/handlers/contact_verification.rs
@@ -4,6 +4,7 @@ use crate::api::AppServicesState;
 use crate::auth::{load_twilio_config_from_env, AuthService};
 use crate::config::AppConfig;
 use crate::extractors::AuthenticatedUser;
+use crate::metadata::Language;
 use crate::models::{
     validate_phone_number, ErrorResponse, SendContactVerificationRequest, VerifyContactRequest,
     VerifyContactResponse,
@@ -26,6 +27,13 @@ pub async fn send_contact_verification(
 ) -> Response {
     let _ = config; // Used for state extraction pattern consistency
     let start_time = std::time::Instant::now();
+
+    // Get user's preferred language for verification emails
+    let user_language = app_services
+        .metadata_db
+        .get_user_preferred_language(&user.user_id)
+        .await
+        .unwrap_or(Language::English);
 
     // Check if wallet exists and user has access - no mutex blocking!
     match app_services
@@ -189,7 +197,6 @@ pub async fn send_contact_verification(
                         "email",
                         &email,
                         &request.name,
-                        &request.language,
                         None, // No code needed for auto-verification
                     )
                     .await
@@ -304,7 +311,6 @@ pub async fn send_contact_verification(
             provider_type,
             &notification_target,
             &request.name,
-            &request.language,
             stored_code,
         )
         .await
@@ -376,7 +382,7 @@ pub async fn send_contact_verification(
                 &notification_target,
                 &request.name,
                 &verification_code,
-                &request.language,
+                user_language.as_str(),
             )
             .await
     };
@@ -508,7 +514,7 @@ pub async fn verify_contact(
     };
 
     // Look up the pending verification - no mutex blocking!
-    let (verification_id, _contact_name, _language, verification_code) = match app_services
+    let (verification_id, _contact_name, verification_code) = match app_services
         .metadata_db
         .get_pending_verification(&wallet_checksum, &notification_target)
         .await

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -4,7 +4,7 @@ use crate::admin_notifications::AdminNotifications;
 use crate::api::AppServicesState;
 use crate::config::{AppConfig, NetworkConfig};
 use crate::extractors::{require_non_demo, AuthenticatedUser};
-use crate::metadata::{Language, ProviderType, WalletDetailResponse};
+use crate::metadata::{ProviderType, WalletDetailResponse};
 use crate::models::{
     CreateWalletRequest, CreateWalletResponse, ErrorResponse, UpdateWalletRequest,
 };
@@ -210,43 +210,16 @@ pub async fn create_wallet_non_blocking(
         Ok(wallet_metadata) => {
             // Check if cloud mode - if so, auto-add user as contact
             if config.is_cloud_mode() {
-                // Log the received language from frontend
-                eprintln!(
-                    "Received preferred_language from frontend: {:?}",
-                    payload.preferred_language
-                );
-
                 // Get user info for contact creation (NON-BLOCKING)
                 let metadata_db = app_services.metadata_db.clone();
                 let user_id = user.user_id.clone();
                 let wallet_checksum = wallet_metadata.checksum.clone();
-                let preferred_language = payload.preferred_language.clone();
 
                 // Spawn async task to create contact (don't block wallet creation if this fails)
                 tokio::spawn(async move {
                     // Get user details from database (no mutex needed)
                     match metadata_db.get_user_by_id(&user_id).await {
                         Ok(Some(user_record)) => {
-                            // Map browser language to supported languages
-                            let language = match preferred_language.as_deref() {
-                                Some(lang)
-                                    if lang.starts_with("no")
-                                        || lang.starts_with("nb")
-                                        || lang.starts_with("nn") =>
-                                {
-                                    eprintln!("Mapping language '{}' to Norwegian", lang);
-                                    Language::Norwegian
-                                }
-                                Some(lang) => {
-                                    eprintln!("Mapping language '{}' to English (default)", lang);
-                                    Language::English
-                                }
-                                None => {
-                                    eprintln!("No language provided, defaulting to English");
-                                    Language::English
-                                }
-                            };
-
                             // Use user's name or fallback to "Me"
                             let contact_name = user_record.name.as_deref().unwrap_or("Me");
 
@@ -258,7 +231,6 @@ pub async fn create_wallet_non_blocking(
                                 .insert_contact_with_notification_methods(
                                     &wallet_checksum,
                                     contact_name,
-                                    &language,
                                     notification_methods,
                                 )
                                 .await

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -340,13 +340,12 @@ async fn main() -> anyhow::Result<()> {
                             );
 
                             // Add "Canary" contact with email notification
-                            use metadata::{Language, ProviderType};
+                            use metadata::ProviderType;
                             match app_services
                                 .metadata_db
                                 .insert_contact_with_notification_methods(
                                     &wallet_metadata.checksum,
                                     "Canary",
-                                    &Language::English,
                                     vec![(
                                         ProviderType::Email,
                                         "contact@canarybitcoin.com".to_string(),
@@ -802,6 +801,13 @@ async fn main() -> anyhow::Result<()> {
                             .ok()
                             .flatten();
 
+                        // Look up user's preferred language for notifications
+                        let user_language = notification_wallet_manager
+                            .metadata_db
+                            .get_user_preferred_language(&wallet_info.user_id)
+                            .await
+                            .unwrap_or(crate::metadata::Language::English);
+
                         // Generate message content once (same for all providers)
                         let mut message_content = String::new();
                         let mut provider_counts = std::collections::HashMap::new();
@@ -838,7 +844,7 @@ async fn main() -> anyhow::Result<()> {
                                 let ntfy_provider = NtfyProvider::with_auth(ntfy_server, ntfy_auth);
                                 use crate::notifications::NotificationProvider;
                                 Ok(ntfy_provider
-                                    .send_notification(&notification, &wallet_info.name, &contacts)
+                                    .send_notification(&notification, &wallet_info.name, &contacts, &user_language)
                                     .await)
                             } else {
                                 manager
@@ -847,6 +853,7 @@ async fn main() -> anyhow::Result<()> {
                                         &notification,
                                         &wallet_info.name,
                                         &contacts,
+                                        &user_language,
                                     )
                                     .await
                             };

--- a/backend/src/metadata.rs
+++ b/backend/src/metadata.rs
@@ -185,7 +185,6 @@ pub struct Contact {
     pub id: Option<String>, // UUIDv4
     pub wallet_checksum: String,
     pub name: String,
-    pub language: Language,
     pub notification_methods: Vec<NotificationMethod>,
     pub created_at: String,
     pub is_active: bool,
@@ -1384,12 +1383,10 @@ impl MetadataDb {
         &self,
         wallet_checksum: &str,
         name: &str,
-        language: &Language,
         notification_methods: Vec<(ProviderType, String)>,
     ) -> Result<String> {
         let pool = self.pool.clone();
         let name = name.to_string();
-        let language = *language;
         let checksum = wallet_checksum.to_string();
 
         spawn_blocking(move || -> Result<String> {
@@ -1399,8 +1396,8 @@ impl MetadataDb {
             // Insert contact with UUID
             let contact_id = Uuid::new_v4().to_string();
             tx.execute(
-                "INSERT INTO contacts (id, wallet_checksum, name, language) VALUES (?1, ?2, ?3, ?4)",
-                params![&contact_id, checksum, &name, language.as_str()],
+                "INSERT INTO contacts (id, wallet_checksum, name) VALUES (?1, ?2, ?3)",
+                params![&contact_id, checksum, &name],
             )?;
 
             // Insert notification methods
@@ -1437,23 +1434,21 @@ impl MetadataDb {
             let conn = pool.get()?;
 
             // Get ALL contacts ordered by created_at ASC (oldest first) for limits enforcement
-            let query = "SELECT id, wallet_checksum, name, language, created_at, is_active
+            let query = "SELECT id, wallet_checksum, name, created_at, is_active
                          FROM contacts
                          WHERE wallet_checksum = ?1 ORDER BY created_at ASC";
             let mut stmt = conn.prepare(query)?;
 
             let contact_iter = stmt.query_map(params![checksum], |row| {
-                let language_str: String = row.get(3)?;
                 Ok((
                     row.get::<_, String>(0)?, // id as UUIDv4
                     Contact {
                         id: Some(row.get(0)?),
                         wallet_checksum: row.get(1)?,
                         name: row.get(2)?,
-                        language: Language::from(language_str.as_str()),
                         notification_methods: Vec::new(), // Will be populated below
-                        created_at: row.get(4)?,
-                        is_active: row.get::<_, i64>(5).unwrap_or(1) != 0, // SQLite stores bool as int
+                        created_at: row.get(3)?,
+                        is_active: row.get::<_, i64>(4).unwrap_or(1) != 0, // SQLite stores bool as int
                     },
                 ))
             })?;
@@ -1507,28 +1502,26 @@ impl MetadataDb {
 
             // Get contacts for the wallet (active only or all based on parameter)
             let query = if include_inactive {
-                "SELECT id, wallet_checksum, name, language, created_at, is_active
+                "SELECT id, wallet_checksum, name, created_at, is_active
                  FROM contacts
                  WHERE wallet_checksum = ?1 ORDER BY name, created_at"
             } else {
-                "SELECT id, wallet_checksum, name, language, created_at, 1 as is_active
+                "SELECT id, wallet_checksum, name, created_at, 1 as is_active
                  FROM contacts
                  WHERE wallet_checksum = ?1 AND is_active = 1 ORDER BY name, created_at"
             };
             let mut stmt = conn.prepare(query)?;
 
             let contact_iter = stmt.query_map(params![checksum], |row| {
-                let language_str: String = row.get(3)?;
                 Ok((
                     row.get::<_, String>(0)?, // id as UUIDv4
                     Contact {
                         id: Some(row.get(0)?),
                         wallet_checksum: row.get(1)?,
                         name: row.get(2)?,
-                        language: Language::from(language_str.as_str()),
                         notification_methods: Vec::new(), // Will be populated below
-                        created_at: row.get(4)?,
-                        is_active: row.get::<_, i64>(5).unwrap_or(1) != 0, // SQLite stores bool as int
+                        created_at: row.get(3)?,
+                        is_active: row.get::<_, i64>(4).unwrap_or(1) != 0, // SQLite stores bool as int
                     },
                 ))
             })?;
@@ -1636,20 +1629,18 @@ impl MetadataDb {
             let conn = pool.get()?;
 
             // Get the contact
-            let query = "SELECT id, wallet_checksum, name, language, created_at, is_active
+            let query = "SELECT id, wallet_checksum, name, created_at, is_active
                          FROM contacts
                          WHERE id = ?1 AND wallet_checksum = ?2";
             let mut stmt = conn.prepare(query)?;
             let contact_result = stmt.query_row(params![contact_id, checksum], |row| {
-                let language_str: String = row.get(3)?;
                 Ok(Contact {
                     id: Some(row.get(0)?),
                     wallet_checksum: row.get(1)?,
                     name: row.get(2)?,
-                    language: Language::from(language_str.as_str()),
                     notification_methods: Vec::new(), // Will be populated below
-                    created_at: row.get(4)?,
-                    is_active: row.get::<_, i64>(5).unwrap_or(1) != 0, // SQLite stores bool as int
+                    created_at: row.get(3)?,
+                    is_active: row.get::<_, i64>(4).unwrap_or(1) != 0, // SQLite stores bool as int
                 })
             });
 
@@ -2863,7 +2854,6 @@ impl MetadataDb {
         provider_type: &str,
         notification_target: &str,
         contact_name: &str,
-        language: &str,
         verification_code: Option<&str>,
     ) -> Result<i64> {
         let pool = self.pool.clone();
@@ -2871,7 +2861,6 @@ impl MetadataDb {
         let provider_type = provider_type.to_string();
         let notification_target = notification_target.to_string();
         let contact_name = contact_name.to_string();
-        let language = language.to_string();
         let verification_code = verification_code.map(|s| s.to_string());
 
         spawn_blocking(move || {
@@ -2880,14 +2869,13 @@ impl MetadataDb {
 
             conn.execute(
                 "INSERT INTO pending_contact_verifications
-                 (wallet_checksum, provider_type, notification_target, contact_name, language, verification_code, expires_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                 (wallet_checksum, provider_type, notification_target, contact_name, verification_code, expires_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                 params![
                     &wallet_checksum,
                     &provider_type,
                     &notification_target,
                     &contact_name,
-                    &language,
                     &verification_code,
                     expires_at.to_rfc3339()
                 ],
@@ -2900,7 +2888,7 @@ impl MetadataDb {
         &self,
         wallet_checksum: &str,
         notification_target: &str,
-    ) -> Result<Option<(i64, String, String, Option<String>)>> {
+    ) -> Result<Option<(i64, String, Option<String>)>> {
         let pool = self.pool.clone();
         let wallet_checksum = wallet_checksum.to_string();
         let notification_target = notification_target.to_string();
@@ -2908,7 +2896,7 @@ impl MetadataDb {
         spawn_blocking(move || {
             let conn = pool.get()?;
             let mut stmt = conn.prepare(
-                "SELECT id, contact_name, language, verification_code
+                "SELECT id, contact_name, verification_code
                  FROM pending_contact_verifications
                  WHERE wallet_checksum = ?1
                  AND notification_target = ?2
@@ -2919,7 +2907,7 @@ impl MetadataDb {
 
             let result = stmt
                 .query_row(params![&wallet_checksum, &notification_target], |row| {
-                    Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
                 })
                 .optional()?;
 
@@ -3047,14 +3035,12 @@ impl MetadataDb {
         contact_id: &str,
         wallet_checksum: &str,
         name: &str,
-        language: &Language,
         new_methods: Vec<(ProviderType, String)>,
     ) -> Result<()> {
         let pool = self.pool.clone();
         let contact_id = contact_id.to_string();
         let checksum = wallet_checksum.to_string();
         let contact_name = name.to_string();
-        let lang = *language;
 
         spawn_blocking(move || -> Result<()> {
             let conn = pool.get()?;
@@ -3065,8 +3051,8 @@ impl MetadataDb {
             match (|| -> Result<()> {
                 // Update contact basics
                 conn.execute(
-                    "UPDATE contacts SET name = ?1, language = ?2 WHERE id = ?3 AND wallet_checksum = ?4",
-                    params![contact_name, lang.as_str(), contact_id, checksum],
+                    "UPDATE contacts SET name = ?1 WHERE id = ?2 AND wallet_checksum = ?3",
+                    params![contact_name, contact_id, checksum],
                 )?;
 
                 // Check if contact was updated (exists and belongs to wallet)
@@ -3236,6 +3222,22 @@ impl MetadataDb {
                 params![currency, user_id],
             )?;
             Ok(())
+        })
+        .await?
+    }
+
+    /// Get user's preferred language for notifications
+    pub async fn get_user_preferred_language(&self, user_id: &str) -> Result<Language> {
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        spawn_blocking(move || -> Result<Language> {
+            let conn = pool.get()?;
+            let language: Option<String> = conn
+                .prepare("SELECT preferred_language FROM users WHERE id = ?1")?
+                .query_row(params![user_id], |row| row.get(0))
+                .optional()?
+                .flatten();
+            Ok(language.map(|l| Language::from(l.as_str())).unwrap_or(Language::English))
         })
         .await?
     }

--- a/backend/src/models/requests.rs
+++ b/backend/src/models/requests.rs
@@ -1,6 +1,6 @@
 //! Request DTOs for API endpoints
 
-use crate::metadata::{BalanceAlertType, Language, ProviderType};
+use crate::metadata::{BalanceAlertType, ProviderType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
@@ -41,8 +41,6 @@ pub struct NotificationMethodRequest {
 pub struct CreateContactWithMethodsRequest {
     /// The name of the contact person
     pub name: String,
-    /// The language preference for notifications
-    pub language: Language,
     /// List of notification methods for this contact
     pub notification_methods: Vec<NotificationMethodRequest>,
 }
@@ -51,8 +49,6 @@ pub struct CreateContactWithMethodsRequest {
 pub struct SendContactVerificationRequest {
     /// Contact name
     pub name: String,
-    /// Language for notifications
-    pub language: String,
     /// Phone number to verify (optional)
     pub phone_number: Option<String>,
     /// Email address to verify (optional)
@@ -63,8 +59,6 @@ pub struct SendContactVerificationRequest {
 pub struct UpdateContactRequest {
     /// Contact name
     pub name: String,
-    /// Contact language
-    pub language: Language,
     /// Notification methods for the contact
     pub notification_methods: Vec<NotificationMethodRequest>,
 }

--- a/backend/src/notifications.rs
+++ b/backend/src/notifications.rs
@@ -1,4 +1,4 @@
-use crate::metadata::{Contact, NotificationMethod, TransactionNotification};
+use crate::metadata::{Contact, Language, NotificationMethod, TransactionNotification};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -26,6 +26,7 @@ pub trait NotificationProvider: Send + Sync {
         notification: &TransactionNotification,
         wallet_name: &str,
         contacts: &[Contact],
+        user_language: &Language,
     ) -> Vec<(NotificationMethod, NotificationResult, String)>;
 
     fn provider_info(&self) -> ProviderInfo;
@@ -61,11 +62,12 @@ impl NotificationManager {
         notification: &TransactionNotification,
         wallet_name: &str,
         contacts: &[Contact],
+        user_language: &Language,
     ) -> Result<Vec<(NotificationMethod, NotificationResult, String)>> {
         match self.providers.get(provider_name) {
             Some(provider) => {
                 let results = provider
-                    .send_notification(notification, wallet_name, contacts)
+                    .send_notification(notification, wallet_name, contacts, user_language)
                     .await;
                 Ok(results)
             }

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -1,6 +1,6 @@
 use crate::message_formatter::MessageFormatter;
 use crate::metadata::{
-    Contact, EventType, NotificationMethod, ProviderType, TransactionNotification,
+    Contact, EventType, Language, NotificationMethod, ProviderType, TransactionNotification,
 };
 use crate::notifications::{NotificationProvider, NotificationResult, ProviderInfo};
 use async_trait::async_trait;
@@ -61,6 +61,7 @@ impl NotificationProvider for NtfyProvider {
         notification: &TransactionNotification,
         wallet_name: &str,
         contacts: &[Contact],
+        user_language: &Language,
     ) -> Vec<(NotificationMethod, NotificationResult, String)> {
         let mut results = Vec::new();
 
@@ -76,7 +77,7 @@ impl NotificationProvider for NtfyProvider {
                 let message = MessageFormatter::create_localized_message(
                     notification,
                     wallet_name,
-                    &contact.language,
+                    user_language,
                 );
 
                 // Extract priority for ntfy headers
@@ -90,7 +91,7 @@ impl NotificationProvider for NtfyProvider {
                 let ntfy_url = format!("{}/{}", self.server_url, topic);
 
                 // Create localized title for push notification
-                let locale = contact.language.as_str();
+                let locale = user_language.as_str();
                 let title_key = match notification {
                     TransactionNotification::Pending(tx) => match tx.transaction_type {
                         EventType::Receive => "titles.receive.pending",

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -62,21 +62,11 @@ async fn test_delete_wallet_contact_authorization() {
 
     // Add contacts to each wallet using the notification methods API
     let contact1_id = db
-        .insert_contact_with_notification_methods(
-            &wallet1_checksum,
-            "Contact 1",
-            &Language::English,
-            vec![],
-        )
+        .insert_contact_with_notification_methods(&wallet1_checksum, "Contact 1", vec![])
         .await
         .unwrap();
     let contact2_id = db
-        .insert_contact_with_notification_methods(
-            &wallet2_checksum,
-            "Contact 2",
-            &Language::English,
-            vec![],
-        )
+        .insert_contact_with_notification_methods(&wallet2_checksum, "Contact 2", vec![])
         .await
         .unwrap();
 
@@ -178,12 +168,7 @@ async fn test_delete_wallet_contact_wrong_wallet() {
 
     // Add contact to wallet1
     let contact_id = db
-        .insert_contact_with_notification_methods(
-            &wallet1_checksum,
-            "Test Contact",
-            &Language::English,
-            vec![],
-        )
+        .insert_contact_with_notification_methods(&wallet1_checksum, "Test Contact", vec![])
         .await
         .unwrap();
 
@@ -207,4 +192,82 @@ async fn test_delete_wallet_contact_wrong_wallet() {
         1,
         "Contact should still exist in original wallet"
     );
+}
+
+#[tokio::test]
+async fn test_get_user_preferred_language_default() {
+    let (db, _temp_dir) = create_test_db().await;
+
+    // Create user without preferred language
+    let user_id = db
+        .create_user(
+            "test@example.com",
+            "hashedpassword",
+            Some("Test User"),
+            false,
+            None, // preferred_currency
+            None, // preferred_language - not set
+        )
+        .await
+        .unwrap();
+
+    // Should return English as default
+    let language = db.get_user_preferred_language(&user_id).await.unwrap();
+    assert_eq!(language, Language::English, "Should default to English when no preference set");
+}
+
+#[tokio::test]
+async fn test_get_user_preferred_language_norwegian() {
+    let (db, _temp_dir) = create_test_db().await;
+
+    // Create user with Norwegian preference
+    let user_id = db
+        .create_user(
+            "nordic@example.com",
+            "hashedpassword",
+            Some("Nordic User"),
+            false,
+            None,           // preferred_currency
+            Some("no"),     // preferred_language - Norwegian
+        )
+        .await
+        .unwrap();
+
+    // Should return Norwegian
+    let language = db.get_user_preferred_language(&user_id).await.unwrap();
+    assert_eq!(language, Language::Norwegian, "Should return Norwegian when set");
+}
+
+#[tokio::test]
+async fn test_get_user_preferred_language_japanese() {
+    let (db, _temp_dir) = create_test_db().await;
+
+    // Create user with Japanese preference
+    let user_id = db
+        .create_user(
+            "japan@example.com",
+            "hashedpassword",
+            Some("Japanese User"),
+            false,
+            None,           // preferred_currency
+            Some("ja"),     // preferred_language - Japanese
+        )
+        .await
+        .unwrap();
+
+    // Should return Japanese
+    let language = db.get_user_preferred_language(&user_id).await.unwrap();
+    assert_eq!(language, Language::Japanese, "Should return Japanese when set");
+}
+
+#[tokio::test]
+async fn test_get_user_preferred_language_nonexistent_user() {
+    let (db, _temp_dir) = create_test_db().await;
+
+    // Query for non-existent user should return English default
+    let language = db
+        .get_user_preferred_language("nonexistent-user-id")
+        .await
+        .unwrap();
+    assert_eq!(language, Language::English, "Should default to English for non-existent user");
 }

--- a/backend/src/tests/notifications.rs
+++ b/backend/src/tests/notifications.rs
@@ -2,6 +2,9 @@ use crate::metadata::{
     Contact, EventType, Language, NotificationMethod, ProviderType, Transaction,
     TransactionNotification,
 };
+
+// Test language constant for all tests
+const TEST_LANGUAGE: Language = Language::English;
 use crate::notifications::{NotificationProvider, NotificationResult, ProviderInfo};
 use crate::ntfy_provider::NtfyProvider;
 use crate::twilio_provider::TwilioProvider;
@@ -30,12 +33,11 @@ fn create_test_transaction(
     }
 }
 
-fn create_test_contact(name: &str, language: Language) -> Contact {
+fn create_test_contact(name: &str) -> Contact {
     Contact {
         id: Some("550e8400-e29b-41d4-a716-446655440001".to_string()),
         wallet_checksum: "test_wallet".to_string(),
         name: name.to_string(),
-        language,
         notification_methods: vec![],
         created_at: "2023-01-01 12:00:00".to_string(),
         is_active: true,
@@ -79,12 +81,12 @@ async fn test_ntfy_send_notification() {
     let event = create_test_transaction(EventType::Receive, 100_000_000, true);
     let notification = TransactionNotification::Confirmed(event);
 
-    let mut contact = create_test_contact("Test User", Language::English);
+    let mut contact = create_test_contact("Test User");
     contact.notification_methods =
         vec![create_notification_method(ProviderType::Ntfy, "test-topic")];
 
     let results = provider
-        .send_notification(&notification, "Test Wallet", &[contact])
+        .send_notification(&notification, "Test Wallet", &[contact], &TEST_LANGUAGE)
         .await;
 
     assert_eq!(results.len(), 1);
@@ -100,14 +102,15 @@ async fn test_ntfy_filters_only_ntfy_methods() {
     let event = create_test_transaction(EventType::Send, 50_000_000, false);
     let notification = TransactionNotification::Pending(event);
 
-    let mut contact = create_test_contact("Test User", Language::Norwegian);
+    let mut contact = create_test_contact("Test User");
     contact.notification_methods = vec![
         create_notification_method(ProviderType::Ntfy, "my-topic"),
         create_notification_method(ProviderType::Sms, "+4712345678"),
     ];
 
+    let norwegian = Language::Norwegian;
     let results = provider
-        .send_notification(&notification, "Test Wallet", &[contact])
+        .send_notification(&notification, "Test Wallet", &[contact], &norwegian)
         .await;
 
     // Should only process the ntfy method
@@ -161,14 +164,14 @@ async fn test_twilio_send_notification() {
     let event = create_test_transaction(EventType::Receive, 100_000_000, true);
     let notification = TransactionNotification::Confirmed(event);
 
-    let mut contact = create_test_contact("Test User", Language::English);
+    let mut contact = create_test_contact("Test User");
     contact.notification_methods = vec![create_notification_method(
         ProviderType::Sms,
         "+15551234567",
     )];
 
     let results = provider
-        .send_notification(&notification, "Test Wallet", &[contact])
+        .send_notification(&notification, "Test Wallet", &[contact], &TEST_LANGUAGE)
         .await;
 
     assert_eq!(results.len(), 1);
@@ -192,14 +195,15 @@ async fn test_twilio_filters_only_sms_methods() {
     let event = create_test_transaction(EventType::Send, 50_000_000, false);
     let notification = TransactionNotification::Pending(event);
 
-    let mut contact = create_test_contact("Test User", Language::Norwegian);
+    let mut contact = create_test_contact("Test User");
     contact.notification_methods = vec![
         create_notification_method(ProviderType::Ntfy, "my-topic"),
         create_notification_method(ProviderType::Sms, "+4712345678"),
     ];
 
+    let norwegian = Language::Norwegian;
     let results = provider
-        .send_notification(&notification, "Test Wallet", &[contact])
+        .send_notification(&notification, "Test Wallet", &[contact], &norwegian)
         .await;
 
     // Should only process the SMS method
@@ -228,6 +232,7 @@ impl NotificationProvider for MockProvider {
         _notification: &TransactionNotification,
         _wallet_name: &str,
         contacts: &[Contact],
+        _user_language: &Language,
     ) -> Vec<(NotificationMethod, NotificationResult, String)> {
         contacts
             .iter()
@@ -289,19 +294,19 @@ async fn test_notification_manager() {
     // Send notifications
     let event = create_test_transaction(EventType::Receive, 100_000_000, true);
     let notification = TransactionNotification::Confirmed(event);
-    let mut contact = create_test_contact("Test User", Language::English);
+    let mut contact = create_test_contact("Test User");
     contact.notification_methods =
         vec![create_notification_method(ProviderType::Ntfy, "test-topic")];
 
     let results = manager
-        .send_notifications("success", &notification, "Test Wallet", &[contact.clone()])
+        .send_notifications("success", &notification, "Test Wallet", &[contact.clone()], &TEST_LANGUAGE)
         .await
         .unwrap();
     assert_eq!(results.len(), 1);
     assert!(results[0].1.success);
 
     let results = manager
-        .send_notifications("failure", &notification, "Test Wallet", &[contact])
+        .send_notifications("failure", &notification, "Test Wallet", &[contact], &TEST_LANGUAGE)
         .await
         .unwrap();
     assert_eq!(results.len(), 1);
@@ -316,10 +321,10 @@ async fn test_notification_manager_unknown_provider() {
     let manager = NotificationManager::new();
     let event = create_test_transaction(EventType::Receive, 100_000_000, true);
     let notification = TransactionNotification::Confirmed(event);
-    let contact = create_test_contact("Test User", Language::English);
+    let contact = create_test_contact("Test User");
 
     let result = manager
-        .send_notifications("unknown", &notification, "Test Wallet", &[contact])
+        .send_notifications("unknown", &notification, "Test Wallet", &[contact], &TEST_LANGUAGE)
         .await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("not found"));

--- a/backend/src/twilio_provider.rs
+++ b/backend/src/twilio_provider.rs
@@ -1,5 +1,5 @@
 use crate::message_formatter::MessageFormatter;
-use crate::metadata::{Contact, NotificationMethod, ProviderType, TransactionNotification};
+use crate::metadata::{Contact, Language, NotificationMethod, ProviderType, TransactionNotification};
 use crate::notifications::{NotificationProvider, NotificationResult, ProviderInfo};
 use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine as _};
@@ -144,6 +144,7 @@ impl NotificationProvider for TwilioProvider {
         notification: &TransactionNotification,
         wallet_name: &str,
         contacts: &[Contact],
+        user_language: &Language,
     ) -> Vec<(NotificationMethod, NotificationResult, String)> {
         let mut results = Vec::new();
 
@@ -159,7 +160,7 @@ impl NotificationProvider for TwilioProvider {
                 let message = MessageFormatter::create_localized_message(
                     notification,
                     wallet_name,
-                    &contact.language,
+                    user_language,
                 );
                 let result = self.send_sms(&method.notification_target, &message).await;
                 results.push((method.clone(), result, message));

--- a/backend/tests/contact_duplicates_test.rs
+++ b/backend/tests/contact_duplicates_test.rs
@@ -1,6 +1,6 @@
 use canary::{
     config::{AppConfig, NetworkConfig, OperatingMode},
-    metadata::{Language, MetadataDb, ProviderType},
+    metadata::{MetadataDb, ProviderType},
 };
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -48,12 +48,7 @@ async fn test_duplicate_email_prevention() {
     // First, create a contact with an email
     let contact1_methods = vec![(ProviderType::Email, "john@example.com".to_string())];
     let contact1_id = metadata_db
-        .insert_contact_with_notification_methods(
-            &wallet_checksum,
-            "John",
-            &Language::English,
-            contact1_methods,
-        )
+        .insert_contact_with_notification_methods(&wallet_checksum, "John", contact1_methods)
         .await
         .unwrap();
 
@@ -171,12 +166,7 @@ async fn test_duplicate_phone_prevention() {
     // First, create a contact with a phone number
     let contact1_methods = vec![(ProviderType::Sms, "+4712345678".to_string())];
     let contact1_id = metadata_db
-        .insert_contact_with_notification_methods(
-            &wallet_checksum,
-            "Alice",
-            &Language::English,
-            contact1_methods,
-        )
+        .insert_contact_with_notification_methods(&wallet_checksum, "Alice", contact1_methods)
         .await
         .unwrap();
 
@@ -282,12 +272,7 @@ async fn test_ntfy_topics_excluded_from_duplicate_check() {
     // Create contact with ntfy topic
     let contact1_methods = vec![(ProviderType::Ntfy, "some-topic".to_string())];
     metadata_db
-        .insert_contact_with_notification_methods(
-            &wallet_checksum,
-            "Bob",
-            &Language::English,
-            contact1_methods,
-        )
+        .insert_contact_with_notification_methods(&wallet_checksum, "Bob", contact1_methods)
         .await
         .unwrap();
 
@@ -350,12 +335,7 @@ async fn test_mixed_provider_types_allowed() {
     // Create contact with email
     let contact1_methods = vec![(ProviderType::Email, "+123456789".to_string())]; // Phone number as email (weird but allowed)
     metadata_db
-        .insert_contact_with_notification_methods(
-            &wallet_checksum,
-            "Contact 1",
-            &Language::English,
-            contact1_methods,
-        )
+        .insert_contact_with_notification_methods(&wallet_checksum, "Contact 1", contact1_methods)
         .await
         .unwrap();
 
@@ -421,7 +401,6 @@ async fn test_verification_endpoint_rejects_duplicates() {
         .insert_contact_with_notification_methods(
             &wallet_checksum,
             "Existing Contact",
-            &Language::English,
             contact1_methods,
         )
         .await

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -587,7 +587,6 @@
       "description": "Opret en ny kontakt for at modtage Bitcoin-transaktionsvarsler.",
       "nameLabel": "Navn",
       "namePlaceholder": "Kontaktnavn",
-      "languageLabel": "Sprog",
       "methodTitle": "Notifikationsmetoder",
       "providers": {
         "ntfy": "ntfy.sh Notifikationer",
@@ -595,7 +594,8 @@
         "email": "E-mail Notifikationer"
       },
       "ntfy": {
-        "topicHint": "Emne genereres automatisk baseret på kontaktnavn"
+        "topicLabel": "ntfy-emne",
+        "topicHint": "Abonner på dette emne på ntfy.sh for at modtage notifikationer"
       },
       "sms": {
         "phoneHint": "Inkluder landekode"
@@ -639,7 +639,8 @@
       "verifyNewEmail": "Bekræft venligst den nye e-mailadresse, før du gemmer kontakten"
     },
     "errors": {
-      "nameRequired": "Kontaktnavn er påkrævet"
+      "nameRequired": "Kontaktnavn er påkrævet",
+      "ntfyTopicRequired": "ntfy-emne er påkrævet"
     },
     "languages": {
       "da": "Dansk",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -587,7 +587,6 @@
       "description": "Richten Sie einen neuen Kontakt ein, um Bitcoin-Transaktionsbenachrichtigungen zu erhalten.",
       "nameLabel": "Name",
       "namePlaceholder": "Kontaktname",
-      "languageLabel": "Sprache",
       "methodTitle": "Benachrichtigungsmethoden",
       "providers": {
         "ntfy": "ntfy.sh-Benachrichtigungen",
@@ -595,7 +594,8 @@
         "email": "E-Mail-Benachrichtigungen"
       },
       "ntfy": {
-        "topicHint": "Topic wird automatisch basierend auf dem Kontaktnamen generiert"
+        "topicLabel": "ntfy-Thema",
+        "topicHint": "Abonnieren Sie dieses Thema auf ntfy.sh, um Benachrichtigungen zu erhalten"
       },
       "sms": {
         "phoneHint": "Ländervorwahl angeben"
@@ -639,7 +639,8 @@
       "verifyNewEmail": "Bitte verifizieren Sie die neue E-Mail-Adresse vor dem Speichern des Kontakts"
     },
     "errors": {
-      "nameRequired": "Kontaktname ist erforderlich"
+      "nameRequired": "Kontaktname ist erforderlich",
+      "ntfyTopicRequired": "ntfy-Thema ist erforderlich"
     },
     "languages": {
       "en": "Englisch",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -587,7 +587,6 @@
       "description": "Set up a new contact to receive Bitcoin transaction notifications.",
       "nameLabel": "Name",
       "namePlaceholder": "Contact name",
-      "languageLabel": "Language",
       "methodTitle": "Notification Methods",
       "providers": {
         "ntfy": "ntfy.sh Notifications",
@@ -595,7 +594,8 @@
         "email": "Email Notifications"
       },
       "ntfy": {
-        "topicHint": "Topic will be auto-generated based on contact name"
+        "topicLabel": "ntfy Topic",
+        "topicHint": "Subscribe to this topic at ntfy.sh to receive notifications"
       },
       "sms": {
         "phoneHint": "Include country code"
@@ -639,7 +639,8 @@
       "verifyNewEmail": "Please verify the new email address before saving the contact"
     },
     "errors": {
-      "nameRequired": "Contact name is required"
+      "nameRequired": "Contact name is required",
+      "ntfyTopicRequired": "ntfy topic is required"
     },
     "languages": {
       "en": "English",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -587,7 +587,6 @@
       "description": "Configura un nuevo contacto para recibir notificaciones de transacciones de Bitcoin.",
       "nameLabel": "Nombre",
       "namePlaceholder": "Nombre del contacto",
-      "languageLabel": "Idioma",
       "methodTitle": "Métodos de notificación",
       "providers": {
         "ntfy": "Notificaciones ntfy.sh",
@@ -595,7 +594,8 @@
         "email": "Notificaciones por correo"
       },
       "ntfy": {
-        "topicHint": "El tema se generará automáticamente según el nombre del contacto"
+        "topicLabel": "Tema de ntfy",
+        "topicHint": "Suscríbete a este tema en ntfy.sh para recibir notificaciones"
       },
       "sms": {
         "phoneHint": "Incluye código de país"
@@ -639,7 +639,8 @@
       "verifyNewEmail": "Verifica la nueva dirección de email antes de guardar el contacto"
     },
     "errors": {
-      "nameRequired": "El nombre del contacto es obligatorio"
+      "nameRequired": "El nombre del contacto es obligatorio",
+      "ntfyTopicRequired": "El tema de ntfy es obligatorio"
     },
     "languages": {
       "en": "Inglés",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -587,7 +587,6 @@
       "description": "Configurez un nouveau contact pour recevoir les notifications de transactions Bitcoin.",
       "nameLabel": "Nom",
       "namePlaceholder": "Nom du contact",
-      "languageLabel": "Langue",
       "methodTitle": "Méthodes de notification",
       "providers": {
         "ntfy": "Notifications ntfy.sh",
@@ -595,7 +594,8 @@
         "email": "Notifications par e-mail"
       },
       "ntfy": {
-        "topicHint": "Le sujet sera généré automatiquement en fonction du nom du contact"
+        "topicLabel": "Sujet ntfy",
+        "topicHint": "Abonnez-vous à ce sujet sur ntfy.sh pour recevoir les notifications"
       },
       "sms": {
         "phoneHint": "Inclure l'indicatif du pays"
@@ -639,7 +639,8 @@
       "verifyNewEmail": "Veuillez vérifier la nouvelle adresse email avant d'enregistrer le contact"
     },
     "errors": {
-      "nameRequired": "Le nom du contact est obligatoire"
+      "nameRequired": "Le nom du contact est obligatoire",
+      "ntfyTopicRequired": "Le sujet ntfy est requis"
     },
     "languages": {
       "en": "Anglais",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -587,7 +587,6 @@
       "description": "Bitcoinトランザクション通知を受け取る新しい連絡先を設定します。",
       "nameLabel": "名前",
       "namePlaceholder": "連絡先名",
-      "languageLabel": "言語",
       "methodTitle": "通知方法",
       "providers": {
         "ntfy": "ntfy.sh通知",
@@ -595,7 +594,8 @@
         "email": "メール通知"
       },
       "ntfy": {
-        "topicHint": "トピックは連絡先名に基づいて自動生成されます"
+        "topicLabel": "ntfyトピック",
+        "topicHint": "通知を受け取るには、ntfy.shでこのトピックを購読してください"
       },
       "sms": {
         "phoneHint": "国番号を含める"
@@ -639,7 +639,8 @@
       "verifyNewEmail": "連絡先を保存する前に新しいメールアドレスを確認してください"
     },
     "errors": {
-      "nameRequired": "連絡先名は必須です"
+      "nameRequired": "連絡先名は必須です",
+      "ntfyTopicRequired": "ntfyトピックは必須です"
     },
     "languages": {
       "en": "英語",

--- a/frontend/messages/no.json
+++ b/frontend/messages/no.json
@@ -587,7 +587,6 @@
       "description": "Sett opp en ny kontakt for å motta Bitcoin-transaksjonsvarsler.",
       "nameLabel": "Navn",
       "namePlaceholder": "Kontaktnavn",
-      "languageLabel": "Språk",
       "methodTitle": "Varslingsmetoder",
       "providers": {
         "ntfy": "ntfy.sh-varsler",
@@ -595,7 +594,8 @@
         "email": "E-postvarsler"
       },
       "ntfy": {
-        "topicHint": "Emne genereres automatisk basert på kontaktnavn"
+        "topicLabel": "ntfy-emne",
+        "topicHint": "Abonner på dette emnet på ntfy.sh for å motta varsler"
       },
       "sms": {
         "phoneHint": "Inkluder landskode"
@@ -639,7 +639,8 @@
       "verifyNewEmail": "Verifiser den nye e-postadressen før du lagrer kontakten"
     },
     "errors": {
-      "nameRequired": "Kontaktnavn er påkrevd"
+      "nameRequired": "Kontaktnavn er påkrevd",
+      "ntfyTopicRequired": "ntfy-emne er påkrevd"
     },
     "languages": {
       "en": "Engelsk",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -587,7 +587,6 @@
       "description": "Configure um novo contato para receber notificações de transações de Bitcoin.",
       "nameLabel": "Nome",
       "namePlaceholder": "Nome do contato",
-      "languageLabel": "Idioma",
       "methodTitle": "Métodos de notificação",
       "providers": {
         "ntfy": "Notificações ntfy.sh",
@@ -595,7 +594,8 @@
         "email": "Notificações por e-mail"
       },
       "ntfy": {
-        "topicHint": "O tópico será gerado automaticamente com base no nome do contato"
+        "topicLabel": "Tópico do ntfy",
+        "topicHint": "Inscreva-se neste tópico em ntfy.sh para receber notificações"
       },
       "sms": {
         "phoneHint": "Inclua o código do país"
@@ -639,7 +639,8 @@
       "verifyNewEmail": "Verifique o novo endereço de email antes de salvar o contato"
     },
     "errors": {
-      "nameRequired": "O nome do contato é obrigatório"
+      "nameRequired": "O nome do contato é obrigatório",
+      "ntfyTopicRequired": "O tópico do ntfy é obrigatório"
     },
     "languages": {
       "en": "Inglês",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -587,7 +587,6 @@
       "description": "Skapa en ny kontakt för att få aviseringar om Bitcoin-transaktioner.",
       "nameLabel": "Namn",
       "namePlaceholder": "Kontaktnamn",
-      "languageLabel": "Språk",
       "methodTitle": "Aviseringsmetoder",
       "providers": {
         "ntfy": "ntfy.sh-aviseringar",
@@ -595,7 +594,8 @@
         "email": "E-postaviseringar"
       },
       "ntfy": {
-        "topicHint": "Ämne kommer att genereras automatiskt baserat på kontaktnamn"
+        "topicLabel": "ntfy-ämne",
+        "topicHint": "Prenumerera på detta ämne på ntfy.sh för att ta emot aviseringar"
       },
       "sms": {
         "phoneHint": "Inkludera landskod"
@@ -640,7 +640,8 @@
       "verifyNewEmail": "Vänligen verifiera den nya e-postadressen innan du sparar kontakten"
     },
     "errors": {
-      "nameRequired": "Kontaktnamn krävs"
+      "nameRequired": "Kontaktnamn krävs",
+      "ntfyTopicRequired": "ntfy-ämne krävs"
     },
     "languages": {
       "en": "Engelska",

--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -41,7 +41,6 @@ const mockProviders = [
 const mockContact = {
   id: 1,
   name: 'Test Contact',
-  language: 'en' as const,
   created_at: '2024-01-01T00:00:00Z',
   notification_methods: [
     {
@@ -76,10 +75,9 @@ describe('ContactModal', () => {
       await act(async () => {
         render(<ContactModal {...defaultProps} />)
       })
-      
+
       expect(screen.getByText('Add New Contact')).toBeInTheDocument()
       expect(screen.getByLabelText('Name')).toBeInTheDocument()
-      expect(screen.getByLabelText('Language')).toBeInTheDocument()
     })
 
     it('does not render when closed', () => {
@@ -146,8 +144,7 @@ describe('ContactModal', () => {
         expect(mockApi.createContact).toHaveBeenCalledWith(
           'test-checksum',
           'Test Contact',
-          'en',
-          [{ provider_type: 'ntfy', notification_target: '' }]
+          [{ provider_type: 'ntfy', notification_target: 'test-contact-test-che' }]
         )
       })
     })
@@ -218,7 +215,6 @@ describe('ContactModal', () => {
         expect(mockApi.sendContactVerification).toHaveBeenCalledWith(
           'test-checksum',
           'SMS Contact',
-          'en',
           '+4712345678',
           undefined
         )

--- a/frontend/src/components/contact-modal.tsx
+++ b/frontend/src/components/contact-modal.tsx
@@ -18,9 +18,24 @@ import { Contact } from "../types"
 import { DeleteContactModal } from "./delete-contact-modal"
 import { useTranslations } from "next-intl"
 
-// Notification languages supported by backend (for contact notifications)
-// Must match backend Language enum: English, Norwegian, Spanish, Portuguese, German, French, Japanese, Danish, Swedish
-const NOTIFICATION_LANGUAGE_VALUES = ['en', 'no', 'es', 'pt', 'de', 'fr', 'ja', 'da', 'sv'] as const
+// Helper to sanitize name for ntfy topic
+function sanitizeForNtfyTopic(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 30) // Leave room for checksum suffix
+}
+
+// Generate default ntfy topic from name and wallet checksum
+function generateDefaultNtfyTopic(name: string, walletChecksum: string): string {
+  const sanitizedName = sanitizeForNtfyTopic(name)
+  if (!sanitizedName) {
+    return walletChecksum.substring(0, 8)
+  }
+  return `${sanitizedName}-${walletChecksum.substring(0, 8)}`
+}
 
 interface ContactModalProps {
   isOpen: boolean
@@ -40,7 +55,8 @@ export function ContactModal({
   const t = useTranslations('contacts')
   const tCommon = useTranslations('common')
   const [name, setName] = useState("")
-  const [language, setLanguage] = useState<typeof NOTIFICATION_LANGUAGE_VALUES[number]>('en')
+  const [ntfyTopic, setNtfyTopic] = useState("")
+  const [userEditedNtfyTopic, setUserEditedNtfyTopic] = useState(false)
   const [providers, setProviders] = useState<ProviderInfo[]>([])
   const [enabledProviders, setEnabledProviders] = useState<Record<string, boolean>>({})
   const [providerValues, setProviderValues] = useState<Record<string, string>>({})
@@ -162,20 +178,21 @@ export function ContactModal({
       setOriginalEmailAddress(null)
       setHasChanges(false)
       setIsDeleteModalOpen(false)
-      
+      setNtfyTopic("")
+      setUserEditedNtfyTopic(false)
+
       if (timerRef.current) {
         clearInterval(timerRef.current)
       }
-      
+
       if (editContact) {
         // Populate form with existing contact data
         setName(editContact.name)
-        setLanguage(editContact.language)
-        
+
         // Set up providers based on existing notification methods
         const newEnabledProviders: Record<string, boolean> = {}
         const newProviderValues: Record<string, string> = {}
-        
+
         editContact.notification_methods.forEach(method => {
           if (method.provider_type === 'sms') {
             const phoneNumber = method.display_target || method.notification_target
@@ -185,6 +202,10 @@ export function ContactModal({
             setSmsVerified(true) // SMS already exists on contact, so it's verified
           } else if (method.provider_type === 'ntfy') {
             newEnabledProviders['ntfy'] = true
+            // Pre-populate ntfy topic from existing notification method
+            const existingTopic = method.notification_target
+            setNtfyTopic(existingTopic)
+            setUserEditedNtfyTopic(true) // Mark as edited so it doesn't auto-update
           } else if (method.provider_type === 'email') {
             const emailAddress = method.display_target || method.notification_target
             newEnabledProviders['email'] = true
@@ -193,13 +214,12 @@ export function ContactModal({
             setEmailVerified(true) // Email already exists on contact, so it's verified
           }
         })
-        
+
         setEnabledProviders(newEnabledProviders)
         setProviderValues(newProviderValues)
       } else {
         // Reset form for new contact
         setName("")
-        setLanguage('en')
         setEnabledProviders({})
         setProviderValues({})
       }
@@ -250,11 +270,10 @@ export function ContactModal({
       await api.sendContactVerification(
         walletChecksum,
         name.trim() || `Contact-${phoneNumber.slice(-4)}`,
-        language,
         phoneNumber,
         undefined // emailAddress
       )
-      
+
       setSmsVerificationPhone(phoneNumber)
       setSmsVerificationSent(true)
       setSmsVerificationCode("")
@@ -358,11 +377,10 @@ export function ContactModal({
       const result = await api.sendContactVerification(
         walletChecksum,
         name.trim() || `Contact-${emailAddress.split('@')[0]}`,
-        language,
         undefined, // phoneNumber
         emailAddress
       )
-      
+
       // Check if email was auto-verified (user's own email)
       if (result.auto_verified) {
         setEmailVerified(true)
@@ -469,6 +487,12 @@ export function ContactModal({
     const hasSms = enabledProviders['twilio'] && providerValues['twilio']?.trim()
     const hasEmail = enabledProviders['email'] && providerValues['email']?.trim()
 
+    // Validate ntfy topic if ntfy is enabled
+    if (hasNtfy && !ntfyTopic.trim()) {
+      setError(t('errors.ntfyTopicRequired'))
+      return
+    }
+
     // Check if SMS verification is required but not completed
     if (smsVerificationRequired && !smsVerified) {
       if (phoneNumberChanged) {
@@ -496,32 +520,31 @@ export function ContactModal({
       // If verification requirements are met
       if ((!hasSms || (hasSms && smsVerified)) && (!hasEmail || (hasEmail && emailVerified))) {
         const notificationMethods: { provider_type: 'sms' | 'ntfy' | 'email'; notification_target: string }[] = []
-        
+
         if (hasNtfy) {
-          notificationMethods.push({ provider_type: 'ntfy', notification_target: '' })
+          notificationMethods.push({ provider_type: 'ntfy', notification_target: ntfyTopic.trim() })
         }
-        
+
         if (hasEmail && emailVerified) {
-          notificationMethods.push({ 
-            provider_type: 'email', 
-            notification_target: emailVerificationAddress || providerValues['email'].trim() 
+          notificationMethods.push({
+            provider_type: 'email',
+            notification_target: emailVerificationAddress || providerValues['email'].trim()
           })
         }
-        
+
         if (hasSms && smsVerified) {
-          notificationMethods.push({ 
-            provider_type: 'sms', 
+          notificationMethods.push({
+            provider_type: 'sms',
             notification_target: smsVerificationPhone || providerValues['twilio'].trim()
           })
         }
-        
+
         if (isEditMode && editContact) {
           // Use PUT for updates - atomic transaction
           await api.updateContact(
             walletChecksum,
             editContact.id,
             name.trim(),
-            language,
             notificationMethods
           )
         } else {
@@ -529,7 +552,6 @@ export function ContactModal({
           await api.createContact(
             walletChecksum,
             name.trim(),
-            language,
             notificationMethods
           )
         }
@@ -580,18 +602,17 @@ export function ContactModal({
 
   const handleResendCode = async () => {
     if (!smsVerificationPhone) return
-    
+
     setIsSendingVerification(true)
     setError(null)
-    
+
     try {
       await api.sendContactVerification(
         walletChecksum,
         name.trim(),
-        language,
         smsVerificationPhone
       )
-      
+
       setSmsVerificationCode("")
       startTimer()
       setError(null)
@@ -634,32 +655,17 @@ export function ContactModal({
               id="contact-name"
               value={name}
               onChange={(e) => {
-                setName(e.target.value)
+                const newName = e.target.value
+                setName(newName)
                 setHasChanges(true)
+                // Auto-update ntfy topic when name changes (if user hasn't manually edited it)
+                if (enabledProviders['ntfy'] && !userEditedNtfyTopic) {
+                  setNtfyTopic(generateDefaultNtfyTopic(newName, walletChecksum))
+                }
               }}
               placeholder={t('add.namePlaceholder')}
               disabled={isSubmitting}
             />
-          </div>
-
-          <div>
-            <Label htmlFor="contact-language">{t('add.languageLabel')}</Label>
-            <select
-              id="contact-language"
-              value={language}
-              onChange={(e) => {
-                setLanguage(e.target.value as typeof NOTIFICATION_LANGUAGE_VALUES[number])
-                setHasChanges(true)
-              }}
-              disabled={isSubmitting}
-              className="w-full h-10 border border-input bg-background px-3 py-2 rounded-md text-sm"
-            >
-              {NOTIFICATION_LANGUAGE_VALUES.map((langValue) => (
-                <option key={langValue} value={langValue}>
-                  {t(`languages.${langValue}`)}
-                </option>
-              ))}
-            </select>
           </div>
 
           <div>
@@ -677,6 +683,10 @@ export function ContactModal({
                           [provider.name]: e.target.checked
                         }))
                         setHasChanges(true)
+                        // Generate default ntfy topic when ntfy is enabled and no topic set
+                        if (provider.name === 'ntfy' && e.target.checked && !ntfyTopic && !userEditedNtfyTopic) {
+                          setNtfyTopic(generateDefaultNtfyTopic(name, walletChecksum))
+                        }
                       }}
                       disabled={isSubmitting}
                       className="mt-1"
@@ -980,9 +990,25 @@ export function ContactModal({
                         </div>
                       )}
                       {enabledProviders[provider.name] && provider.name === 'ntfy' && (
-                        <p className="text-xs text-muted-foreground mt-1">
-                          {t('add.ntfy.topicHint')}
-                        </p>
+                        <div className="mt-2 space-y-2">
+                          <div>
+                            <Label htmlFor="ntfy-topic">{t('add.ntfy.topicLabel')}</Label>
+                            <Input
+                              id="ntfy-topic"
+                              value={ntfyTopic}
+                              onChange={(e) => {
+                                setNtfyTopic(e.target.value)
+                                setUserEditedNtfyTopic(true)
+                                setHasChanges(true)
+                              }}
+                              placeholder={generateDefaultNtfyTopic(name || 'contact', walletChecksum)}
+                              disabled={isSubmitting}
+                            />
+                            <p className="text-xs text-muted-foreground mt-1">
+                              {t('add.ntfy.topicHint')}
+                            </p>
+                          </div>
+                        </div>
                       )}
                     </div>
                   </label>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@ import { getApiBaseUrl, handleApiResponse, createNetworkError, ApiError } from '
 
 // Re-export ApiError for convenience
 export { ApiError } from './utils'
-import { Wallet, Contact, TransactionEvent, BalanceAlert, CreateBalanceAlertRequest, NotificationLanguage } from '../types'
+import { Wallet, Contact, TransactionEvent, BalanceAlert, CreateBalanceAlertRequest } from '../types'
 
 export interface ProviderInfo {
   name: string
@@ -114,14 +114,12 @@ class ApiClient {
   async createContact(
     walletChecksum: string,
     name: string,
-    language: NotificationLanguage,
     notificationMethods: Array<{ provider_type: 'sms' | 'ntfy' | 'email', notification_target: string }>
   ): Promise<Contact> {
     return this.request<Contact>(`/api/wallets/${walletChecksum}/contacts`, {
       method: 'POST',
       body: JSON.stringify({
         name,
-        language,
         notification_methods: notificationMethods,
       }),
     })
@@ -130,7 +128,6 @@ class ApiClient {
   async sendContactVerification(
     walletChecksum: string,
     name: string,
-    language: string,
     phoneNumber?: string,
     emailAddress?: string
   ): Promise<{ message: string; auto_verified?: boolean }> {
@@ -138,7 +135,6 @@ class ApiClient {
       method: 'POST',
       body: JSON.stringify({
         name,
-        language,
         phone_number: phoneNumber,
         email_address: emailAddress,
       }),
@@ -165,14 +161,12 @@ class ApiClient {
     walletChecksum: string,
     contactId: string,
     name: string,
-    language: NotificationLanguage,
     notificationMethods: Array<{ provider_type: 'sms' | 'ntfy' | 'email', notification_target: string }>
   ): Promise<Contact> {
     return this.request<Contact>(`/api/wallets/${walletChecksum}/contacts/${contactId}`, {
       method: 'PUT',
       body: JSON.stringify({
         name,
-        language,
         notification_methods: notificationMethods,
       }),
     })

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -77,7 +77,6 @@ export interface Contact {
   id: string
   wallet_checksum: string
   name: string
-  language: NotificationLanguage
   notification_methods: NotificationMethod[]
   created_at: string
   is_active: boolean


### PR DESCRIPTION
## Summary

Implements issue #37: Simplify language handling by using the account's `preferred_language` for all notification formatting instead of per-contact language settings. Also makes ntfy topics user-editable.

### Key Changes

**Backend:**
- Updated `NotificationProvider` trait to accept `user_language` parameter
- All notification providers (ntfy, twilio, email) now use the account's preferred language
- Added `get_user_preferred_language()` helper function in metadata.rs
- Removed `language` field from `Contact` struct and all request DTOs
- Created migration 018 to drop the `language` column from `contacts` and `pending_contact_verifications` tables
- Added unit tests for the new `get_user_preferred_language()` function

**Frontend:**
- Made ntfy topics user-editable with smart default generation (`{sanitized-name}-{checksum}`)
- Removed language dropdown from contact modal
- Updated API layer to remove language parameter from contact operations
- Updated TypeScript types
- Updated all 9 translation files with new ntfy topic labels

### Breaking Changes

- The `language` field is removed from contact creation/update APIs
- Existing contacts will continue to work; their topics are preserved
- Notifications will now use the user's account language preference

## Test Plan

- [x] Backend unit tests pass (including 4 new tests for `get_user_preferred_language()`)
- [x] Frontend tests pass (100 tests)
- [x] Manual testing: upgraded from old database, created new contacts, edited ntfy topics
- [x] Clippy passes (only pre-existing warnings)

Closes #37