### PR TITLE
docs: Add Umbrel ntfy server URL note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Real-time notifications in 9 languages via **[ntfy.sh](https://ntfy.sh)** push n
 
 **Supported Languages:** English, Norwegian, Spanish, Portuguese, German, French, Japanese, Danish, Swedish
 
+> **Umbrel / Docker note:** When running on Umbrel, the ntfy server URL in Settings must use the Docker internal hostname — not the URL you use in your browser. For example, if you access ntfy at `http://umbrel.local:13119`, the correct value in Canary's Settings is typically `http://ntfy_app_1` (the Docker container name). This is because the Canary backend sends notifications server-side from within the Docker network. Use "Send Test Notification" in Settings to verify your configuration.
+
 ## Self-Hosted vs. canarybitcoin.com
 
 | | Self-Hosted | [canarybitcoin.com](https://canarybitcoin.com) |


### PR DESCRIPTION
## Summary

- Add a note to the Notifications section in README explaining that Umbrel users need to use the Docker internal hostname (e.g., `http://ntfy_app_1`) as the ntfy server URL in Settings, not the browser-accessible URL (`http://umbrel.local:13119`)

This addresses confusion from users running both Canary and ntfy as Docker containers on Umbrel, where the backend sends notifications server-side from within the Docker network.

Ref: https://github.com/schjonhaug/canary/issues/167#issuecomment-3936363568