### PR TITLE
Fix API proxy following redirects instead of passing them through

### DIFF
--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -87,6 +87,7 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
       method: request.method,
       headers,
       body,
+      redirect: 'manual',
       signal: AbortSignal.timeout(30_000),
     });
 


### PR DESCRIPTION
## Summary
- Add `redirect: 'manual'` to the proxy fetch so backend 302 responses (e.g. donation redirects to BTCPay) are returned to the browser instead of being followed server-side

Without this fix, the Next.js API proxy follows 302 redirects from the backend, fetches the target page server-side, and returns the raw HTML (without CSS/JS) to the browser.

## Test plan
- [ ] Visit `/api/donations/one-time` and verify browser redirects to BTCPay checkout
- [ ] Visit `/api/donations/recurring` and verify browser redirects to BTCPay plan checkout
- [ ] Verify existing API calls (wallets, contacts, auth) still work correctly