### PR TITLE
fix(security): Remove Stripe webhook signature from logs

### DIFF
--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -378,10 +378,6 @@ pub async fn handle_stripe_webhook(
     headers: HeaderMap,
     body: String,
 ) -> Response {
-    let _start_time = std::time::Instant::now();
-    // Debug: Log all headers
-    tracing::info!("Webhook headers received: {:?}", headers);
-
     // Get Stripe signature from headers (case-insensitive lookup)
     let signature = match headers.get("stripe-signature") {
         Some(sig) => match sig.to_str() {


### PR DESCRIPTION
## Summary
- Remove debug logging that exposed the `stripe-signature` header in application logs
- This header contains cryptographic material (HMAC signature) that should not be visible in logs

## Changes
- Removed `tracing::info!("Webhook headers received: {:?}", headers);` from `handle_stripe_webhook`
- Removed associated debug comment and unused `_start_time` variable

## Test plan
- [x] `cargo fmt` - formatting passes
- [x] `cargo clippy` - no new warnings
- [x] `cargo test -- --test-threads=1` - all tests pass

Closes #83