### PR TITLE
fix(ci): Update claude-code-action from @beta to @v1

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Update `anthropics/claude-code-action` from `@beta` to `@v1` in both workflow files

## Problem
The `@beta` branch installs Claude Code CLI v1.0.88 which fails with:
```
It looks like your version of Claude Code (1.0.88) needs an update.
A newer version (2.0.0 or higher) is required to continue.
```

## Solution
Switch to `@v1` which uses the latest stable release (v1.0.29) with proper CLI version support.

## Files Changed
- `.github/workflows/claude-mention.yml`
- `.github/workflows/claude-pull-request-code-review.yml`

## Test Plan
- [ ] Verify Claude Code Review workflow passes on this PR