### PR TITLE
fix(i18n): Include contact name in delete confirmation message

### DIFF
--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "Slet kontakt",
-      "description": "Er du sikker på, at du vil slette denne kontakt? <strong>{name}</strong> vil ikke længere modtage notifikationer."
+      "description": "Er du sikker på, at du vil slette denne kontakt? <bold>{name}</bold> vil ikke længere modtage notifikationer."
     },
     "verification": {
       "codeLabel": "Verifikationskode",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "Kontakt löschen",
-      "description": "Sind Sie sicher, dass Sie diesen Kontakt löschen möchten? <strong>{name}</strong> erhält keine Benachrichtigungen mehr."
+      "description": "Sind Sie sicher, dass Sie diesen Kontakt löschen möchten? <bold>{name}</bold> erhält keine Benachrichtigungen mehr."
     },
     "verification": {
       "codeLabel": "Bestätigungscode",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "Delete Contact",
-      "description": "Are you sure you want to delete this contact? <strong>{name}</strong> will no longer receive notifications."
+      "description": "Are you sure you want to delete this contact? <bold>{name}</bold> will no longer receive notifications."
     },
     "verification": {
       "codeLabel": "Verification Code",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "Eliminar contacto",
-      "description": "¿Estás seguro de que deseas eliminar este contacto? <strong>{name}</strong> ya no recibirá notificaciones."
+      "description": "¿Estás seguro de que deseas eliminar este contacto? <bold>{name}</bold> ya no recibirá notificaciones."
     },
     "verification": {
       "codeLabel": "Código de verificación",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "Supprimer le contact",
-      "description": "Êtes-vous sûr de vouloir supprimer ce contact ? <strong>{name}</strong> ne recevra plus de notifications."
+      "description": "Êtes-vous sûr de vouloir supprimer ce contact ? <bold>{name}</bold> ne recevra plus de notifications."
     },
     "verification": {
       "codeLabel": "Code de vérification",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "連絡先を削除",
-      "description": "この連絡先を削除してもよろしいですか？<strong>{name}</strong>には通知が届かなくなります。"
+      "description": "この連絡先を削除してもよろしいですか？<bold>{name}</bold>には通知が届かなくなります。"
     },
     "verification": {
       "codeLabel": "確認コード",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "Slett kontakt",
-      "description": "Er du sikker på at du vil slette denne kontakten? <strong>{name}</strong> vil ikke lenger motta varsler."
+      "description": "Er du sikker på at du vil slette denne kontakten? <bold>{name}</bold> vil ikke lenger motta varsler."
     },
     "verification": {
       "codeLabel": "Verifiseringskode",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "Excluir contato",
-      "description": "Tem certeza de que deseja excluir este contato? <strong>{name}</strong> não receberá mais notificações."
+      "description": "Tem certeza de que deseja excluir este contato? <bold>{name}</bold> não receberá mais notificações."
     },
     "verification": {
       "codeLabel": "Código de verificação",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -613,7 +613,7 @@
     },
     "delete": {
       "title": "Radera kontakt",
-      "description": "Är du säker på att du vill radera denna kontakt? <strong>{name}</strong> kommer inte längre att få aviseringar."
+      "description": "Är du säker på att du vill radera denna kontakt? <bold>{name}</bold> kommer inte längre att få aviseringar."
     },
     "verification": {
       "codeLabel": "Verifieringskod",

--- a/frontend/src/components/delete-contact-modal.tsx
+++ b/frontend/src/components/delete-contact-modal.tsx
@@ -66,7 +66,7 @@ export function DeleteContactModal({
           <DialogDescription>
             {t.rich('delete.description', {
               name: contact?.name ?? '',
-              strong: (chunks) => <strong>{chunks}</strong>
+              bold: (chunks) => <strong>{chunks}</strong>
             })}
           </DialogDescription>
         </DialogHeader>


### PR DESCRIPTION
## Summary
- Fix awkward delete contact modal text that showed the contact name appended at the end
- Now says "**{name}** will no longer receive notifications" instead of "They will no longer receive notifications. **{name}**"
- Updated all 9 translation files

## Test plan
- [ ] Open a wallet with contacts
- [ ] Click delete on a contact
- [ ] Verify the modal shows the contact name in the sentence naturally