### PR TITLE
fix(docker): Upgrade Rust to 1.88 for time crate compatibility

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for Rust
-FROM rust:1.85-slim AS rust-builder
+FROM rust:1.88-slim AS rust-builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Upgrades Docker Rust image from 1.85-slim to 1.88-slim
- Fixes canary deployment failure caused by `time` crate v0.3.47 requiring rustc 1.88.0

## Context
The dependency upgrade in #178 pulled in `time@0.3.47` which has a minimum supported Rust version of 1.88.0. The Docker build was failing with:
```
error: rustc 1.85.1 is not supported by the following packages:
  time@0.3.47 requires rustc 1.88.0
```

## Test plan
- [ ] Verify Docker build succeeds with `./docker.sh build`
- [ ] Verify canary deployment succeeds after merge