### PR TITLE
fix: Move useEffect above early returns in subscription page

### DIFF
--- a/frontend/src/app/subscription/page.tsx
+++ b/frontend/src/app/subscription/page.tsx
@@ -26,15 +26,15 @@ export default function SubscriptionPage() {
   const [isPortalLoading, setIsPortalLoading] = useState(false)
   const [showUpgradeModal, setShowUpgradeModal] = useState(false)
 
-  if (isSuccess) return <BillingSuccessPage />
-  if (isCancelled) return <BillingCancelPage />
-
   useEffect(() => {
     // Only refresh billing status when auth is ready and user is logged in
     if (!isLoading && user) {
       refreshBillingStatus()
     }
   }, [refreshBillingStatus, isLoading, user])
+
+  if (isSuccess) return <BillingSuccessPage />
+  if (isCancelled) return <BillingCancelPage />
 
   const handleManageBilling = async () => {
     if (!billingStatus?.stripe_customer_id) return


### PR DESCRIPTION
## Summary
- Moves the `useEffect` hook above the conditional early returns for `isSuccess`/`isCancelled` in the subscription page, fixing a React Rules of Hooks violation

## Test plan
- [ ] Navigate to `/subscription?success=true` — verify the success page renders correctly
- [ ] Navigate to `/subscription?cancelled=true` — verify the cancel page renders correctly
- [ ] Navigate to `/subscription` (no query params) — verify the main subscription page renders with billing status
- [ ] Navigate from `/subscription?success=true` to `/subscription` — verify no "Rendered fewer hooks than expected" error

Closes #180