### PR TITLE
fix(ci): Scope Codex review to PR changes only

### DIFF
--- a/.github/workflows/codex-pull-request-code-review.yml
+++ b/.github/workflows/codex-pull-request-code-review.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
 
       - name: Pre-fetch base and head refs
         run: |


### PR DESCRIPTION
## Summary
- Update Codex code review workflow to focus exclusively on changed files
- Prevents reporting pre-existing issues unrelated to the PR

## Problem
Codex was scanning the entire codebase and reporting issues in files not touched by the PR. For example, on PR #107 (a simple logging fix in `billing.rs`), Codex reported issues in `auth.rs`, `metadata/user.rs`, and `extractors/auth.rs`.

## Solution
- Add a step to capture the list of changed files using `git diff --name-only`
- Update the prompt to explicitly instruct Codex to:
  - Review ONLY the changes in the PR
  - Use `git diff` to see actual changes
  - NOT scan or report issues in unchanged parts of the codebase
  - NOT report pre-existing issues unrelated to the PR

## Test plan
- [x] Workflow syntax is valid (YAML)
- [ ] Next PR will verify Codex only reports issues in changed files