### PR TITLE
fix(ci): Programmatically add Gemini review header

### DIFF
--- a/.gemini/gemini-review.md
+++ b/.gemini/gemini-review.md
@@ -1,18 +1,13 @@
-You are reviewing a pull request. Use the GitHub MCP tools to read the PR details and submit a review.
-
-CRITICAL: Your review body MUST begin with this exact line (including the emoji):
-## 💎 Gemini Code Review
+You are reviewing a pull request. Use the GitHub MCP tools to read the PR details.
 
 ## Instructions
 
 1. Read the pull request using `pull_request_read` with the repository and PR number from environment variables
-2. Create a pending review using `create_pending_pull_request_review`
-3. Add comments on specific lines if needed using `add_comment_to_pending_review`
-4. Submit the review using `submit_pending_pull_request_review`
+2. Output your review as plain text (it will be posted separately)
 
 ## Review Content
 
-After the header, provide:
+Provide:
 - A brief summary of the changes
 - General feedback on code quality, organization, and best practices
 - Any potential bugs, security concerns, or performance issues

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Gemini PR Review
+        id: gemini
         uses: google-github-actions/run-gemini-cli@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -41,10 +42,7 @@ jobs:
                     "ghcr.io/github/github-mcp-server:v0.18.0"
                   ],
                   "includeTools": [
-                    "add_comment_to_pending_review",
-                    "create_pending_pull_request_review",
-                    "pull_request_read",
-                    "submit_pending_pull_request_review"
+                    "pull_request_read"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
@@ -53,3 +51,20 @@ jobs:
               }
             }
           prompt: '/gemini-review'
+
+      - name: Post Gemini review
+        if: steps.gemini.outputs.summary != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const header = '## 💎 Gemini Code Review\n\n';
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              body: header + process.env.GEMINI_SUMMARY,
+              event: 'COMMENT'
+            });
+        env:
+          GEMINI_SUMMARY: ${{ steps.gemini.outputs.summary }}


### PR DESCRIPTION
## Summary
- Captures Gemini's output using the action's `summary` output variable
- Adds a separate step using `actions/github-script` to prepend the `## 💎 Gemini Code Review` header
- Removes MCP tools for submitting reviews since we now post separately
- Matches the pattern used by the Codex workflow

## Problem
Gemini was ignoring the prompt instruction to include the branded header and instead used XML-style `<SUMMARY>` tags (see PR #102 review).

## Solution
Instead of relying on the LLM to follow formatting instructions, programmatically prepend the header in post-processing.

## Test plan
- [ ] Verify Gemini workflow runs successfully on this PR
- [ ] Verify review includes `## 💎 Gemini Code Review` header
- [ ] Verify review content is still useful and complete

Closes #104