### PR TITLE
Use Next.js Link instead of anchor tag in billing cancel page

### DIFF
--- a/frontend/src/app/subscription/cancel.tsx
+++ b/frontend/src/app/subscription/cancel.tsx
@@ -34,10 +34,10 @@ export default function BillingCancelPage() {
             <h3 className="font-semibold">What would you like to do?</h3>
             <div className="grid gap-3">
               <Button asChild>
-                <a href="/subscription">
+                <Link href="/subscription">
                   <ArrowLeft className="mr-2 h-4 w-4" />
                   Try Again
-                </a>
+                </Link>
               </Button>
 
               <Button variant="outline" asChild>


### PR DESCRIPTION
## Summary
- Replace plain `<a href="/subscription">` with `<Link href="/subscription">` in the billing cancel page to enable client-side navigation instead of a full page reload
- The `Link` import was already present; other `<a>` tags in the file are `mailto:` links (correct usage)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` passes (no new issues)
- [x] `pnpm test` passes (114/114)

Closes #176