### PR TITLE
fix(frontend): Clean up setTimeout in billing success useEffect

### DIFF
--- a/frontend/src/app/subscription/success.tsx
+++ b/frontend/src/app/subscription/success.tsx
@@ -33,34 +33,48 @@ export default function BillingSuccessPage() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let isMounted = true
     let timeoutId: ReturnType<typeof setTimeout>
 
     const fetchSessionDetails = async () => {
       if (!sessionId) {
-        setError('No session ID provided')
-        setLoading(false)
+        if (isMounted) {
+          setError('No session ID provided')
+          setLoading(false)
+        }
         return
       }
 
       try {
         setLoading(true)
         const details = await api.getCheckoutSessionDetails(sessionId)
+        if (!isMounted) return
+
         setSessionDetails(details)
 
         // Refresh billing status to get updated subscription
         timeoutId = setTimeout(() => {
-          refreshBillingStatus()
+          if (isMounted) {
+            refreshBillingStatus()
+          }
         }, 2000)
       } catch (err) {
         console.error('Failed to fetch session details:', err)
-        setError('Failed to load payment details')
+        if (isMounted) {
+          setError('Failed to load payment details')
+        }
       } finally {
-        setLoading(false)
+        if (isMounted) {
+          setLoading(false)
+        }
       }
     }
 
     fetchSessionDetails()
-    return () => clearTimeout(timeoutId)
+    return () => {
+      isMounted = false
+      clearTimeout(timeoutId)
+    }
   }, [sessionId, refreshBillingStatus])
 
   if (loading) {


### PR DESCRIPTION
## Summary
- Add cleanup function to the `useEffect` in the billing success page that clears the 2-second `setTimeout` for `refreshBillingStatus`
- Prevents state updates on unmounted components if the user navigates away before the timer fires

Closes #175