### PR TITLE
Fix notifications for historical txs on single address wallets

### DIFF
--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -1736,12 +1736,14 @@ impl WalletSyncService {
             .update_wallet_last_synced(wallet_checksum)
             .await;
 
-        // Check balance alerts
-        if let Err(e) = self
-            .check_balance_alerts(wallet_checksum, total_balance)
-            .await
-        {
-            warn!("[{}] Balance alert checking failed: {}", wallet_checksum, e);
+        // Check balance alerts (skip during initial sync to avoid spurious alerts)
+        if !suppress_notifications {
+            if let Err(e) = self
+                .check_balance_alerts(wallet_checksum, total_balance)
+                .await
+            {
+                warn!("[{}] Balance alert checking failed: {}", wallet_checksum, e);
+            }
         }
 
         let sync_duration = sync_start.elapsed();
@@ -2026,12 +2028,14 @@ impl WalletSyncService {
                 .update_wallet_last_synced(wallet_checksum)
                 .await;
 
-            // Check balance alerts for this watcher
-            if let Err(e) = self
-                .check_balance_alerts(wallet_checksum, total_balance)
-                .await
-            {
-                warn!("[{}] Balance alert checking failed: {}", wallet_checksum, e);
+            // Check balance alerts for this watcher (skip during initial sync)
+            if !suppress_notifications {
+                if let Err(e) = self
+                    .check_balance_alerts(wallet_checksum, total_balance)
+                    .await
+                {
+                    warn!("[{}] Balance alert checking failed: {}", wallet_checksum, e);
+                }
             }
 
             if has_changes {

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -1062,13 +1062,13 @@ impl WalletManager {
                             watchers.iter().map(|w| w.checksum.clone()).collect();
 
                         if watcher_count == 1 {
-                            // Single watcher — use existing method
+                            // Single watcher — ongoing background sync, notifications enabled
                             match sync_service
                                 .sync_address_watch(
                                     &checksums[0],
                                     &descriptor,
                                     electrum_manager.as_deref(),
-                                    false,
+                                    false, // ongoing sync — send notifications for new txs
                                 )
                                 .await
                             {
@@ -1082,13 +1082,13 @@ impl WalletManager {
                                 }
                             }
                         } else {
-                            // Multiple watchers — query Electrum once, fan out results
+                            // Multiple watchers — ongoing background sync, notifications enabled
                             match sync_service
                                 .sync_address_watch_group(
                                     &checksums,
                                     &descriptor,
                                     electrum_manager.as_deref(),
-                                    false,
+                                    false, // ongoing sync — send notifications for new txs
                                 )
                                 .await
                             {


### PR DESCRIPTION
## Summary
- Single address wallets (`addr()` / `pk()`) were sending email notifications for all pre-existing historical transactions when first added — output descriptor wallets already suppressed these correctly
- Added `suppress_notifications` parameter to `sync_address_watch()` and `sync_address_watch_group()` to skip notifications during the initial sync while keeping them active for ongoing periodic syncs

## Test plan
- [ ] Add a single address wallet with known historical transactions — verify no notification emails are sent for existing transactions
- [ ] After the wallet is synced, send a new transaction to the address — verify notification is sent
- [ ] Add an output descriptor wallet — verify behavior is unchanged (no regression)
- [ ] Verify grouped address watch sync (multiple users watching same address) also suppresses on initial load