### PR TITLE
fix(security): Hash email verification tokens before storage

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -233,11 +233,12 @@ pub async fn register(
     // Send verification email for non-dev accounts
     if !is_dev_email {
         let token = auth_service.generate_verification_token();
+        let token_hash = AuthService::hash_token(&token);
 
-        // Store verification token - no mutex blocking!
+        // Store verification token (hashed for security) - no mutex blocking!
         if let Err(e) = app_services
             .metadata_db
-            .create_email_verification_token(&user_id, &token)
+            .create_email_verification_token(&user_id, &token_hash)
             .await
         {
             return (
@@ -642,8 +643,15 @@ pub async fn verify_email(
 ) -> Response {
     let start_time = std::time::Instant::now();
 
+    // Hash the incoming token for verification (tokens are stored hashed)
+    let token_hash = AuthService::hash_token(&token);
+
     // Direct metadata access - no mutex blocking!
-    let result = match app_services.metadata_db.verify_email_token(&token).await {
+    let result = match app_services
+        .metadata_db
+        .verify_email_token(&token_hash)
+        .await
+    {
         Ok(Some(_user_id)) => Json(serde_json::json!({
             "message": "Email verified successfully. You can now log in."
         }))

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -603,6 +603,8 @@ impl MetadataDb {
     // EMAIL VERIFICATION TOKEN MANAGEMENT
     // ============================
 
+    /// Creates an email verification token. The token should be pre-hashed by the caller
+    /// using AuthService::hash_token() for security.
     pub async fn create_email_verification_token(&self, user_id: &str, token: &str) -> Result<()> {
         let pool = self.pool.clone();
         let token = token.to_string();
@@ -621,6 +623,8 @@ impl MetadataDb {
         }).await?
     }
 
+    /// Verifies an email verification token. The token should be pre-hashed by the caller
+    /// using AuthService::hash_token() for security.
     pub async fn verify_email_token(&self, token: &str) -> Result<Option<String>> {
         let pool = self.pool.clone();
         let token = token.to_string();


### PR DESCRIPTION
## Summary
- Apply SHA256 hashing to email verification tokens before storing in the database
- Hash incoming tokens before verification/comparison
- Add documentation comments clarifying security requirements

This follows the same pattern used for password reset tokens (fixed in #111).

Closes #110

## Test plan
- [x] Backend builds successfully
- [x] All backend tests pass (`cargo test -- --test-threads=1`)
- [x] Frontend builds successfully
- [ ] Manual verification: register new user and verify email works

🤖 Generated with [Claude Code](https://claude.com/claude-code)