### PR TITLE
Add GitHub link to footer in self-hosted mode

### DIFF
--- a/frontend/src/components/app-footer.tsx
+++ b/frontend/src/components/app-footer.tsx
@@ -1,15 +1,18 @@
 "use client"
 
 import Image from "next/image"
+import { Github } from "lucide-react"
 import { useBlockHeader } from "@/hooks/useBlockHeader"
 import { useRelativeTime } from "@/hooks/useRelativeTime"
 import { useFormatters } from "@/hooks/useFormatters"
+import { useAuth } from "@/contexts/auth-context"
 import { BuildInfo } from "./build-info"
 import { useTranslations } from "next-intl"
 
 export function AppFooter() {
   const { blockHeader } = useBlockHeader()
   const blockHeaderTime = useRelativeTime(blockHeader?.timestamp)
+  const { isCloudMode } = useAuth()
   const t = useTranslations('footer')
   const tCommon = useTranslations('common')
   const { formatNumber } = useFormatters()
@@ -37,7 +40,20 @@ export function AppFooter() {
           </div>
         </div>
 
-        <BuildInfo />
+        <div className="flex items-center gap-3">
+          {!isCloudMode && (
+            <a
+              href="https://github.com/schjonhaug/canary"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Github className="h-5 w-5" />
+            </a>
+          )}
+          {isCloudMode && <BuildInfo />}
+        </div>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary
- Add a GitHub icon link to the footer in self-hosted mode, pointing to the project repository
- Only show BuildInfo (commit hash) in cloud mode, since it doesn't work in Docker/Umbrel deployments anyway

## Test plan
- [ ] Run `pnpm build` and `pnpm lint` — no new errors
- [ ] In self-hosted mode: GitHub icon visible in footer, no build info shown
- [ ] In cloud mode: Build info shown in footer, no GitHub icon