### PR TITLE
fix(cors): Support credentials in self-hosted mode CORS config

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -266,8 +266,24 @@ fn build_cors_layer(config: &AppConfig) -> CorsLayer {
             cors.allow_origin("https://invalid.localhost".parse::<HeaderValue>().unwrap())
         }
     } else {
-        // Self-hosted mode: Use permissive CORS (mirrors origin, allows credentials)
-        CorsLayer::permissive()
+        // Self-hosted mode: Mirror origin and allow credentials
+        // Note: CorsLayer::permissive() uses "*" which doesn't work with credentials: 'include'
+        // Also cannot use Any for headers when credentials are enabled
+        CorsLayer::new()
+            .allow_origin(tower_http::cors::AllowOrigin::mirror_request())
+            .allow_methods([
+                Method::GET,
+                Method::POST,
+                Method::PUT,
+                Method::DELETE,
+                Method::OPTIONS,
+            ])
+            .allow_headers([
+                HeaderName::from_static("content-type"),
+                HeaderName::from_static("authorization"),
+                HeaderName::from_static("accept"),
+            ])
+            .allow_credentials(true)
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix CORS configuration in self-hosted mode to work with `credentials: 'include'`
- `CorsLayer::permissive()` returns `Access-Control-Allow-Origin: *` which browsers reject when credentials are included
- Replace with explicit CORS config that mirrors the request origin

## Background
PR #114 added HttpOnly cookie authentication with `credentials: 'include'` on all frontend fetch requests. This broke self-hosted mode when running frontend (`:3001`) and backend (`:3000`) on different ports because:

1. `CorsLayer::permissive()` returns `Access-Control-Allow-Origin: *`
2. Browsers reject `*` when `credentials: 'include'` is used
3. Cloud mode was unaffected (uses explicit `FRONTEND_URL` origin)

## Test plan
- [x] Backend compiles
- [x] Backend tests pass
- [x] Frontend builds
- [ ] Manual test: Run self-hosted mode with frontend on `:3001` and backend on `:3000`
- [ ] Verify API requests succeed without CORS errors

🤖 Generated with [Claude Code](https://claude.ai/code)