### PR TITLE
fix(ci): Fix Claude and Gemini PR review workflows

### DIFF
--- a/.gemini/gemini-review.md
+++ b/.gemini/gemini-review.md
@@ -1,21 +1,53 @@
-You are reviewing a pull request. Use the GitHub MCP tools to read the PR details.
+## Role
 
-## Instructions
+You are a code review agent. Your task is to review a GitHub Pull Request and post your feedback directly to GitHub using the provided MCP tools.
 
-1. Read the pull request using `pull_request_read` with the repository and PR number from environment variables
-2. Output your review as plain text (it will be posted separately)
+## Critical Constraints
 
-## Review Content
+1. **Tool Exclusivity:** All interactions with GitHub MUST be performed using the provided MCP tools.
+2. **No Approvals:** When submitting the review, you MUST use event type `COMMENT`. Never use `APPROVE` or `REQUEST_CHANGES`.
+3. **Scope Limitation:** Only comment on lines that are part of the changes in the diff (lines with `+` or `-`).
+4. **Fact-Based Review:** Only add comments for verifiable issues, bugs, or concrete improvements. Do not add comments that simply explain what the code does.
 
-Provide:
-- A brief summary of the changes
-- General feedback on code quality, organization, and best practices
-- Any potential bugs, security concerns, or performance issues
-- Suggestions for improvement (if any)
+## Input Data
 
-## Environment Variables
+- **Repository**: Use environment variable `REPOSITORY`
+- **Pull Request Number**: Use environment variable `PULL_REQUEST_NUMBER`
 
-- `REPOSITORY`: The repository in `owner/repo` format
-- `PULL_REQUEST_NUMBER`: The PR number to review
+## Execution Workflow
 
-Be constructive and helpful in your feedback.
+### Step 1: Gather Information
+
+1. Use `pull_request_read` with method `get` to retrieve PR title, body, and metadata
+2. Use `pull_request_read` with method `get_files` to get the list of changed files
+3. Use `pull_request_read` with method `get_diff` to get the actual code changes
+
+### Step 2: Analyze the Code
+
+Review the changes for:
+- **Correctness:** Logic errors, unhandled edge cases, incorrect API usage
+- **Security:** Vulnerabilities, injection attacks, secrets exposure
+- **Performance:** Bottlenecks, unnecessary computations, inefficient patterns
+- **Maintainability:** Readability, adherence to project conventions
+
+### Step 3: Post the Review
+
+1. Use `create_pending_pull_request_review` to create a pending review
+2. Use `add_comment_to_pending_review` for each specific issue found (with line numbers from the diff)
+3. Use `submit_pending_pull_request_review` to submit the review with:
+   - A summary of your findings
+   - Event type MUST be `COMMENT` (never APPROVE or REQUEST_CHANGES)
+
+## Review Format
+
+For inline comments, include:
+- What the issue is
+- Why it matters
+- A suggested fix (if applicable)
+
+For the summary, include:
+- Brief overview of the changes
+- Key findings (if any)
+- General feedback on code quality
+
+Be constructive and helpful. Focus on substantive issues rather than style nitpicks.

--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     
     steps:
@@ -40,8 +40,8 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Prompt for automated review (no @claude mention needed)
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Gemini PR Review
-        id: gemini
         uses: google-github-actions/run-gemini-cli@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -33,6 +32,9 @@ jobs:
           workflow_name: 'gemini-review'
           settings: |
             {
+              "model": {
+                "maxSessionTurns": 25
+              },
               "mcpServers": {
                 "github": {
                   "command": "docker",
@@ -42,7 +44,10 @@ jobs:
                     "ghcr.io/github/github-mcp-server:v0.18.0"
                   ],
                   "includeTools": [
-                    "pull_request_read"
+                    "add_comment_to_pending_review",
+                    "create_pending_pull_request_review",
+                    "pull_request_read",
+                    "submit_pending_pull_request_review"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
@@ -51,20 +56,3 @@ jobs:
               }
             }
           prompt: '/gemini-review'
-
-      - name: Post Gemini review
-        if: steps.gemini.outputs.summary != ''
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const header = '## 💎 Gemini Code Review\n\n';
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              body: header + process.env.GEMINI_SUMMARY,
-              event: 'COMMENT'
-            });
-        env:
-          GEMINI_SUMMARY: ${{ steps.gemini.outputs.summary }}


### PR DESCRIPTION
## Summary

Fixes issues with automated PR review workflows that were causing reviews to not be posted.

### Claude workflow fixes:
- **Parameter rename**: Changed `direct_prompt` to `prompt` (renamed in `@v1` release)
- **Permissions**: Changed `pull-requests` and `issues` from `read` to `write`

### Gemini workflow fixes:
- **MCP tools**: Added write tools (`add_comment_to_pending_review`, `create_pending_pull_request_review`, `submit_pending_pull_request_review`) so Gemini can post reviews directly
- **Removed separate posting step**: Gemini now posts via MCP tools instead of a separate GitHub script step
- **Added `maxSessionTurns: 25`** for handling complex reviews

### Gemini prompt rewrite:
- Explicit tool usage instructions for the 3-step review process
- Added constraint to only use `COMMENT` event (never `APPROVE` or `REQUEST_CHANGES`)

## Root causes identified

1. **Claude**: The `direct_prompt` parameter was renamed to `prompt` in v1, so Claude saw "NO PROMPT" and skipped the review
2. **Gemini**: Only had `pull_request_read` tool, missing write tools needed to post reviews

## Test plan

- [ ] Open a test PR and verify Claude posts a review
- [ ] Open a test PR and verify Gemini posts a review with inline comments