### PR TITLE
fix(frontend): Use user's preferred language for number formatting

### DIFF
--- a/frontend/src/app/subscription/success.tsx
+++ b/frontend/src/app/subscription/success.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { CheckCircle2, Loader2, ArrowRight } from "lucide-react"
 import { getTierDisplayName } from "@/lib/pricing-data"
 import { formatPrice, usePricing } from "@/hooks/usePricing"
+import { useLocale } from "next-intl"
 
 export default function BillingSuccessPage() {
   const searchParams = useSearchParams()
@@ -18,6 +19,7 @@ export default function BillingSuccessPage() {
   const { refreshBillingStatus } = useAuth()
   const { pricing } = usePricing()
   const discountPercent = pricing?.yearly_discount_percent || 20
+  const locale = useLocale()
 
   const [sessionDetails, setSessionDetails] = useState<{
     session_id: string
@@ -133,7 +135,7 @@ export default function BillingSuccessPage() {
               <div className="flex justify-between items-center">
                 <span className="font-medium">Amount Paid</span>
                 <span className="font-bold">
-                  {formatPrice(amount, currency)}
+                  {formatPrice(amount, currency, locale)}
                   {isYearly ? '/year' : '/month'}
                 </span>
               </div>

--- a/frontend/src/app/wallets/page.tsx
+++ b/frontend/src/app/wallets/page.tsx
@@ -3,7 +3,6 @@
 import { AlertCircle } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
-import { formatBitcoinAmount } from "@/lib/utils"
 import { useAuth } from "@/contexts/auth-context"
 import { WalletCards } from "@/components/wallet-cards"
 import { WalletOnboarding } from "@/components/wallet-onboarding"
@@ -11,6 +10,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { useWalletsContext } from "@/contexts/wallets-context"
 import { useTranslations } from "next-intl"
+import { useFormatters } from "@/hooks/useFormatters"
 
 export default function WalletsPage() {
   const t = useTranslations('wallets')
@@ -18,6 +18,7 @@ export default function WalletsPage() {
   const { wallets, error, lastUpdate, isConnected, isLoading: walletsLoading } = useWalletsContext()
   const { isAuthenticated, isLoading: authLoading, user, isCloudMode, billingStatus } = useAuth()
   const router = useRouter()
+  const { formatBitcoinAmount, formatFiatAmount, locale } = useFormatters()
 
   // Set page title
   useEffect(() => {
@@ -81,7 +82,7 @@ export default function WalletsPage() {
             {t('connectionLost.description')}
             {lastUpdate && (
               <span className="block mt-1 text-xs">
-                {t('connectionLost.lastUpdated', { time: new Date(lastUpdate * 1000).toLocaleString() })}
+                {t('connectionLost.lastUpdated', { time: new Date(lastUpdate * 1000).toLocaleString(locale) })}
               </span>
             )}
           </AlertDescription>
@@ -106,14 +107,7 @@ export default function WalletsPage() {
                         if (fiatTotal) {
                           return (
                             <span>
-                              {' '}(
-                              {new Intl.NumberFormat(undefined, {
-                                style: 'currency',
-                                currency: fiatTotal.currency,
-                                minimumFractionDigits: 0,
-                                maximumFractionDigits: 0
-                              }).format(fiatTotal.amount)}
-                              )
+                              {' '}({formatFiatAmount(fiatTotal.amount, fiatTotal.currency)})
                             </span>
                           )
                         }

--- a/frontend/src/components/app-footer.tsx
+++ b/frontend/src/components/app-footer.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import { useBlockHeader } from "@/hooks/useBlockHeader"
 import { useRelativeTime } from "@/hooks/useRelativeTime"
+import { useFormatters } from "@/hooks/useFormatters"
 import { BuildInfo } from "./build-info"
 import { useTranslations } from "next-intl"
 
@@ -11,6 +12,7 @@ export function AppFooter() {
   const blockHeaderTime = useRelativeTime(blockHeader?.timestamp)
   const t = useTranslations('footer')
   const tCommon = useTranslations('common')
+  const { formatNumber } = useFormatters()
 
   return (
     <footer className="mt-16 pt-8 border-t border-border">
@@ -27,7 +29,7 @@ export function AppFooter() {
             <h3 className="text-lg font-bold tracking-wide">{t('appName')}</h3>
             {blockHeader ? (
               <p className="text-muted-foreground text-sm">
-                {t('blockInfo', { height: blockHeader.height.toLocaleString() })} • {blockHeaderTime}
+                {t('blockInfo', { height: formatNumber(blockHeader.height) })} • {blockHeaderTime}
               </p>
             ) : (
               <p className="text-muted-foreground text-sm">{tCommon('connectingToNetwork')}</p>

--- a/frontend/src/components/balance-alerts-list.tsx
+++ b/frontend/src/components/balance-alerts-list.tsx
@@ -18,13 +18,12 @@ import { BalanceAlert, CreateBalanceAlertRequest } from "@/types"
 import {
   satsToBtc,
   btcToSats,
-  formatBtcAmount,
   parseBtcInput,
   getBtcPlaceholder
 } from "@/lib/utils"
-import { formatFiatAmount } from "@/lib/currencies"
 import { useAuth } from "@/contexts/auth-context"
 import { useTranslations } from "next-intl"
+import { useFormatters } from "@/hooks/useFormatters"
 
 interface BalanceAlertsListProps {
   walletChecksum: string
@@ -59,6 +58,7 @@ export function BalanceAlertsList({
   const { user, isCloudMode } = useAuth()
   const t = useTranslations('balanceAlerts')
   const tCommon = useTranslations('common')
+  const { formatFiatAmount, formatBtcAmount } = useFormatters()
 
   // Use local state for optimistic updates
   const [localAlerts, setLocalAlerts] = useState<BalanceAlert[]>(balanceAlerts)

--- a/frontend/src/components/plan-comparison.tsx
+++ b/frontend/src/components/plan-comparison.tsx
@@ -7,6 +7,7 @@ import { CheckCircle2, Loader2, Github } from "lucide-react"
 import { allFeatures } from "@/lib/pricing-data"
 import { usePricing, formatPrice, sortTiers } from "@/hooks/usePricing"
 import { useTranslations } from "next-intl"
+import { useLocale } from "next-intl"
 
 // Map tier slug to translation key (handles selfhosted -> selfHosted)
 function getTierTranslationKey(tier: string): string {
@@ -161,6 +162,7 @@ function PlanComparisonContent({
   hasPaidSubscription
 }: PlanComparisonContentProps) {
   const t = useTranslations('billing')
+  const locale = useLocale()
 
   // Separate paid tiers from self-hosted for different layout
   const paidTiers = tiersToShow.filter(tier => tier.tier !== 'selfhosted')
@@ -224,7 +226,7 @@ function PlanComparisonContent({
               )}
               {showPricing && monthlyPrice && tier.tier !== 'selfhosted' && (
                 <div className="mt-3">
-                  <span className="text-2xl font-bold">{formatPrice(monthlyPrice.amount, monthlyPrice.currency)}</span>
+                  <span className="text-2xl font-bold">{formatPrice(monthlyPrice.amount, monthlyPrice.currency, locale)}</span>
                   <span className="text-muted-foreground text-sm">{t('perMonth')}</span>
                   <div className="text-xs text-muted-foreground mt-0.5">
                     {t('plusTaxes')}

--- a/frontend/src/components/transaction-card.tsx
+++ b/frontend/src/components/transaction-card.tsx
@@ -17,8 +17,8 @@ import {
   Clock
 } from "lucide-react"
 import { Transaction } from "../types"
-import { formatBitcoinAmount, formatTransactionAmount, formatDateTime } from "@/lib/utils"
 import { useTranslations } from "next-intl"
+import { useFormatters } from "@/hooks/useFormatters"
 
 interface TransactionCardProps {
   transaction: Transaction
@@ -28,6 +28,7 @@ interface TransactionCardProps {
 export function TransactionCard({ transaction, showWalletName }: TransactionCardProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const t = useTranslations('transactions')
+  const { formatTransactionAmount, formatDateTime } = useFormatters()
 
   const getUniqueProviderSummary = (notifications: typeof transaction.notification_status) => {
     if (!notifications || notifications.length === 0) return null

--- a/frontend/src/components/transaction-details.tsx
+++ b/frontend/src/components/transaction-details.tsx
@@ -3,8 +3,8 @@
 import React from "react"
 import { Mail, MessageCircle, Bell, XCircle, ArrowRight } from "lucide-react"
 import { Transaction } from "../types"
-import { formatTransactionAmount, formatDateTime } from "@/lib/utils"
 import { useTranslations } from "next-intl"
+import { useFormatters } from "@/hooks/useFormatters"
 
 interface ProviderIconProps {
   providerType: string
@@ -31,6 +31,7 @@ interface TransactionDetailsProps {
 
 export function TransactionDetails({ transaction, isExpanded }: TransactionDetailsProps) {
   const t = useTranslations('transactions')
+  const { formatTransactionAmount, formatDateTime } = useFormatters()
 
   const renderNotificationGroup = (notifications: NonNullable<Transaction['notification_status']>) => {
     // Group notifications by contact name to avoid repetition

--- a/frontend/src/components/transactions.tsx
+++ b/frontend/src/components/transactions.tsx
@@ -15,10 +15,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Skeleton } from "@/components/ui/skeleton"
 import { CheckCircle, Baby, Mail, MessageCircle, Bell, ChevronDown, ChevronRight, XCircle, Loader2, ArrowRight } from "lucide-react"
 import { Transaction } from "../types"
-import { formatTransactionAmount, formatDateTime } from "@/lib/utils"
 import { TransactionCard } from "./transaction-card"
 import { TransactionDetails } from "./transaction-details"
 import { useTranslations } from "next-intl"
+import { useFormatters } from "@/hooks/useFormatters"
 
 interface TransactionsProps {
   selectedWalletChecksum?: string | null
@@ -33,6 +33,7 @@ export function Transactions({ selectedWalletChecksum, transactions, error, last
   const [hasReceivedData, setHasReceivedData] = useState(false)
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
   const t = useTranslations('transactions')
+  const { formatTransactionAmount, formatDateTime } = useFormatters()
 
   // Track when we've received data for the first time
   useEffect(() => {

--- a/frontend/src/components/wallet-cards.tsx
+++ b/frontend/src/components/wallet-cards.tsx
@@ -6,8 +6,9 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
 import { Users, AlertTriangle, Loader2 } from "lucide-react"
 import Link from "next/link"
-import { loadCanarySvg, getCachedCanarySvg, formatBitcoinAmount } from "@/lib/utils"
+import { loadCanarySvg, getCachedCanarySvg } from "@/lib/utils"
 import { useTranslations } from "next-intl"
+import { useFormatters } from "@/hooks/useFormatters"
 
 import { Wallet } from "../types"
 
@@ -21,6 +22,7 @@ interface WalletCardsProps {
 export function WalletCards({ wallets, error, lastUpdate, subscriptionStatus }: WalletCardsProps) {
   const [hasReceivedData, setHasReceivedData] = useState(false)
   const t = useTranslations('wallets')
+  const { formatBitcoinAmount, formatFiatAmount, locale } = useFormatters()
 
   // Check if subscription is expired
   const isSubscriptionExpired = subscriptionStatus === 'expired'
@@ -200,19 +202,14 @@ export function WalletCards({ wallets, error, lastUpdate, subscriptionStatus }: 
                       </div>
                       {wallet.balance_fiat !== undefined && wallet.fiat_currency && (
                         <div className="text-sm text-muted-foreground mt-1">
-                          {new Intl.NumberFormat(undefined, {
-                            style: 'currency',
-                            currency: wallet.fiat_currency,
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 0
-                          }).format(wallet.balance_fiat)}
+                          {formatFiatAmount(wallet.balance_fiat, wallet.fiat_currency)}
                         </div>
                       )}
                     </div>
                     <div className="flex justify-between items-center text-xs text-muted-foreground">
                       <span>
                         {wallet.last_activity
-                          ? t('card.lastActivity', { date: new Date(parseInt(wallet.last_activity) * 1000).toLocaleDateString(undefined, {
+                          ? t('card.lastActivity', { date: new Date(parseInt(wallet.last_activity) * 1000).toLocaleDateString(locale, {
                               year: '2-digit',
                               month: '2-digit',
                               day: '2-digit'

--- a/frontend/src/components/wallet-detail/wallet-detail-warning-banners.tsx
+++ b/frontend/src/components/wallet-detail/wallet-detail-warning-banners.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { AlertCircle, AlertTriangle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { useFormatters } from "@/hooks/useFormatters"
 import type { Wallet } from "@/types"
 
 interface WalletDetailWarningBannersProps {
@@ -25,6 +26,7 @@ export function WalletDetailWarningBanners({
   billingStatus,
   t,
 }: WalletDetailWarningBannersProps) {
+  const { locale } = useFormatters()
   return (
     <>
       {/* Connection Warning Banner */}
@@ -37,7 +39,7 @@ export function WalletDetailWarningBanners({
             {lastUpdate && (
               <span className="block mt-1 text-xs">
                 {t("connectionLost.lastUpdated", {
-                  time: new Date(lastUpdate * 1000).toLocaleString(),
+                  time: new Date(lastUpdate * 1000).toLocaleString(locale),
                 })}
               </span>
             )}

--- a/frontend/src/components/wallet-detail/wallet-info-sidebar.tsx
+++ b/frontend/src/components/wallet-detail/wallet-info-sidebar.tsx
@@ -5,8 +5,8 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { WalletContactsList } from "@/components/wallet-contacts-list"
 import { BalanceAlertsList } from "@/components/balance-alerts-list"
-import { formatBitcoinAmount } from "@/lib/utils"
 import { useTranslations } from "next-intl"
+import { useFormatters } from "@/hooks/useFormatters"
 import type { Wallet, Contact, BalanceAlert } from "@/types"
 
 interface WalletInfoSidebarProps {
@@ -30,6 +30,7 @@ export function WalletInfoSidebar({
 }: WalletInfoSidebarProps) {
   const t = useTranslations("wallets")
   const tCommon = useTranslations("common")
+  const { formatBitcoinAmount, formatFiatAmount } = useFormatters()
 
   return (
     <div className="lg:col-span-1">
@@ -45,12 +46,7 @@ export function WalletInfoSidebar({
             </div>
             {wallet.balance_fiat !== undefined && wallet.fiat_currency && (
               <div className="text-sm text-muted-foreground mt-1">
-                {new Intl.NumberFormat(undefined, {
-                  style: "currency",
-                  currency: wallet.fiat_currency,
-                  minimumFractionDigits: 0,
-                  maximumFractionDigits: 0,
-                }).format(wallet.balance_fiat)}
+                {formatFiatAmount(wallet.balance_fiat, wallet.fiat_currency)}
               </div>
             )}
           </div>

--- a/frontend/src/hooks/useFormatters.ts
+++ b/frontend/src/hooks/useFormatters.ts
@@ -1,0 +1,27 @@
+import { useLocale } from 'next-intl'
+import { formatBitcoinAmount, formatTransactionAmount, formatDateTime, formatBtcAmount } from '@/lib/utils'
+import { formatFiatAmount } from '@/lib/currencies'
+
+/**
+ * Hook that provides locale-aware formatting functions.
+ * Uses the user's preferred locale from next-intl for consistent formatting
+ * across the application, matching the backend's ICU4X-based formatting.
+ */
+export function useFormatters() {
+  const locale = useLocale()
+
+  return {
+    formatBitcoinAmount: (sats: number | null | undefined) =>
+      formatBitcoinAmount(sats, locale),
+    formatTransactionAmount: (sats: number | null | undefined, eventType?: 'send' | 'receive') =>
+      formatTransactionAmount(sats, eventType, locale),
+    formatDateTime: (dateTime: string | number) =>
+      formatDateTime(dateTime, locale),
+    formatFiatAmount: (amount: number, currencyCode: string) =>
+      formatFiatAmount(amount, currencyCode, locale),
+    formatBtcAmount: (btc: number) =>
+      formatBtcAmount(btc, locale),
+    formatNumber: (num: number) => num.toLocaleString(locale),
+    locale,
+  }
+}

--- a/frontend/src/hooks/usePricing.ts
+++ b/frontend/src/hooks/usePricing.ts
@@ -68,8 +68,8 @@ export function usePricing() {
 }
 
 // Helper function to format price from cents to dollars
-export function formatPrice(amountInCents: number, currency: string = 'USD'): string {
-  return new Intl.NumberFormat('en-US', {
+export function formatPrice(amountInCents: number, currency: string, locale: string): string {
+  return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency: currency.toUpperCase(),
     minimumFractionDigits: 0,

--- a/frontend/src/lib/currencies.ts
+++ b/frontend/src/lib/currencies.ts
@@ -86,12 +86,12 @@ export function getCurrencyName(code: string): string {
 }
 
 /**
- * Format a fiat amount with currency symbol using browser locale
+ * Format a fiat amount with currency symbol using user's preferred locale
  */
-export function formatFiatAmount(amount: number, currencyCode: string): string {
-  // Use browser's locale (undefined) to format currency appropriately
+export function formatFiatAmount(amount: number, currencyCode: string, locale: string): string {
+  // Use user's preferred locale to format currency appropriately
   // This handles symbol placement, separators, and decimals based on locale
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency: currencyCode,
     minimumFractionDigits: 0,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -170,11 +170,11 @@ export async function loadCanarySvg(hexColor: string): Promise<string> {
 }
 
 // Bitcoin amount formatting for balances (no trailing zeros)
-export function formatBitcoinAmount(sats: number | null | undefined): string {
+export function formatBitcoinAmount(sats: number | null | undefined, locale: string): string {
   if (sats === null || sats === undefined) return "0 BTC"
 
   const btc = sats / 100_000_000
-  const formattedAmount = btc.toLocaleString(undefined, {
+  const formattedAmount = btc.toLocaleString(locale, {
     minimumFractionDigits: 0,
     maximumFractionDigits: 8
   })
@@ -183,12 +183,12 @@ export function formatBitcoinAmount(sats: number | null | undefined): string {
 }
 
 // Bitcoin amount formatting for transactions (full 8-digit precision)
-export function formatTransactionAmount(sats: number | null | undefined, eventType?: 'send' | 'receive'): string {
+export function formatTransactionAmount(sats: number | null | undefined, eventType: 'send' | 'receive' | undefined, locale: string): string {
   if (sats === null || sats === undefined) return "0.00000000 BTC"
 
   const absSats = Math.abs(sats)
   const btc = absSats / 100_000_000
-  const formattedAmount = btc.toLocaleString(undefined, {
+  const formattedAmount = btc.toLocaleString(locale, {
     minimumFractionDigits: 8,
     maximumFractionDigits: 8
   })
@@ -205,9 +205,9 @@ export function formatTransactionAmount(sats: number | null | undefined, eventTy
 }
 
 // Date formatting utilities
-export function formatDateTime(dateTime: string | number): string {
+export function formatDateTime(dateTime: string | number, locale: string): string {
   let date: Date
-  
+
   if (typeof dateTime === 'number') {
     // Convert Unix timestamp to milliseconds
     date = new Date(dateTime * 1000)
@@ -221,14 +221,14 @@ export function formatDateTime(dateTime: string | number): string {
       date = new Date(dateTime)
     }
   }
-  
+
   // Ensure valid date object
   if (isNaN(date.getTime())) {
     return "Invalid date"
   }
-  
-  // Use browser's locale with consistent formatting options
-  return date.toLocaleString(undefined, {
+
+  // Use user's preferred locale with consistent formatting options
+  return date.toLocaleString(locale, {
     year: '2-digit',
     month: '2-digit',
     day: '2-digit',
@@ -238,9 +238,9 @@ export function formatDateTime(dateTime: string | number): string {
   })
 }
 
-export function formatDate(dateTime: string): string {
+export function formatDate(dateTime: string, locale: string): string {
   const date = new Date(dateTime)
-  return date.toLocaleDateString()
+  return date.toLocaleDateString(locale)
 }
 
 // API utilities
@@ -373,8 +373,8 @@ export function btcToSats(btc: number): number {
   return Math.round(btc * 100_000_000)
 }
 
-export function formatBtcAmount(btc: number): string {
-  return btc.toLocaleString(undefined, {
+export function formatBtcAmount(btc: number, locale: string): string {
+  return btc.toLocaleString(locale, {
     minimumFractionDigits: 0,
     maximumFractionDigits: 8
   })


### PR DESCRIPTION
## Summary
- Add required `locale` parameter to formatting functions in `utils.ts`, `currencies.ts`, and `usePricing.ts`
- Create new `useFormatters()` hook that uses `useLocale()` from next-intl (following the established pattern in `useRelativeTime.ts`)
- Update 12 components to use locale-aware formatters instead of browser locale (`undefined`)

## Problem
The frontend was using browser locale (`undefined`) for all number formatting, while the backend properly uses the user's `preferred_language` setting with ICU4X. This created inconsistent formatting between the UI and notifications.

**Example**: A German browser user who sets Norwegian in settings would see:
- Frontend UI: `1.234,56` (German formatting from browser)
- Notifications: `1 234,56` (Norwegian formatting from backend)

## Test plan
- [ ] Start the frontend dev server: `cd frontend && pnpm dev`
- [ ] Login and navigate to Settings
- [ ] Change language to Norwegian (nb)
- [ ] Navigate to wallets page - verify amounts use Norwegian formatting (space as thousands separator, comma as decimal)
- [ ] Change language to German (de-DE) - verify German formatting (period as thousands separator, comma as decimal)
- [ ] Check balance alerts page - verify fiat and BTC amounts use the selected locale
- [ ] Check transaction list - verify amounts and dates use the selected locale
- [ ] Check the footer block height - verify it uses the selected locale for number formatting

## Testing completed
- [x] Automated tests pass (`pnpm test` - 101 tests passed)
- [x] Frontend build passes (`pnpm build`)
- [x] Frontend lint passes (`pnpm lint` - only pre-existing warnings)