### PR TITLE
chore: Fix unterminated pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon[
-]
+Icon?
 
 # Thumbnails
 ._*


### PR DESCRIPTION
## Summary
- Fix invalid `.gitignore` pattern that broke ripgrep and other tools
- Replace `Icon[` + `]` (unterminated character class) with `Icon?`

## Problem
The `.gitignore` had:
```
Icon[
]
```
This is an invalid regex pattern (unclosed character class) that caused "unclosed character class" errors in ripgrep.

## Solution
Use `Icon?` which matches macOS Icon files (Icon followed by any single character, typically `\r`).

## Test plan
- [x] Verified `rg --files` works without errors

Closes #97