### PR TITLE
fix(security): Remove insecure JWT_SECRET fallback value

### DIFF
--- a/backend/.env.example.cloud
+++ b/backend/.env.example.cloud
@@ -25,7 +25,9 @@ CANARY_DATA_DIR=./database
 #############################################
 
 # JWT Secret for session management (REQUIRED)
-JWT_SECRET=your-secret-key-change-in-production
+# IMPORTANT: Generate a secure random secret for production!
+# Example: openssl rand -base64 32
+JWT_SECRET=CHANGE_ME_GENERATE_SECURE_SECRET
 
 #############################################
 # STRIPE BILLING

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -401,7 +401,7 @@ impl AuthService {
     }
 }
 
-pub fn authenticate_user(auth_header: Option<&str>) -> Result<AuthUser> {
+pub fn authenticate_user(auth_header: Option<&str>, jwt_secret: &str) -> Result<AuthUser> {
     // Cloud mode: validate JWT token
     let auth_header = auth_header.ok_or_else(|| anyhow!("Authorization header required"))?;
 
@@ -410,10 +410,8 @@ pub fn authenticate_user(auth_header: Option<&str>) -> Result<AuthUser> {
     }
 
     let token = &auth_header[7..];
-    let jwt_secret = std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
 
-    let auth_service = AuthService::new(jwt_secret, None);
+    let auth_service = AuthService::new(jwt_secret.to_string(), None);
     let claims = auth_service.validate_token(token)?;
 
     Ok(AuthUser {

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -111,6 +111,8 @@ pub struct AppConfig {
     pub data_dir: String,
     pub operating_mode: OperatingMode,
     pub frontend_url: Option<String>,
+    /// JWT secret for authentication (only used in cloud mode)
+    jwt_secret: Option<String>,
 }
 
 impl AppConfig {
@@ -178,6 +180,9 @@ impl AppConfig {
         // Load frontend URL (optional in self-hosted mode, validated in cloud mode)
         let frontend_url = std::env::var("FRONTEND_URL").ok();
 
+        // Load JWT secret (only used in cloud mode)
+        let jwt_secret = std::env::var("JWT_SECRET").ok();
+
         Ok(AppConfig {
             network,
             electrum_url,
@@ -185,6 +190,7 @@ impl AppConfig {
             data_dir,
             operating_mode,
             frontend_url,
+            jwt_secret,
         })
     }
 
@@ -207,6 +213,17 @@ impl AppConfig {
     /// Returns None in self-hosted mode or if not configured
     pub fn frontend_url(&self) -> Option<&str> {
         self.frontend_url.as_deref()
+    }
+
+    /// Get JWT secret for authentication (cloud mode only).
+    /// Returns error if called in self-hosted mode or if JWT_SECRET is not configured.
+    pub fn get_jwt_secret(&self) -> Result<&str, &'static str> {
+        if self.is_self_hosted_mode() {
+            return Err("JWT authentication not available in self-hosted mode");
+        }
+        self.jwt_secret
+            .as_deref()
+            .ok_or("JWT_SECRET required for cloud mode - check your .env file")
     }
 
     /// Check if ntfy provider should be enabled
@@ -379,6 +396,28 @@ impl AppConfig {
     pub fn metadata_db_path(&self) -> String {
         format!("database/{}/metadata.sqlite", self.network_name())
     }
+
+    /// Create an AppConfig for testing purposes.
+    /// This allows external tests to construct AppConfig with all required fields.
+    pub fn new_for_test(
+        network: NetworkConfig,
+        electrum_url: Option<String>,
+        bind_address: String,
+        data_dir: String,
+        operating_mode: OperatingMode,
+        frontend_url: Option<String>,
+        jwt_secret: Option<String>,
+    ) -> Self {
+        Self {
+            network,
+            electrum_url,
+            bind_address,
+            data_dir,
+            operating_mode,
+            frontend_url,
+            jwt_secret,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -434,6 +473,7 @@ mod tests {
             data_dir: "./database".to_string(),
             operating_mode: OperatingMode::Cloud, // Default for tests
             frontend_url: Some("http://localhost:3001".to_string()),
+            jwt_secret: Some("test-jwt-secret".to_string()),
         }
     }
 
@@ -445,6 +485,7 @@ mod tests {
             data_dir: data_dir.to_string(),
             operating_mode: OperatingMode::Cloud,
             frontend_url: Some("http://localhost:3001".to_string()),
+            jwt_secret: Some("test-jwt-secret".to_string()),
         }
     }
 
@@ -456,6 +497,7 @@ mod tests {
             data_dir: "./database".to_string(),
             operating_mode: OperatingMode::SelfHosted,
             frontend_url: None,
+            jwt_secret: None, // Not used in self-hosted mode
         }
     }
 
@@ -611,6 +653,7 @@ mod tests {
             data_dir: "./database".to_string(),
             operating_mode: OperatingMode::Cloud,
             frontend_url: Some("http://localhost:3001".to_string()),
+            jwt_secret: Some("test-jwt-secret".to_string()),
         };
         assert_eq!(config.electrum_url(), "ssl://custom.electrum.server:50002");
     }
@@ -645,5 +688,37 @@ mod tests {
         let self_hosted_config = test_config_self_hosted(NetworkConfig::Regtest);
         assert!(!self_hosted_config.is_cloud_mode());
         assert!(self_hosted_config.is_self_hosted_mode());
+    }
+
+    #[test]
+    fn test_get_jwt_secret_cloud_mode_with_secret() {
+        let config = test_config(NetworkConfig::Regtest);
+        assert_eq!(config.get_jwt_secret().unwrap(), "test-jwt-secret");
+    }
+
+    #[test]
+    fn test_get_jwt_secret_cloud_mode_without_secret() {
+        let config = AppConfig {
+            network: NetworkConfig::Regtest,
+            electrum_url: None,
+            bind_address: "127.0.0.1:3000".to_string(),
+            data_dir: "./database".to_string(),
+            operating_mode: OperatingMode::Cloud,
+            frontend_url: Some("http://localhost:3001".to_string()),
+            jwt_secret: None, // Missing JWT secret
+        };
+        assert_eq!(
+            config.get_jwt_secret().unwrap_err(),
+            "JWT_SECRET required for cloud mode - check your .env file"
+        );
+    }
+
+    #[test]
+    fn test_get_jwt_secret_self_hosted_mode() {
+        let config = test_config_self_hosted(NetworkConfig::Regtest);
+        assert_eq!(
+            config.get_jwt_secret().unwrap_err(),
+            "JWT authentication not available in self-hosted mode"
+        );
     }
 }

--- a/backend/src/extractors/auth.rs
+++ b/backend/src/extractors/auth.rs
@@ -50,7 +50,17 @@ where
             }))
         } else {
             // Cloud mode: authenticate using JWT
-            authenticate_user(auth_header)
+            let jwt_secret = config.get_jwt_secret().map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("Configuration error: {}", e),
+                    }),
+                )
+                    .into_response()
+            })?;
+
+            authenticate_user(auth_header, jwt_secret)
                 .map(AuthenticatedUser)
                 .map_err(|_| {
                     (

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -26,6 +26,7 @@ use crate::auth::{
 pub async fn register(
     State(app_services): State<AppServicesState>,
     State(stripe_billing): State<StripeBillingState>,
+    State(config): State<Arc<AppConfig>>,
     Json(request): Json<RegisterRequest>,
 ) -> Response {
     let start_time = std::time::Instant::now();
@@ -79,8 +80,18 @@ pub async fn register(
         }
     }
 
-    let jwt_secret = std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
+    let jwt_secret = match config.get_jwt_secret() {
+        Ok(secret) => secret.to_string(),
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
 
     // Email service not configured, will work in dev mode
     let email_service = EmailService::from_env().ok();
@@ -275,6 +286,7 @@ pub async fn register(
 /// User login endpoint
 pub async fn login(
     State(app_services): State<AppServicesState>,
+    State(config): State<Arc<AppConfig>>,
     Json(request): Json<LoginRequest>,
 ) -> Response {
     // Check if user exists - no mutex blocking!
@@ -304,8 +316,18 @@ pub async fn login(
         }
     };
 
-    let jwt_secret = std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
+    let jwt_secret = match config.get_jwt_secret() {
+        Ok(secret) => secret.to_string(),
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
 
     let email_service = match EmailService::from_env() {
         Ok(service) => {
@@ -532,8 +554,18 @@ pub async fn demo_login(
     }
 
     // Generate JWT token for demo user
-    let jwt_secret = std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
+    let jwt_secret = match config.get_jwt_secret() {
+        Ok(secret) => secret.to_string(),
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
     let auth_service = AuthService::new(jwt_secret, None);
 
     let token = match auth_service.generate_token(
@@ -640,6 +672,7 @@ pub async fn verify_email(
 /// Forgot password endpoint
 pub async fn forgot_password(
     State(app_services): State<AppServicesState>,
+    State(config): State<Arc<AppConfig>>,
     Json(request): Json<ForgotPasswordRequest>,
 ) -> Response {
     let start_time = std::time::Instant::now();
@@ -669,8 +702,18 @@ pub async fn forgot_password(
         }
     };
 
-    let jwt_secret = std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
+    let jwt_secret = match config.get_jwt_secret() {
+        Ok(secret) => secret.to_string(),
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
 
     let email_service = EmailService::from_env().ok();
 
@@ -804,6 +847,7 @@ pub async fn submit_contact_form(Json(payload): Json<ContactFormRequest>) -> Res
 /// Reset password endpoint
 pub async fn reset_password(
     State(app_services): State<AppServicesState>,
+    State(config): State<Arc<AppConfig>>,
     Path(token): Path<String>,
     Json(request): Json<ResetPasswordRequest>,
 ) -> Response {
@@ -847,8 +891,18 @@ pub async fn reset_password(
         }
     };
 
-    let jwt_secret = std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
+    let jwt_secret = match config.get_jwt_secret() {
+        Ok(secret) => secret.to_string(),
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
 
     let auth_service = AuthService::new(jwt_secret, None);
 

--- a/backend/src/handlers/contact_verification.rs
+++ b/backend/src/handlers/contact_verification.rs
@@ -25,7 +25,6 @@ pub async fn send_contact_verification(
     State(config): State<Arc<AppConfig>>,
     Json(request): Json<SendContactVerificationRequest>,
 ) -> Response {
-    let _ = config; // Used for state extraction pattern consistency
     let start_time = std::time::Instant::now();
 
     // Get user's preferred language for verification emails
@@ -184,8 +183,18 @@ pub async fn send_contact_verification(
         // Check if email matches current user's account email (skip verification) - no mutex blocking!
         if let Ok(Some(user_record)) = app_services.metadata_db.get_user_by_id(&user.user_id).await
         {
-            let jwt_secret = std::env::var("JWT_SECRET")
-                .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
+            let jwt_secret = match config.get_jwt_secret() {
+                Ok(secret) => secret.to_string(),
+                Err(e) => {
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        Json(ErrorResponse {
+                            error: e.to_string(),
+                        }),
+                    )
+                        .into_response();
+                }
+            };
             let auth_service = AuthService::new(jwt_secret.clone(), None);
 
             if auth_service.should_skip_email_verification(&email, &user_record.email) {
@@ -328,8 +337,18 @@ pub async fn send_contact_verification(
     }
 
     // Send verification code
-    let jwt_secret = std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
+    let jwt_secret = match config.get_jwt_secret() {
+        Ok(secret) => secret.to_string(),
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
 
     let result = if provider_type == "sms" {
         // SMS verification via Twilio
@@ -419,6 +438,7 @@ pub async fn verify_contact(
     AuthenticatedUser(user): AuthenticatedUser,
     Path(wallet_checksum): Path<String>,
     State(app_services): State<AppServicesState>,
+    State(config): State<Arc<AppConfig>>,
     Json(request): Json<VerifyContactRequest>,
 ) -> Response {
     let start_time = std::time::Instant::now();
@@ -545,8 +565,18 @@ pub async fn verify_contact(
         }
     };
 
-    let jwt_secret = std::env::var("JWT_SECRET")
-        .unwrap_or_else(|_| "your-secret-key-change-in-production".to_string());
+    let jwt_secret = match config.get_jwt_secret() {
+        Ok(secret) => secret.to_string(),
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
 
     // Verify the code based on provider type
     let is_valid = if provider_type == "email" {

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -7,14 +7,15 @@ async fn create_test_db() -> (MetadataDb, tempfile::TempDir) {
     let db_path = temp_dir.path().join("test.db");
 
     // Create test config
-    let test_config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_string_lossy().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let test_config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_string_lossy().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let db = MetadataDb::new(db_path.to_str().unwrap(), &test_config)
         .await

--- a/backend/system_tests/common/docker_environment.rs
+++ b/backend/system_tests/common/docker_environment.rs
@@ -108,14 +108,15 @@ impl IsolatedTestEnvironment {
         // Create test database
         let db_path = temp_dir.path().join("test.db");
 
-        let test_config = AppConfig {
-            network: NetworkConfig::Regtest,
-            electrum_url: None,
-            bind_address: "127.0.0.1:3000".to_string(),
-            data_dir: temp_path.clone(),
-            operating_mode: OperatingMode::SelfHosted, // Self-hosted mode for simpler testing without Stripe
-            frontend_url: None,
-        };
+        let test_config = AppConfig::new_for_test(
+            NetworkConfig::Regtest,
+            None,
+            "127.0.0.1:3000".to_string(),
+            temp_path.clone(),
+            OperatingMode::SelfHosted, // Self-hosted mode for simpler testing without Stripe
+            None,
+            None, // No JWT secret needed for self-hosted mode
+        );
 
         let metadata_db = MetadataDb::new(db_path.to_str().unwrap(), &test_config).await?;
 
@@ -269,14 +270,15 @@ impl IsolatedTestEnvironment {
         // Create test database
         let db_path = temp_dir.path().join("test.db");
 
-        let test_config = AppConfig {
-            network: NetworkConfig::Regtest,
-            electrum_url: None,
-            bind_address: "127.0.0.1:3000".to_string(),
-            data_dir: temp_path.clone(),
-            operating_mode: OperatingMode::SelfHosted, // Self-hosted mode for simpler testing without Stripe
-            frontend_url: None,
-        };
+        let test_config = AppConfig::new_for_test(
+            NetworkConfig::Regtest,
+            None,
+            "127.0.0.1:3000".to_string(),
+            temp_path.clone(),
+            OperatingMode::SelfHosted, // Self-hosted mode for simpler testing without Stripe
+            None,
+            None, // No JWT secret needed for self-hosted mode
+        );
 
         let metadata_db = MetadataDb::new(db_path.to_str().unwrap(), &test_config).await?;
 

--- a/backend/tests/balance_alerts_system_tests.rs
+++ b/backend/tests/balance_alerts_system_tests.rs
@@ -17,14 +17,15 @@ async fn create_test_db() -> (Arc<MetadataDb>, tempfile::TempDir) {
     let test_db_path = temp_dir.path().join("test_metadata.sqlite");
 
     // Create test config
-    let test_config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_str().unwrap().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let test_config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_str().unwrap().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let db = Arc::new(
         MetadataDb::new(test_db_path.to_str().unwrap(), &test_config)
@@ -625,14 +626,15 @@ async fn test_fiat_alert_fires_on_exchange_rate_change() {
     assert!(alert.is_active, "Alert should be active initially");
 
     // Create sync service and config
-    let test_config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_str().unwrap().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let test_config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_str().unwrap().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
     let sync_service = create_sync_service(&metadata_db, &test_config);
 
     // Check alerts - should NOT fire at 50k NOK
@@ -742,14 +744,15 @@ async fn test_balance_alert_threshold_crossing_detection() {
     let (_user_id, wallet_checksum) = create_test_user_and_wallet(&metadata_db).await;
 
     // Create test config
-    let test_config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: _temp_dir.path().to_str().unwrap().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let test_config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        _temp_dir.path().to_str().unwrap().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let sync_service = create_sync_service(&metadata_db, &test_config);
 

--- a/backend/tests/contact_duplicates_test.rs
+++ b/backend/tests/contact_duplicates_test.rs
@@ -11,14 +11,15 @@ async fn test_duplicate_email_prevention() {
     let db_path = temp_dir.path().join("test.db");
 
     // Create metadata database
-    let config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_string_lossy().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_string_lossy().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let metadata_db = Arc::new(
         MetadataDb::new(db_path.to_str().unwrap(), &config)
@@ -129,14 +130,15 @@ async fn test_duplicate_phone_prevention() {
     let db_path = temp_dir.path().join("test.db");
 
     // Create metadata database
-    let config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_string_lossy().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_string_lossy().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let metadata_db = Arc::new(
         MetadataDb::new(db_path.to_str().unwrap(), &config)
@@ -235,14 +237,15 @@ async fn test_ntfy_topics_excluded_from_duplicate_check() {
     let db_path = temp_dir.path().join("test.db");
 
     // Create metadata database
-    let config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_string_lossy().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_string_lossy().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let metadata_db = Arc::new(
         MetadataDb::new(db_path.to_str().unwrap(), &config)
@@ -298,14 +301,15 @@ async fn test_mixed_provider_types_allowed() {
     let db_path = temp_dir.path().join("test.db");
 
     // Create metadata database
-    let config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_string_lossy().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_string_lossy().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let metadata_db = Arc::new(
         MetadataDb::new(db_path.to_str().unwrap(), &config)
@@ -361,14 +365,15 @@ async fn test_verification_endpoint_rejects_duplicates() {
     let db_path = temp_dir.path().join("test.db");
 
     // Create metadata database
-    let config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_string_lossy().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_string_lossy().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let metadata_db = Arc::new(
         MetadataDb::new(db_path.to_str().unwrap(), &config)

--- a/backend/tests/debug_wallet_drain.rs
+++ b/backend/tests/debug_wallet_drain.rs
@@ -20,14 +20,15 @@ async fn debug_wallet_drain_detection() {
 
     // Create test database
     let db_path = temp_dir.path().join("test.db");
-    let test_config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_path.clone(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let test_config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_path.clone(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let metadata_db = MetadataDb::new(db_path.to_str().unwrap(), &test_config)
         .await

--- a/backend/tests/stripe_integration_tests.rs
+++ b/backend/tests/stripe_integration_tests.rs
@@ -21,14 +21,15 @@ async fn create_test_app() -> axum::Router {
     let test_db_path = format!("{}/test_metadata.sqlite", temp_path);
 
     // Create test config
-    let test_config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_path.to_string(),
-        operating_mode: OperatingMode::Cloud, // Stripe tests need cloud mode
-        frontend_url: Some("http://localhost:3001".to_string()),
-    };
+    let test_config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_path.to_string(),
+        OperatingMode::Cloud, // Stripe tests need cloud mode
+        Some("http://localhost:3001".to_string()),
+        Some("test-jwt-secret".to_string()),
+    );
 
     let (event_tx, _event_rx) =
         broadcast::channel::<canary::metadata::TransactionNotification>(100);

--- a/backend/tests/wallet_handlers_tests.rs
+++ b/backend/tests/wallet_handlers_tests.rs
@@ -39,14 +39,15 @@ async fn create_test_app() -> (axum::Router, TempDir) {
     let test_db_path = format!("{}/test_metadata.sqlite", temp_path);
 
     // Create test config with self-hosted mode (no auth required)
-    let test_config = AppConfig {
-        network: NetworkConfig::Regtest,
-        electrum_url: Some("tcp://127.0.0.1:50001".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_path.to_string(),
-        operating_mode: OperatingMode::SelfHosted, // Self-hosted = hardcoded admin user
-        frontend_url: None,
-    };
+    let test_config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_path.to_string(),
+        OperatingMode::SelfHosted, // Self-hosted = hardcoded admin user
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let (event_tx, _event_rx) =
         broadcast::channel::<canary::metadata::TransactionNotification>(100);

--- a/backend/tests/wallet_key_format_tests.rs
+++ b/backend/tests/wallet_key_format_tests.rs
@@ -177,14 +177,15 @@ async fn test_duplicate_wallet_detection_zpub_xpub() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let config = AppConfig {
-        network: NetworkConfig::Mainnet,
-        electrum_url: Some("ssl://electrum.blockstream.info:50002".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_string_lossy().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Mainnet,
+        Some("ssl://electrum.blockstream.info:50002".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_string_lossy().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let metadata_db = Arc::new(
         MetadataDb::new(db_path.to_str().unwrap(), &config)
@@ -264,14 +265,15 @@ async fn test_duplicate_wallet_detection_vpub_tpub() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let config = AppConfig {
-        network: NetworkConfig::Testnet,
-        electrum_url: Some("ssl://electrum.blockstream.info:60002".to_string()),
-        bind_address: "127.0.0.1:3000".to_string(),
-        data_dir: temp_dir.path().to_string_lossy().to_string(),
-        operating_mode: OperatingMode::SelfHosted,
-        frontend_url: None,
-    };
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Testnet,
+        Some("ssl://electrum.blockstream.info:60002".to_string()),
+        "127.0.0.1:3000".to_string(),
+        temp_dir.path().to_string_lossy().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None, // No JWT secret needed for self-hosted mode
+    );
 
     let metadata_db = Arc::new(
         MetadataDb::new(db_path.to_str().unwrap(), &config)


### PR DESCRIPTION
## Summary
- Centralizes JWT_SECRET handling in AppConfig to prevent silent fallback to insecure default
- Adds `get_jwt_secret()` helper that fails fast if JWT_SECRET is missing in cloud mode
- Updates all auth and contact verification handlers to use centralized config
- Self-hosted mode continues to work without JWT_SECRET (uses hardcoded admin)

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test -- --test-threads=1` passes all tests
- [x] `cargo clippy` passes (pre-existing warnings only)
- [x] `cargo fmt` applied
- [x] Frontend build succeeds
- [ ] Manual: Start cloud mode without JWT_SECRET - should fail at startup
- [ ] Manual: Start self-hosted mode - should work without JWT_SECRET

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)