### PR TITLE
fix(a11y): Add aria-labels to mobile icon-only header buttons

### DIFF
--- a/frontend/src/components/app-header.tsx
+++ b/frontend/src/components/app-header.tsx
@@ -54,9 +54,10 @@ export function AppHeader({ customLogo }: AppHeaderProps) {
             <Button
               size="sm"
               className="bg-accent hover:bg-accent/90 text-accent-foreground gap-1.5 sm:gap-2"
+              aria-label={tNav('addWallet')}
             >
               <Plus size={16} />
-              <span className="hidden sm:inline">{tNav('addWallet')}</span>
+              <span className="hidden sm:inline" aria-hidden="true">{tNav('addWallet')}</span>
             </Button>
           </Link>
         )}
@@ -68,9 +69,10 @@ export function AppHeader({ customLogo }: AppHeaderProps) {
               variant="outline"
               size="sm"
               className="gap-1.5 sm:gap-2"
+              aria-label={tNav('settings')}
             >
               <Settings size={16} />
-              <span className="hidden sm:inline">{tNav('settings')}</span>
+              <span className="hidden sm:inline" aria-hidden="true">{tNav('settings')}</span>
             </Button>
           </Link>
         )}


### PR DESCRIPTION
## Summary
- Add `aria-label` attributes to the Add Wallet and Settings buttons in the header
- Mark visible text spans as `aria-hidden` to prevent duplicate screen reader announcements

## Context
Issue #7 requested several mobile navigation improvements. Upon investigation, most items were already implemented:
- ✅ Breadcrumb navigation exists (`wizard-breadcrumb.tsx`, `wallet-detail-header.tsx`)
- ✅ Mobile-responsive icon-only buttons work correctly
- ✅ Focus management has proper `focus-visible` styles

The remaining gap was **accessibility for screen readers**: when buttons show only icons on mobile (text hidden with `hidden sm:inline`), screen readers couldn't announce what the buttons do.

## Test Plan
- [x] Frontend build passes
- [x] All 100 frontend tests pass
- [ ] Verify with VoiceOver/NVDA that buttons are properly announced

Closes #7