### PR TITLE
fix: Restrict admin notifications to cloud mode only

### DIFF
--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -30,15 +30,6 @@ CANARY_DATA_DIR=./database
 # NTFY_SERVER_URL=https://ntfy.example.com
 
 #############################################
-# ADMIN NOTIFICATIONS
-#############################################
-
-# ntfy topic for admin notifications (OPTIONAL)
-# Get notified when new users register and wallets are created
-# Subscribe at: {NTFY_SERVER_URL}/your-admin-topic
-ADMIN_NOTIFICATION_TOPIC=canary-admin-alerts
-
-#############################################
 # SELF-HOSTED MODE FEATURES
 #############################################
 

--- a/backend/src/admin_notifications.rs
+++ b/backend/src/admin_notifications.rs
@@ -8,7 +8,17 @@ pub struct AdminNotifications {
 
 impl AdminNotifications {
     pub fn new() -> Self {
-        let topic = std::env::var("ADMIN_NOTIFICATION_TOPIC").ok();
+        // Only enable admin notifications in cloud mode
+        let is_cloud_mode = std::env::var("CANARY_MODE")
+            .map(|m| m.to_lowercase() == "cloud")
+            .unwrap_or(false);
+
+        let topic = if is_cloud_mode {
+            std::env::var("ADMIN_NOTIFICATION_TOPIC").ok()
+        } else {
+            None
+        };
+
         let server_url = std::env::var("NTFY_SERVER_URL")
             .unwrap_or_else(|_| "https://ntfy.sh".to_string())
             .trim_end_matches('/')


### PR DESCRIPTION
## Summary
- Admin notifications now only send in cloud mode (CANARY_MODE=cloud)
- Removed ADMIN_NOTIFICATION_TOPIC from .env.example.self-hosted since it's not applicable

## Test plan
- [ ] Start backend in self-hosted mode with ADMIN_NOTIFICATION_TOPIC set
- [ ] Create a wallet
- [ ] Verify no admin notification is sent (check logs for "✅ Admin notification sent")
- [ ] Start backend in cloud mode with ADMIN_NOTIFICATION_TOPIC set
- [ ] Create a wallet
- [ ] Verify admin notification is sent

Closes #127