### PR TITLE
fix(frontend): Change verification button label for better UX

### DIFF
--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "Verifikationskode",
       "codePlaceholder": "Indtast 6-cifret kode",
-      "sendCode": "Send verifikationskode",
+      "sendCode": "Verificer",
       "sendingCode": "Sender...",
       "verify": "Verificer",
       "verifying": "Verificerer...",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "Bestätigungscode",
       "codePlaceholder": "6-stelligen Code eingeben",
-      "sendCode": "Bestätigungscode senden",
+      "sendCode": "Verifizieren",
       "sendingCode": "Sende...",
       "verify": "Verifizieren",
       "verifying": "Verifiziere...",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "Verification Code",
       "codePlaceholder": "Enter 6-digit code",
-      "sendCode": "Send Verification Code",
+      "sendCode": "Verify",
       "sendingCode": "Sending...",
       "verify": "Verify",
       "verifying": "Verifying...",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "Código de verificación",
       "codePlaceholder": "Ingresa código de 6 dígitos",
-      "sendCode": "Enviar código de verificación",
+      "sendCode": "Verificar",
       "sendingCode": "Enviando...",
       "verify": "Verificar",
       "verifying": "Verificando...",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "Code de vérification",
       "codePlaceholder": "Entrez le code à 6 chiffres",
-      "sendCode": "Envoyer le code de vérification",
+      "sendCode": "Vérifier",
       "sendingCode": "Envoi...",
       "verify": "Vérifier",
       "verifying": "Vérification...",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "確認コード",
       "codePlaceholder": "6桁のコードを入力",
-      "sendCode": "確認コードを送信",
+      "sendCode": "確認",
       "sendingCode": "送信中...",
       "verify": "確認",
       "verifying": "確認中...",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "Verifiseringskode",
       "codePlaceholder": "Skriv inn 6-sifret kode",
-      "sendCode": "Send verifiseringskode",
+      "sendCode": "Verifiser",
       "sendingCode": "Sender...",
       "verify": "Verifiser",
       "verifying": "Verifiserer...",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "Código de verificação",
       "codePlaceholder": "Digite código de 6 dígitos",
-      "sendCode": "Enviar código de verificação",
+      "sendCode": "Verificar",
       "sendingCode": "Enviando...",
       "verify": "Verificar",
       "verifying": "Verificando...",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -614,7 +614,7 @@
     "verification": {
       "codeLabel": "Verifieringskod",
       "codePlaceholder": "Ange 6-siffrig kod",
-      "sendCode": "Skicka verifieringskod",
+      "sendCode": "Verifiera",
       "sendingCode": "Skickar...",
       "verify": "Verifiera",
       "verifying": "Verifierar...",

--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -193,7 +193,7 @@ describe('ContactModal', () => {
       await user.type(phoneInput, '+4712345678')
 
       // Verification button should appear
-      expect(screen.getByText('Send Verification Code')).toBeInTheDocument()
+      expect(screen.getByText('Verify')).toBeInTheDocument()
     })
 
     it('sends SMS verification and shows code input', async () => {
@@ -214,7 +214,7 @@ describe('ContactModal', () => {
       await user.type(phoneInput, '+4712345678')
 
       // Send verification
-      await user.click(screen.getByText('Send Verification Code'))
+      await user.click(screen.getByText('Verify'))
 
       await waitFor(() => {
         expect(mockApi.sendContactVerification).toHaveBeenCalledWith(
@@ -248,7 +248,7 @@ describe('ContactModal', () => {
       await user.type(phoneInput, '+4712345678')
 
       // Send and verify
-      await user.click(screen.getByText('Send Verification Code'))
+      await user.click(screen.getByText('Verify'))
 
       await waitFor(() => {
         expect(screen.getByLabelText('Verification Code')).toBeInTheDocument()
@@ -293,7 +293,7 @@ describe('ContactModal', () => {
       const phoneInput = screen.getByPlaceholderText('+1 234 567 8900')
       await user.type(phoneInput, '+4712345678')
 
-      await user.click(screen.getByText('Send Verification Code'))
+      await user.click(screen.getByText('Verify'))
 
       await waitFor(() => {
         expect(screen.getByLabelText('Verification Code')).toBeInTheDocument()
@@ -349,7 +349,7 @@ describe('ContactModal', () => {
       const emailInput = screen.getByPlaceholderText('your@email.com')
       await user.type(emailInput, 'test@example.com')
 
-      expect(screen.getByText('Send Verification Code')).toBeInTheDocument()
+      expect(screen.getByText('Verify')).toBeInTheDocument()
     })
 
     it('handles auto-verified email (user\'s own email)', async () => {
@@ -373,7 +373,7 @@ describe('ContactModal', () => {
       const emailInput = screen.getByPlaceholderText('your@email.com')
       await user.type(emailInput, 'your@email.com')
 
-      await user.click(screen.getByText('Send Verification Code'))
+      await user.click(screen.getByText('Verify'))
 
       await waitFor(() => {
         expect(screen.getAllByText((content, element) => {
@@ -402,7 +402,7 @@ describe('ContactModal', () => {
       await user.type(emailInput, 'test@example.com')
 
       // Send verification
-      await user.click(screen.getByText('Send Verification Code'))
+      await user.click(screen.getByText('Verify'))
 
       await waitFor(() => {
         expect(screen.getByLabelText('Verification Code')).toBeInTheDocument()
@@ -446,7 +446,7 @@ describe('ContactModal', () => {
       expect(phoneInput.value).toBe('+4799999999')
 
       // Should show as already verified (no verification button)
-      expect(screen.queryByText('Send Verification Code')).not.toBeInTheDocument()
+      expect(screen.queryByText('Verify')).not.toBeInTheDocument()
     })
 
     it('requires verification when phone number changes in edit mode', async () => {
@@ -466,7 +466,7 @@ describe('ContactModal', () => {
       await user.type(phoneInput, '+4788888888')
 
       // Verification button should appear
-      expect(screen.getByText('Send Verification Code')).toBeInTheDocument()
+      expect(screen.getByText('Verify')).toBeInTheDocument()
     })
 
     it('reverts to verified state when phone number reverts to original', async () => {
@@ -485,14 +485,14 @@ describe('ContactModal', () => {
       // Change phone number
       await user.clear(phoneInput)
       await user.type(phoneInput, '+4788888888')
-      expect(screen.getByText('Send Verification Code')).toBeInTheDocument()
+      expect(screen.getByText('Verify')).toBeInTheDocument()
 
       // Revert to original
       await user.clear(phoneInput)
       await user.type(phoneInput, '+4799999999')
       
       // Should be verified again
-      expect(screen.queryByText('Send Verification Code')).not.toBeInTheDocument()
+      expect(screen.queryByText('Verify')).not.toBeInTheDocument()
     })
   })
 
@@ -515,7 +515,7 @@ describe('ContactModal', () => {
       // Verify all provider sections are visible
       expect(screen.getByPlaceholderText('+1 234 567 8900')).toBeInTheDocument()
       expect(screen.getByPlaceholderText('your@email.com')).toBeInTheDocument()
-      expect(screen.getAllByText('Send Verification Code')).toHaveLength(2) // SMS and Email verification buttons
+      expect(screen.getAllByText('Verify')).toHaveLength(2) // SMS and Email verification buttons
     })
   })
 
@@ -557,7 +557,7 @@ describe('ContactModal', () => {
 
       const phoneInput = screen.getByPlaceholderText('+1 234 567 8900')
       await user.type(phoneInput, 'invalid')
-      await user.click(screen.getByText('Send Verification Code'))
+      await user.click(screen.getByText('Verify'))
 
       await waitFor(() => {
         expect(screen.getAllByText((content, element) => {

--- a/frontend/src/hooks/useSmsVerification.ts
+++ b/frontend/src/hooks/useSmsVerification.ts
@@ -107,17 +107,23 @@ export function useSmsVerification({
     setPhoneError(null)
 
     try {
-      await api.sendContactVerification(
+      const result = await api.sendContactVerification(
         walletChecksum,
         contactName || `Contact-${phoneNumber.slice(-4)}`,
         phoneNumber,
         undefined
       )
 
-      setVerificationPhone(phoneNumber)
-      setVerificationSent(true)
-      setVerificationCode("")
-      startTimer()
+      // Check if phone was auto-verified (cross-wallet verification)
+      if (result.auto_verified) {
+        setIsVerified(true)
+        setShowSuccess(true)
+      } else {
+        setVerificationPhone(phoneNumber)
+        setVerificationSent(true)
+        setVerificationCode("")
+        startTimer()
+      }
     } catch (err) {
       let errorMessage: string
       if (err instanceof ApiError) {
@@ -197,14 +203,21 @@ export function useSmsVerification({
     setVerificationError(null)
 
     try {
-      await api.sendContactVerification(
+      const result = await api.sendContactVerification(
         walletChecksum,
         contactName,
         verificationPhone
       )
 
-      setVerificationCode("")
-      startTimer()
+      // Check if phone was auto-verified (cross-wallet verification)
+      if (result.auto_verified) {
+        setIsVerified(true)
+        setShowSuccess(true)
+        clearTimer()
+      } else {
+        setVerificationCode("")
+        startTimer()
+      }
     } catch (err) {
       if (err instanceof ApiError) {
         onError?.(err.isNetworkError() || err.isServerError()


### PR DESCRIPTION
## Summary
- Rename "Send Verification Code" to "Verify" in all 9 languages
- Fix `useSmsVerification` hook to handle `auto_verified` response from backend
- Better UX when contacts are auto-verified via cross-wallet verification (PR #151)

## Bug Fixed
The SMS verification hook wasn't checking for `auto_verified` in the API response, causing the code input to show even when the backend had already auto-verified the phone number.

## Changes
**Translation files** - Updated `sendCode` key in all locale files:
- 🇺🇸 en-US: "Verify"
- 🇳🇴 nb: "Verifiser"
- 🇪🇸 es-419: "Verificar"
- 🇧🇷 pt-BR: "Verificar"
- 🇩🇪 de-DE: "Verifizieren"
- 🇫🇷 fr-FR: "Vérifier"
- 🇯🇵 ja: "確認"
- 🇩🇰 da: "Verificer"
- 🇸🇪 sv: "Verifiera"

**Hook fix** - `useSmsVerification.ts`:
- Check `result.auto_verified` in `sendVerification()` and `resendCode()`
- Set `isVerified=true` and `showSuccess=true` when auto-verified

## Test plan
- [x] All 101 frontend tests pass
- [x] Manual test: Adding phone number already verified on another wallet auto-verifies instantly