### PR TITLE
fix(frontend): Preserve unchanged notification methods when editing contacts

### DIFF
--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -18,6 +18,7 @@ jest.mock('../../lib/api', () => {
       sendContactVerification: jest.fn(),
       verifyContact: jest.fn(),
       createContact: jest.fn(),
+      updateContact: jest.fn(),
       deleteContact: jest.fn(),
     },
   }
@@ -481,7 +482,7 @@ describe('ContactModal', () => {
       })
 
       const phoneInput = screen.getByPlaceholderText('+1 234 567 8900')
-      
+
       // Change phone number
       await user.clear(phoneInput)
       await user.type(phoneInput, '+4788888888')
@@ -490,9 +491,59 @@ describe('ContactModal', () => {
       // Revert to original
       await user.clear(phoneInput)
       await user.type(phoneInput, '+4799999999')
-      
+
       // Should be verified again
       expect(screen.queryByText('Verify')).not.toBeInTheDocument()
+    })
+
+    it('preserves unchanged email when editing contact name', async () => {
+      // Contact with email
+      const contactWithEmail = {
+        id: 2,
+        name: 'Email Contact',
+        created_at: '2024-01-01T00:00:00Z',
+        notification_methods: [
+          {
+            id: 2,
+            provider_type: 'email' as const,
+            notification_target: 'test@example.com',
+            display_target: 'test@example.com',
+            verified: true,
+            created_at: '2024-01-01T00:00:00Z',
+          },
+        ],
+      }
+
+      const user = userEvent.setup()
+      mockApi.updateContact.mockResolvedValue({ id: 2 })
+
+      await act(async () => {
+        render(<ContactModal {...defaultProps} editContact={contactWithEmail} />)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Email Notifications')).toBeInTheDocument()
+      })
+
+      // Change only the name (email unchanged)
+      const nameInput = screen.getByLabelText('Name')
+      await user.clear(nameInput)
+      await user.type(nameInput, 'Updated Name')
+
+      // Submit the form
+      await user.click(screen.getByRole('button', { name: /Update Contact/i }))
+
+      // Check that updateContact was called with the unchanged email preserved
+      await waitFor(() => {
+        expect(mockApi.updateContact).toHaveBeenCalledWith(
+          'test-checksum',
+          2,
+          'Updated Name',
+          expect.arrayContaining([
+            expect.objectContaining({ provider_type: 'email', notification_target: 'test@example.com' }),
+          ])
+        )
+      })
     })
   })
 

--- a/frontend/src/components/contact-modal.tsx
+++ b/frontend/src/components/contact-modal.tsx
@@ -250,17 +250,25 @@ export function ContactModal({
     setIsSubmitting(true)
     setError(null)
 
+    // Check if unchanged methods in edit mode (already verified when first added)
+    const emailUnchangedInEditMode = isEditMode && !emailAddressChanged && originalState.emailEnabled
+    const smsUnchangedInEditMode = isEditMode && !phoneNumberChanged && originalState.smsEnabled
+
+    // SMS is ready if: not enabled, OR verified, OR unchanged in edit mode
+    const smsReady = !hasSms || smsVerification.isVerified || smsUnchangedInEditMode
+    // Email is ready if: not enabled, OR verified, OR unchanged in edit mode
+    const emailReady = !hasEmail || emailVerification.isVerified || emailUnchangedInEditMode
+
     try {
       // If verification requirements are met
-      if ((!hasSms || (hasSms && smsVerification.isVerified)) && (!hasEmail || (hasEmail && emailVerification.isVerified))) {
+      if (smsReady && emailReady) {
         const notificationMethods: { provider_type: 'sms' | 'ntfy' | 'email'; notification_target: string }[] = []
 
         if (hasNtfy) {
           notificationMethods.push({ provider_type: 'ntfy', notification_target: ntfyTopic.trim() })
         }
 
-        // Include email if verified OR if unchanged in edit mode (already verified when first added)
-        const emailUnchangedInEditMode = isEditMode && !emailAddressChanged && originalState.emailEnabled
+        // Include email if verified OR if unchanged in edit mode
         if (hasEmail && (emailVerification.isVerified || emailUnchangedInEditMode)) {
           notificationMethods.push({
             provider_type: 'email',
@@ -268,8 +276,7 @@ export function ContactModal({
           })
         }
 
-        // Include SMS if verified OR if unchanged in edit mode (already verified when first added)
-        const smsUnchangedInEditMode = isEditMode && !phoneNumberChanged && originalState.smsEnabled
+        // Include SMS if verified OR if unchanged in edit mode
         if (hasSms && (smsVerification.isVerified || smsUnchangedInEditMode)) {
           notificationMethods.push({
             provider_type: 'sms',


### PR DESCRIPTION
## Summary
Fixes a bug where unchanged notification methods (e.g., email) were deleted when editing a contact to add/modify another method (e.g., SMS with auto-verification).

## Problem
When editing a contact:
1. Contact has both email and SMS
2. User removes SMS, then re-adds it with the same number
3. SMS auto-verifies (cross-wallet verification from PR #151)
4. User saves → **email disappears**

The root cause: The backend deletes all notification methods and re-inserts only what's sent in the request. The frontend was only including methods where `verification.isVerified === true`, but for unchanged methods, the verification hook state could become inconsistent during complex edit flows.

## Solution
For unchanged notification methods in edit mode, include them regardless of verification hook state:
- If email is enabled AND (verified OR unchanged from original) → include
- If SMS is enabled AND (verified OR unchanged from original) → include

This is safe because unchanged methods were already verified when originally added.

## Test plan
- [x] All 101 frontend tests pass
- [x] Manual test: Edit contact with email+SMS, remove SMS, re-add same SMS (auto-verifies), save → email preserved