### PR TITLE
fix(security): Remove backend URL from proxy error responses

### DIFF
--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -95,12 +95,11 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
     console.error('API Proxy Error:', error);
     console.error('Backend URL:', url.toString());
     
-    // Return more detailed error information
+    // Return error without exposing backend URL (logged server-side above)
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return new Response(JSON.stringify({ 
+    return new Response(JSON.stringify({
       error: 'Backend request failed',
-      details: errorMessage,
-      backendUrl: url.toString()
+      details: errorMessage
     }), { 
       status: 502,
       headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
## Summary
- Removes `backendUrl` from API proxy error responses to prevent leaking internal infrastructure details
- Backend URL is still logged server-side for debugging purposes

## Problem
The Next.js API proxy was exposing the backend URL (including internal host/port) to clients in error responses. This leaks infrastructure details that could help attackers understand service topology.

## Solution
Remove the `backendUrl` field from the error response JSON while keeping the server-side logging intact.

## Test plan
- [x] Frontend tests pass
- [x] Frontend builds successfully
- [ ] Manual verification: Trigger a proxy error and confirm the response no longer contains `backendUrl`

Fixes #93