### PR TITLE
Add Gemini GitHub Action for PR reviews

### DIFF
--- a/.github/workflows/codex-pull-request-code-review.yml
+++ b/.github/workflows/codex-pull-request-code-review.yml
@@ -54,11 +54,12 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
+            const header = '## 🤖 Codex Code Review\n\n';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: process.env.CODEX_FINAL_MESSAGE,
+              body: header + process.env.CODEX_FINAL_MESSAGE,
             });
         env:
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -1,0 +1,35 @@
+name: Gemini Code Review
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  gemini-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Gemini Code Review
+        uses: google-github-actions/run-gemini-cli@v0.1.18
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          prompt: |
+            Start your response with "## 🤖 Gemini Code Review" as a header.
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Be constructive and helpful in your feedback.


### PR DESCRIPTION
## Summary
- Add Gemini CLI GitHub Action for automated PR reviews (alongside Claude and Codex)
- Add header prefixes to Codex and Gemini comments for clear identification since they post as "github-actions bot"

## Changes
- **New**: `.github/workflows/gemini-pull-request-code-review.yml` - Gemini PR review workflow
- **Modified**: `.github/workflows/codex-pull-request-code-review.yml` - Added "🤖 Codex Code Review" header

## Setup Required
Add `GEMINI_API_KEY` secret from [Google AI Studio](https://aistudio.google.com/apikey)

## Test plan
- [ ] Verify Claude reviews the PR (posts as "claude bot")
- [ ] Verify Codex reviews the PR (posts as "github-actions bot" with header)
- [ ] Verify Gemini reviews the PR (posts as "github-actions bot" with header)