### PR TITLE
fix(backend): Address clippy warnings (result_large_err, too_many_arguments, type_complexity, ptr_arg)

### DIFF
--- a/backend/src/extractors/auth.rs
+++ b/backend/src/extractors/auth.rs
@@ -93,6 +93,7 @@ where
 ///     // Continue with the operation
 /// }
 /// ```
+#[allow(clippy::result_large_err)]
 pub fn require_non_demo(user: &AuthUser) -> Result<(), Response> {
     if user.is_demo {
         Err((

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -2,6 +2,7 @@
 
 use crate::api::{AppServicesState, ConfigState, StripeBillingState};
 use crate::extractors::AuthenticatedUser;
+use crate::metadata::SubscriptionUpdateParams;
 use crate::models::{
     BillingStatusResponse, BillingTierLimits, CreateCheckoutSessionRequest,
     CreateCustomerPortalRequest, ErrorResponse,
@@ -556,17 +557,17 @@ pub async fn handle_stripe_webhook(
                     }
                 } else {
                     // Regular subscription update (tier + status) - no mutex blocking!
+                    let sub_params = SubscriptionUpdateParams {
+                        subscription_tier: &update.subscription_tier,
+                        subscription_status: &update.subscription_status,
+                        stripe_subscription_id: update.stripe_subscription_id.as_deref(),
+                        subscription_started_at: update.subscription_started_at.as_deref(),
+                        subscription_ends_at: update.subscription_ends_at.as_deref(),
+                        trial_ends_at: update.trial_ends_at.as_deref(),
+                    };
                     if let Err(e) = app_services
                         .metadata_db
-                        .update_user_subscription(
-                            &actual_user_id,
-                            &update.subscription_tier,
-                            &update.subscription_status,
-                            update.stripe_subscription_id.as_deref(),
-                            update.subscription_started_at.as_deref(),
-                            update.subscription_ends_at.as_deref(),
-                            update.trial_ends_at.as_deref(),
-                        )
+                        .update_user_subscription(&actual_user_id, &sub_params)
                         .await
                     {
                         tracing::error!(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -34,7 +34,7 @@ mod xpub_converter;
 
 use config::AppConfig;
 use email_provider::EmailProvider;
-use metadata::TransactionNotification;
+use metadata::{NotificationLogParams, TransactionNotification};
 use notifications::NotificationManager;
 use ntfy_provider::{NtfyAuth, NtfyProvider};
 use std::sync::Arc;
@@ -864,6 +864,14 @@ async fn main() -> anyhow::Result<()> {
                                         let status = if result.success { "sent" } else { "failed" };
 
                                         // Handle logging based on notification type
+                                        let log_params = NotificationLogParams {
+                                            notification_method_id: method_id,
+                                            provider_name,
+                                            provider_message_id: result.provider_id.as_deref(),
+                                            status,
+                                            error_message: result.error_message.as_deref(),
+                                            message_content: &message,
+                                        };
                                         let log_result = match &notification {
                                             TransactionNotification::Pending(tx)
                                             | TransactionNotification::Confirmed(tx) => {
@@ -873,12 +881,7 @@ async fn main() -> anyhow::Result<()> {
                                                     .insert_notification_log_for_transaction(
                                                         &tx.txid,
                                                         &tx.wallet_checksum,
-                                                        method_id,
-                                                        provider_name,
-                                                        result.provider_id.as_deref(),
-                                                        status,
-                                                        result.error_message.as_deref(),
-                                                        &message,
+                                                        &log_params,
                                                         notification_type,
                                                     )
                                                     .await
@@ -890,12 +893,7 @@ async fn main() -> anyhow::Result<()> {
                                                     .insert_notification_log_for_balance_alert(
                                                         &alert.balance_alert_id,
                                                         &alert.wallet_checksum,
-                                                        method_id,
-                                                        provider_name,
-                                                        result.provider_id.as_deref(),
-                                                        status,
-                                                        result.error_message.as_deref(),
-                                                        &message,
+                                                        &log_params,
                                                     )
                                                     .await
                                             }

--- a/backend/src/metadata/alert.rs
+++ b/backend/src/metadata/alert.rs
@@ -15,22 +15,17 @@ impl MetadataDb {
         &self,
         balance_alert_id: &str,
         wallet_checksum: &str,
-        notification_method_id: &str,
-        provider_name: &str,
-        provider_message_id: Option<&str>,
-        status: &str,
-        error_message: Option<&str>,
-        message_content: &str,
+        params: &NotificationLogParams<'_>,
     ) -> Result<String> {
         let pool = self.pool.clone();
         let balance_alert_id = balance_alert_id.to_string();
         let wallet_checksum = wallet_checksum.to_string();
-        let notification_method_id = notification_method_id.to_string();
-        let provider_name = provider_name.to_string();
-        let provider_message_id = provider_message_id.map(|s| s.to_string());
-        let status = status.to_string();
-        let error_message = error_message.map(|s| s.to_string());
-        let message_content = message_content.to_string();
+        let notification_method_id = params.notification_method_id.to_string();
+        let provider_name = params.provider_name.to_string();
+        let provider_message_id = params.provider_message_id.map(|s| s.to_string());
+        let status = params.status.to_string();
+        let error_message = params.error_message.map(|s| s.to_string());
+        let message_content = params.message_content.to_string();
 
         spawn_blocking(move || -> Result<String> {
             let conn = pool.get()?;
@@ -355,18 +350,19 @@ impl MetadataDb {
         &self,
         balance_alert_id: &str,
         wallet_checksum: &str,
-        threshold_sats: i64,
-        current_balance_sats: i64,
-        alert_type: BalanceAlertType,
-        threshold_currency: Option<String>,
-        threshold_fiat_amount: Option<f64>,
-        exchange_rate_snapshot: Option<f64>,
+        params: &BalanceAlertTriggerParams,
     ) -> Result<BalanceAlertNotification> {
         let pool = self.pool.clone();
         let notification_id = Uuid::new_v4().to_string();
         let balance_alert_id = balance_alert_id.to_string();
         let wallet_checksum = wallet_checksum.to_string();
+        let alert_type = params.alert_type;
         let alert_type_str = alert_type.as_str().to_string();
+        let threshold_sats = params.threshold_sats;
+        let current_balance_sats = params.current_balance_sats;
+        let threshold_currency = params.threshold_currency.clone();
+        let threshold_fiat_amount = params.threshold_fiat_amount;
+        let exchange_rate_snapshot = params.exchange_rate_snapshot;
         let notification_sent_at = chrono::Utc::now().timestamp() as u64;
 
         spawn_blocking(move || -> Result<BalanceAlertNotification> {

--- a/backend/src/metadata/transaction.rs
+++ b/backend/src/metadata/transaction.rs
@@ -187,23 +187,18 @@ impl MetadataDb {
         &self,
         transaction_txid: &str,
         transaction_wallet_checksum: &str,
-        notification_method_id: &str,
-        provider_name: &str,
-        provider_message_id: Option<&str>,
-        status: &str,
-        error_message: Option<&str>,
-        message_content: &str,
+        params: &NotificationLogParams<'_>,
         notification_type: &str,
     ) -> Result<String> {
         let pool = self.pool.clone();
         let transaction_txid = transaction_txid.to_string();
         let transaction_wallet_checksum = transaction_wallet_checksum.to_string();
-        let notification_method_id = notification_method_id.to_string();
-        let provider_name = provider_name.to_string();
-        let provider_message_id = provider_message_id.map(|s| s.to_string());
-        let status = status.to_string();
-        let error_message = error_message.map(|s| s.to_string());
-        let message_content = message_content.to_string();
+        let notification_method_id = params.notification_method_id.to_string();
+        let provider_name = params.provider_name.to_string();
+        let provider_message_id = params.provider_message_id.map(|s| s.to_string());
+        let status = params.status.to_string();
+        let error_message = params.error_message.map(|s| s.to_string());
+        let message_content = params.message_content.to_string();
         let notification_type = notification_type.to_string();
 
         spawn_blocking(move || -> Result<String> {

--- a/backend/src/metadata/types.rs
+++ b/backend/src/metadata/types.rs
@@ -107,11 +107,7 @@ impl UserRecord {}
 /// Convert browser locale to language code for emails and notifications
 /// Returns language code for supported locales, "en" for all others
 pub fn locale_to_language(locale: &str) -> &'static str {
-    let lang_code = locale
-        .split(|c| c == '-' || c == '_')
-        .next()
-        .unwrap_or("")
-        .to_lowercase();
+    let lang_code = locale.split(['-', '_']).next().unwrap_or("").to_lowercase();
     match lang_code.as_str() {
         "nb" | "nn" | "no" => "no",
         "es" => "es",
@@ -472,4 +468,37 @@ fn checksum_to_hex_color(checksum: &str) -> String {
 pub fn calculate_wallet_color(descriptor: &str) -> String {
     let checksum = extract_checksum(descriptor);
     checksum_to_hex_color(&checksum)
+}
+
+/// Parameters for creating a notification log entry
+#[derive(Debug, Clone)]
+pub struct NotificationLogParams<'a> {
+    pub notification_method_id: &'a str,
+    pub provider_name: &'a str,
+    pub provider_message_id: Option<&'a str>,
+    pub status: &'a str,
+    pub error_message: Option<&'a str>,
+    pub message_content: &'a str,
+}
+
+/// Parameters for triggering a balance alert notification
+#[derive(Debug, Clone)]
+pub struct BalanceAlertTriggerParams {
+    pub threshold_sats: i64,
+    pub current_balance_sats: i64,
+    pub alert_type: BalanceAlertType,
+    pub threshold_currency: Option<String>,
+    pub threshold_fiat_amount: Option<f64>,
+    pub exchange_rate_snapshot: Option<f64>,
+}
+
+/// Parameters for updating a user's subscription
+#[derive(Debug, Clone, Default)]
+pub struct SubscriptionUpdateParams<'a> {
+    pub subscription_tier: &'a str,
+    pub subscription_status: &'a str,
+    pub stripe_subscription_id: Option<&'a str>,
+    pub subscription_started_at: Option<&'a str>,
+    pub subscription_ends_at: Option<&'a str>,
+    pub trial_ends_at: Option<&'a str>,
 }

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -488,21 +488,16 @@ impl MetadataDb {
     pub async fn update_user_subscription(
         &self,
         user_id: &str,
-        subscription_tier: &str,
-        subscription_status: &str,
-        stripe_subscription_id: Option<&str>,
-        subscription_started_at: Option<&str>,
-        subscription_ends_at: Option<&str>,
-        trial_ends_at: Option<&str>,
+        params: &SubscriptionUpdateParams<'_>,
     ) -> Result<()> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
-        let subscription_tier = subscription_tier.to_string();
-        let subscription_status = subscription_status.to_string();
-        let stripe_subscription_id = stripe_subscription_id.map(|s| s.to_string());
-        let subscription_started_at = subscription_started_at.map(|s| s.to_string());
-        let subscription_ends_at = subscription_ends_at.map(|s| s.to_string());
-        let trial_ends_at = trial_ends_at.map(|s| s.to_string());
+        let subscription_tier = params.subscription_tier.to_string();
+        let subscription_status = params.subscription_status.to_string();
+        let stripe_subscription_id = params.stripe_subscription_id.map(|s| s.to_string());
+        let subscription_started_at = params.subscription_started_at.map(|s| s.to_string());
+        let subscription_ends_at = params.subscription_ends_at.map(|s| s.to_string());
+        let trial_ends_at = params.trial_ends_at.map(|s| s.to_string());
 
         spawn_blocking(move || -> Result<()> {
             let conn = pool.get()?;

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::metadata::{MetadataDb, UserRecord};
+use crate::metadata::{MetadataDb, SubscriptionUpdateParams, UserRecord};
 use crate::stripe_client_service::StripeClientService;
 use crate::subscription::SubscriptionTier;
 
@@ -592,17 +592,20 @@ impl StripeBilling {
         // Update user's subscription info in database
         let now = chrono::Utc::now();
         let trial_end = now + chrono::Duration::days(30);
+        let now_str = now.to_rfc3339();
+        let trial_end_str = trial_end.to_rfc3339();
+        let tier_str = format!("{:?}", tier).to_lowercase();
 
+        let sub_params = SubscriptionUpdateParams {
+            subscription_tier: &tier_str,
+            subscription_status: "trialing",
+            stripe_subscription_id: Some(&subscription_id),
+            subscription_started_at: Some(&now_str),
+            subscription_ends_at: None, // subscription_ends_at - not set for trials
+            trial_ends_at: Some(&trial_end_str),
+        };
         metadata_db
-            .update_user_subscription(
-                &user.id,
-                &format!("{:?}", tier).to_lowercase(),
-                "trialing",
-                Some(&subscription_id),
-                Some(&now.to_rfc3339()),
-                None, // subscription_ends_at - not set for trials
-                Some(&trial_end.to_rfc3339()),
-            )
+            .update_user_subscription(&user.id, &sub_params)
             .await?;
 
         tracing::info!(

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -2,7 +2,8 @@ use crate::admin_notifications::AdminNotifications;
 use crate::config::AppConfig;
 use crate::electrum::{ElectrumClient, ElectrumClientManager};
 use crate::metadata::{
-    EventType, MetadataDb, Transaction, TransactionInsert, TransactionNotification,
+    BalanceAlertTriggerParams, EventType, MetadataDb, Transaction, TransactionInsert,
+    TransactionNotification,
 };
 use anyhow::Result;
 use bdk_wallet::{rusqlite::Connection, PersistedWallet};
@@ -13,6 +14,9 @@ use tracing::{debug, error, info, warn};
 
 /// Number of consecutive reconnection failures before sending an alert
 const ALERT_FAILURE_THRESHOLD: u32 = 3;
+
+/// Transaction summary: (txid, amount_sats, block_height, is_confirmed, first_seen_at, confirmed_at)
+type TransactionSummary = (String, i64, Option<u32>, bool, u64, Option<u64>);
 
 /// Transaction-based wallet sync service
 /// This replaces the old balance-based sync logic with proper transaction tracking
@@ -1085,7 +1089,7 @@ impl WalletSyncService {
         &self,
         wallet: &PersistedWallet<Connection>,
         wallet_checksum: &str,
-        all_transactions: &[(String, i64, Option<u32>, bool, u64, Option<u64>)],
+        all_transactions: &[TransactionSummary],
     ) -> Result<std::collections::HashMap<String, String>> {
         use std::collections::HashMap;
 
@@ -1364,18 +1368,17 @@ impl WalletSyncService {
                 }
 
                 // Create notification record in balance_alert_notifications table
+                let trigger_params = BalanceAlertTriggerParams {
+                    threshold_sats: alert.threshold_sats,
+                    current_balance_sats,
+                    alert_type: alert.alert_type,
+                    threshold_currency: alert.threshold_currency.clone(),
+                    threshold_fiat_amount: alert.threshold_fiat_amount,
+                    exchange_rate_snapshot,
+                };
                 if let Err(e) = self
                     .metadata_db
-                    .create_balance_alert_notification(
-                        &alert.id,
-                        wallet_checksum,
-                        alert.threshold_sats,
-                        current_balance_sats,
-                        alert.alert_type,
-                        alert.threshold_currency.clone(),
-                        alert.threshold_fiat_amount,
-                        exchange_rate_snapshot,
-                    )
+                    .create_balance_alert_notification(&alert.id, wallet_checksum, &trigger_params)
                     .await
                 {
                     warn!(

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -9,11 +9,30 @@ use bdk_wallet::{bitcoin::Network, KeychainKind, PersistedWallet, Wallet};
 use futures::future::join_all;
 use miniscript::{Descriptor, DescriptorPublicKey};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{broadcast, Mutex, Semaphore};
 use tracing::{debug, error, info, warn};
+
+/// Individual wallet entry containing BDK wallet and its SQLite connection
+type WalletEntry = Arc<Mutex<(PersistedWallet<Connection>, Connection)>>;
+
+/// Thread-safe map of wallet checksums to wallet entries
+type WalletMap = Arc<Mutex<HashMap<String, WalletEntry>>>;
+
+/// Context for completing wallet creation with deep scanning
+struct WalletCreationContext {
+    wallet_path: PathBuf,
+    receive_descriptor: String,
+    change_descriptor: String,
+    network: Network,
+    electrum_client: Option<ElectrumClient>,
+    metadata_db: MetadataDb,
+    checksum: String,
+    is_fresh_wallet: bool,
+    stop_gap: Option<String>,
+}
 
 /// Maximum number of wallets to sync in parallel
 const MAX_PARALLEL_SYNCS: usize = 10;
@@ -144,32 +163,27 @@ impl WalletCreationService {
             .ok_or_else(|| anyhow!("Failed to retrieve created wallet metadata"))?;
 
         // PHASE 2: Spawn background task for slow operations
-        let electrum_client_clone = self.electrum_client.clone();
-        let metadata_db_clone = self.metadata_db.clone();
-        let network = self.network;
-        let checksum_clone = checksum.clone();
-        let stop_gap_clone = stop_gap.map(|s| s.to_string());
         let wallet_manager_clone = self.wallet_manager.clone();
-        let wallet_path_clone = wallet_path.clone();
+        let ctx = WalletCreationContext {
+            wallet_path: wallet_path.clone(),
+            receive_descriptor,
+            change_descriptor,
+            network: self.network,
+            electrum_client: self.electrum_client.clone(),
+            metadata_db: self.metadata_db.clone(),
+            checksum: checksum.clone(),
+            is_fresh_wallet,
+            stop_gap: stop_gap.map(|s| s.to_string()),
+        };
 
         tokio::spawn(async move {
             debug!(
                 "[{}] Starting background wallet creation with stop gap: {:?}",
-                checksum_clone, stop_gap_clone
+                ctx.checksum, ctx.stop_gap
             );
-            if let Err(e) = WalletManager::complete_wallet_creation_with_stop_gap(
-                wallet_path_clone.clone(),
-                receive_descriptor,
-                change_descriptor,
-                network,
-                electrum_client_clone,
-                metadata_db_clone,
-                checksum_clone.clone(),
-                is_fresh_wallet,
-                stop_gap_clone.as_deref(),
-                wallet_manager_clone,
-            )
-            .await
+            if let Err(e) =
+                WalletManager::complete_wallet_creation_with_stop_gap(ctx, wallet_manager_clone)
+                    .await
             {
                 error!(
                     "[{}] Background wallet creation failed: {}",
@@ -265,32 +279,27 @@ impl WalletCreationService {
             .ok_or_else(|| anyhow!("Failed to retrieve created wallet metadata"))?;
 
         // PHASE 2: Spawn background task for slow operations
-        let electrum_client_clone = self.electrum_client.clone();
-        let metadata_db_clone = self.metadata_db.clone();
-        let network = self.network;
-        let checksum_clone = checksum.clone();
-        let stop_gap_clone = stop_gap.map(|s| s.to_string());
         let wallet_manager_clone = self.wallet_manager.clone();
-        let wallet_path_clone = wallet_path.clone();
+        let ctx = WalletCreationContext {
+            wallet_path: wallet_path.clone(),
+            receive_descriptor,
+            change_descriptor,
+            network: self.network,
+            electrum_client: self.electrum_client.clone(),
+            metadata_db: self.metadata_db.clone(),
+            checksum: checksum.clone(),
+            is_fresh_wallet: true, // Fresh wallet for XPUB with known type
+            stop_gap: stop_gap.map(|s| s.to_string()),
+        };
 
         tokio::spawn(async move {
             debug!(
                 "[{}] Starting background wallet creation with stop gap: {:?}",
-                checksum_clone, stop_gap_clone
+                ctx.checksum, ctx.stop_gap
             );
-            if let Err(e) = WalletManager::complete_wallet_creation_with_stop_gap(
-                wallet_path_clone.clone(),
-                receive_descriptor,
-                change_descriptor,
-                network,
-                electrum_client_clone,
-                metadata_db_clone,
-                checksum_clone.clone(),
-                true, // Fresh wallet for XPUB with known type
-                stop_gap_clone.as_deref(),
-                wallet_manager_clone,
-            )
-            .await
+            if let Err(e) =
+                WalletManager::complete_wallet_creation_with_stop_gap(ctx, wallet_manager_clone)
+                    .await
             {
                 error!(
                     "[{}] Background wallet creation failed: {}",
@@ -311,7 +320,7 @@ impl WalletCreationService {
 pub struct WalletManager {
     // Thread-safe HashMap for in-memory wallet storage
     // Each wallet has its own mutex for parallel access
-    pub wallets: Arc<Mutex<HashMap<String, Arc<Mutex<(PersistedWallet<Connection>, Connection)>>>>>,
+    pub wallets: WalletMap,
     pub wallet_dir: PathBuf,
     /// Electrum client manager with automatic reconnection support
     pub electrum_client_manager: Option<Arc<ElectrumClientManager>>,
@@ -440,42 +449,37 @@ impl WalletManager {
 
     /// Background task to complete wallet creation with scan depth support
     async fn complete_wallet_creation_with_stop_gap(
-        wallet_path: PathBuf,
-        receive_descriptor: String,
-        change_descriptor: String,
-        network: Network,
-        electrum_client: Option<ElectrumClient>,
-        metadata_db: MetadataDb,
-        checksum: String,
-        is_fresh_wallet: bool,
-        stop_gap: Option<&str>,
+        ctx: WalletCreationContext,
         wallet_manager: Arc<WalletManager>,
     ) -> Result<()> {
+        let stop_gap = ctx.stop_gap.as_deref();
         debug!(
             "[{}] Starting background wallet creation with stop gap: {:?}",
-            checksum, stop_gap
+            ctx.checksum, stop_gap
         );
 
         // Create SQLite connection
-        let mut db = Connection::open(&wallet_path).map_err(|e| {
+        let mut db = Connection::open(&ctx.wallet_path).map_err(|e| {
             anyhow!(
                 "Failed to create connection to {}: {}",
-                wallet_path.display(),
+                ctx.wallet_path.display(),
                 e
             )
         })?;
 
         // Parse descriptors
-        let receive_desc: Descriptor<DescriptorPublicKey> = receive_descriptor
+        let receive_desc: Descriptor<DescriptorPublicKey> = ctx
+            .receive_descriptor
             .parse()
             .map_err(|e| anyhow!("Failed to parse receive descriptor: {}", e))?;
-        let change_desc: Descriptor<DescriptorPublicKey> = change_descriptor
+        let change_desc: Descriptor<DescriptorPublicKey> = ctx
+            .change_descriptor
             .parse()
             .map_err(|e| anyhow!("Failed to parse change descriptor: {}", e))?;
 
         // Create new wallet
         let mut wallet = Wallet::create(receive_desc, change_desc)
-            .network(network)
+            .network(ctx.network)
             .create_wallet(&mut db)
             .map_err(|e| anyhow!("Failed to create wallet: {}", e))?;
 
@@ -490,7 +494,7 @@ impl WalletManager {
                 if let Ok(max_index) = stop_gap_str.parse::<u32>() {
                     debug!(
                         "[{}] Applying custom stop gap: {} addresses",
-                        checksum, max_index
+                        ctx.checksum, max_index
                     );
 
                     // Reveal addresses up to the specified index
@@ -505,7 +509,7 @@ impl WalletManager {
                     if let Err(e) = wallet.persist(&mut db) {
                         error!(
                             "[{}] Warning: Failed to persist revealed addresses: {}",
-                            checksum, e
+                            ctx.checksum, e
                         );
                     }
                 }
@@ -513,7 +517,7 @@ impl WalletManager {
         }
 
         // Full scan with electrum (using custom stop gap if specified)
-        if let Some(ref client) = electrum_client {
+        if let Some(ref client) = ctx.electrum_client {
             let custom_stop_gap = if let Some(stop_gap_str) = stop_gap {
                 if stop_gap_str != "auto" {
                     stop_gap_str.parse::<usize>().ok()
@@ -527,25 +531,25 @@ impl WalletManager {
             if let Err(e) = client.full_scan_wallet(&mut wallet, custom_stop_gap).await {
                 error!(
                     "[{}] Warning: Failed to full scan wallet during background creation: {}",
-                    checksum, e
+                    ctx.checksum, e
                 );
             } else {
                 // Persist after sync
                 if let Err(e) = wallet.persist(&mut db) {
                     error!(
                         "[{}] Warning: Failed to persist wallet after sync: {}",
-                        checksum, e
+                        ctx.checksum, e
                     );
                 }
 
                 // Deep scanning for existing wallets with no funds (only if stop_gap is auto)
-                if !is_fresh_wallet
+                if !ctx.is_fresh_wallet
                     && wallet.balance().total().to_sat() == 0
                     && stop_gap.unwrap_or("auto") == "auto"
                 {
                     debug!(
                         "[{}] No funds found in initial scan, starting deep scan...",
-                        checksum
+                        ctx.checksum
                     );
 
                     // Deep scan in batches up to 500 addresses (only for auto mode)
@@ -553,7 +557,7 @@ impl WalletManager {
                         let reveal_to = batch * 100;
                         debug!(
                             "[{}] Deep scan batch {}: checking addresses up to index {}",
-                            checksum, batch, reveal_to
+                            ctx.checksum, batch, reveal_to
                         );
 
                         // Reveal more addresses for both keychains
@@ -566,7 +570,7 @@ impl WalletManager {
 
                         debug!(
                             "[{}] Revealed {} external, {} internal addresses (total: {} each)",
-                            checksum,
+                            ctx.checksum,
                             ext_revealed.len(),
                             int_revealed.len(),
                             reveal_to + 1
@@ -576,7 +580,7 @@ impl WalletManager {
                         if let Err(e) = client.sync_wallet(&mut wallet).await {
                             error!(
                                 "[{}] Warning: Failed to sync during deep scan batch {}: {}",
-                                checksum, batch, e
+                                ctx.checksum, batch, e
                             );
                             break;
                         }
@@ -586,7 +590,7 @@ impl WalletManager {
                         if current_balance > 0 {
                             debug!(
                                 "[{}] Found activity during deep scan! Balance: {} sats",
-                                checksum, current_balance
+                                ctx.checksum, current_balance
                             );
                             // Continue scanning to find all transactions
                         }
@@ -596,7 +600,7 @@ impl WalletManager {
                     if let Err(e) = wallet.persist(&mut db) {
                         error!(
                             "[{}] Warning: Failed to persist after deep scan: {}",
-                            checksum, e
+                            ctx.checksum, e
                         );
                     }
                 }
@@ -605,13 +609,14 @@ impl WalletManager {
 
         // Update balance in metadata database
         let balance = wallet.balance().total().to_sat() as i64;
-        if let Err(e) = metadata_db
-            .update_wallet_balance_by_checksum(&checksum, balance)
+        if let Err(e) = ctx
+            .metadata_db
+            .update_wallet_balance_by_checksum(&ctx.checksum, balance)
             .await
         {
             error!(
                 "[{}] Warning: Failed to update wallet balance: {}",
-                checksum, e
+                ctx.checksum, e
             );
         }
 
@@ -619,54 +624,63 @@ impl WalletManager {
         if let Err(e) =
             crate::sync::WalletSyncService::extract_historical_transactions_for_background(
                 &wallet,
-                &checksum,
-                &metadata_db,
-                electrum_client.as_ref(),
+                &ctx.checksum,
+                &ctx.metadata_db,
+                ctx.electrum_client.as_ref(),
             )
             .await
         {
             error!(
                 "[{}] Warning: Failed to extract historical transactions: {}",
-                checksum, e
+                ctx.checksum, e
             );
         }
 
         // Update last synced timestamp
-        if let Err(e) = metadata_db.update_wallet_last_synced(&checksum).await {
+        if let Err(e) = ctx
+            .metadata_db
+            .update_wallet_last_synced(&ctx.checksum)
+            .await
+        {
             error!(
                 "[{}] Warning: Failed to update wallet last synced: {}",
-                checksum, e
+                ctx.checksum, e
             );
         }
 
         // Mark wallet as ready after deep scan and transaction extraction is complete
-        if let Err(e) = metadata_db.update_wallet_status(&checksum, "ready").await {
+        if let Err(e) = ctx
+            .metadata_db
+            .update_wallet_status(&ctx.checksum, "ready")
+            .await
+        {
             error!(
                 "[{}] Warning: Failed to mark wallet as ready: {}",
-                checksum, e
+                ctx.checksum, e
             );
         } else {
             debug!(
                 "[{}] ✅ Wallet marked as ready - available for frontend display",
-                checksum
+                ctx.checksum
             );
         }
 
         // Add wallet to in-memory storage after it's fully set up and marked as ready
-        if let Ok((wallet, conn)) = Self::load_wallet_from_disk(&wallet_path, network).await {
+        if let Ok((wallet, conn)) = Self::load_wallet_from_disk(&ctx.wallet_path, ctx.network).await
+        {
             wallet_manager
-                .register_wallet(checksum.clone(), wallet, conn)
+                .register_wallet(ctx.checksum.clone(), wallet, conn)
                 .await;
         } else {
             error!(
                 "[{}] Failed to load wallet into memory after creation",
-                checksum
+                ctx.checksum
             );
         }
 
         debug!(
             "[{}] Background wallet creation with scan depth completed",
-            checksum
+            ctx.checksum
         );
         Ok(())
     }
@@ -1187,11 +1201,11 @@ impl WalletManager {
     /// Load a single wallet from disk
     /// Returns the wallet and its database connection
     async fn load_wallet_from_disk(
-        wallet_path: &PathBuf,
+        wallet_path: &Path,
         network: Network,
     ) -> Result<(PersistedWallet<Connection>, Connection)> {
         // Run blocking I/O in a separate thread
-        let path = wallet_path.clone();
+        let path = wallet_path.to_path_buf();
         let result = tokio::task::spawn_blocking(move || {
             let conn = Connection::open(&path)
                 .map_err(|e| anyhow!("Failed to open wallet database: {}", e))?;


### PR DESCRIPTION
## Summary
- Fix 10 clippy warnings to enable `cargo clippy -- -D warnings` to pass
- Add `#[allow(clippy::result_large_err)]` for Axum extractor pattern in auth.rs
- Create parameter structs: `NotificationLogParams`, `BalanceAlertTriggerParams`, `SubscriptionUpdateParams`, `WalletCreationContext`
- Add type aliases: `WalletEntry`, `WalletMap`, `TransactionSummary`
- Fix `&PathBuf` to `&Path` in `load_wallet_from_disk`
- Use `.split(['-', '_'])` instead of lambda for character pattern matching

## Test plan
- [ ] Run `cargo clippy -- -D warnings` - should pass with no errors
- [ ] Run `cargo test -- --test-threads=1` - all tests should pass
- [ ] Run frontend tests with `pnpm test` - all tests should pass

## Testing completed
- [x] Automated tests pass (`cargo test -- --test-threads=1`)
- [x] Clippy passes with `-D warnings` flag
- [x] Frontend tests pass (`pnpm test`)

Closes #135