### PR TITLE
fix(security): Hash password reset tokens before storage

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -719,11 +719,12 @@ pub async fn forgot_password(
 
     let auth_service = AuthService::new(jwt_secret, email_service);
     let token = auth_service.generate_verification_token();
+    let token_hash = AuthService::hash_token(&token);
 
-    // Store password reset token - no mutex blocking!
+    // Store password reset token (hashed for security) - no mutex blocking!
     if let Err(e) = app_services
         .metadata_db
-        .create_password_reset_token(&user_record.id, &token)
+        .create_password_reset_token(&user_record.id, &token_hash)
         .await
     {
         return (
@@ -864,10 +865,13 @@ pub async fn reset_password(
             .into_response();
     }
 
+    // Hash the incoming token for verification (tokens are stored hashed)
+    let token_hash = AuthService::hash_token(&token);
+
     // Verify token and get user ID - no mutex blocking!
     let user_id = match app_services
         .metadata_db
-        .verify_password_reset_token(&token)
+        .verify_password_reset_token(&token_hash)
         .await
     {
         Ok(Some(id)) => id,
@@ -923,7 +927,7 @@ pub async fn reset_password(
     // Update password and clear reset tokens - no mutex blocking!
     if let Err(e) = app_services
         .metadata_db
-        .update_user_password(user_id, &password_hash)
+        .update_user_password(&user_id, &password_hash)
         .await
     {
         return (

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -692,14 +692,14 @@ impl MetadataDb {
         }).await?
     }
 
-    pub async fn verify_password_reset_token(&self, token: &str) -> Result<Option<i64>> {
+    pub async fn verify_password_reset_token(&self, token: &str) -> Result<Option<String>> {
         let pool = self.pool.clone();
         let token = token.to_string();
         let current_time = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
 
-        spawn_blocking(move || -> Result<Option<i64>> {
+        spawn_blocking(move || -> Result<Option<String>> {
             let conn = pool.get()?;
-            let user_id: Option<i64> = conn
+            let user_id: Option<String> = conn
                 .prepare("SELECT user_id FROM password_reset_tokens WHERE token = ?1 AND expires_at > ?2")?
                 .query_row(params![&token, &current_time], |row| row.get(0))
                 .ok();
@@ -707,8 +707,9 @@ impl MetadataDb {
         }).await?
     }
 
-    pub async fn update_user_password(&self, user_id: i64, password_hash: &str) -> Result<()> {
+    pub async fn update_user_password(&self, user_id: &str, password_hash: &str) -> Result<()> {
         let pool = self.pool.clone();
+        let user_id = user_id.to_string();
         let password_hash = password_hash.to_string();
 
         spawn_blocking(move || -> Result<()> {
@@ -718,13 +719,13 @@ impl MetadataDb {
             // Update password
             tx.execute(
                 "UPDATE users SET password_hash = ?1 WHERE id = ?2",
-                params![&password_hash, user_id],
+                params![&password_hash, &user_id],
             )?;
 
             // Delete all password reset tokens for this user
             tx.execute(
                 "DELETE FROM password_reset_tokens WHERE user_id = ?1",
-                params![user_id],
+                params![&user_id],
             )?;
 
             tx.commit()?;


### PR DESCRIPTION
## Summary

- Hash password reset tokens using SHA256 before storing in database
- Fix type mismatch where `user_id` was returned as `i64` instead of `String` (UUID)
- Reuse existing `AuthService::hash_token()` function for consistency with JWT session tokens

## Security Impact

Previously, password reset tokens were stored in plaintext. If the database were compromised, attackers could immediately use these tokens to reset any user's password. Now only the SHA256 hash is stored, preventing direct token reuse from database leaks.

## Test plan

- [x] All existing tests pass (`cargo test -- --test-threads=1`)
- [x] Manual test: Request password reset, verify token in database is 64-char SHA256 hash (not 36-char UUID)
- [x] Manual test: Password reset email delivered successfully
- [x] Verify plaintext token is still sent in email (user can click link)

## Files changed

- `backend/src/handlers/auth.rs` - Hash tokens in forgot_password and reset_password handlers
- `backend/src/metadata/user.rs` - Fix return type from `i64` to `String` for user_id

Closes #88

🤖 Generated with [Claude Code](https://claude.ai/code)