### PR TITLE
Fix test import of private metadata::types module

### DIFF
--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -372,8 +372,7 @@ fn test_twilio_locale_all_languages_are_valid() {
 // Cross-wallet verification tests
 // ============================
 
-use crate::metadata::types::{EventType, TransactionInsert};
-use crate::metadata::ProviderType;
+use crate::metadata::{EventType, ProviderType, TransactionInsert};
 
 #[tokio::test]
 async fn test_cross_wallet_verification_same_user_sms() {


### PR DESCRIPTION
## Summary
- Fix test compilation error in `metadata.rs` where `EventType` and `TransactionInsert` were imported directly from the private `crate::metadata::types` module instead of using the public re-exports from `crate::metadata`

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test -- --test-threads=1` passes (135 unit + 54 integration tests)