### PR TITLE
fix(auth): Clear auth state on 401/403 API errors

### DIFF
--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import { api } from '@/lib/api'
+import { ApiError } from '@/lib/utils'
 import { setStoredLocale, clearStoredLocale } from '@/lib/locale'
 import { type Locale, locales } from '@/i18n/config'
 
@@ -96,8 +97,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       syncLocaleFromUser(userData)
     } catch (error) {
       console.error('Failed to fetch user:', error)
-      // Only clear auth on 401 Unauthorized - other errors might be temporary
-      if (error instanceof Error && error.message.includes('401')) {
+      // Clear auth on 401/403 authentication errors - token is invalid or expired
+      if (error instanceof ApiError && error.isAuthError()) {
         console.log('Token appears invalid, logging out')
         localStorage.removeItem('auth_token')
         setToken(null)


### PR DESCRIPTION
## Summary
- Fix invalid/expired JWT token handling in frontend auth context
- Replace brittle string matching (`error.message.includes('401')`) with proper `ApiError.isAuthError()` check
- The existing `ApiError` class already has the `isAuthError()` helper method that correctly identifies 401/403 errors

## Problem
The `fetchUser` function in `auth-context.tsx` used string matching to detect 401 errors:
```typescript
if (error instanceof Error && error.message.includes('401'))
```

This never matched because `ApiError` messages are user-friendly strings like "Please sign in to continue." rather than HTTP status codes. This caused:
- `isAuthenticated` to stay true with a null user
- All API calls to keep failing
- Poor user experience as the app didn't recover

## Solution
Use the existing `ApiError.isAuthError()` method which properly checks the error type:
```typescript
if (error instanceof ApiError && error.isAuthError())
```

## Test plan
- [x] Frontend tests pass (100 tests)
- [x] Frontend builds successfully
- [ ] Manual testing: Set an expired JWT in localStorage, refresh page, verify automatic logout

Closes #94