### PR TITLE
Remove locale passthrough from donation flow

### DIFF
--- a/backend/src/handlers/donations.rs
+++ b/backend/src/handlers/donations.rs
@@ -1,27 +1,8 @@
 use crate::api::BtcPayClientState;
 use crate::config::AppConfig;
-use axum::extract::{Query, State};
+use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
-use serde::Deserialize;
-
-const SUPPORTED_LOCALES: &[&str] = &[
-    "en-US", "nb", "es-419", "pt-BR", "de-DE", "fr-FR", "ja", "da", "sv",
-];
-
-#[derive(Deserialize)]
-pub struct DonationParams {
-    locale: Option<String>,
-}
-
-impl DonationParams {
-    /// Return the locale only if it matches a supported value.
-    fn validated_locale(&self) -> Option<&str> {
-        self.locale
-            .as_deref()
-            .filter(|l| SUPPORTED_LOCALES.contains(l))
-    }
-}
 
 pub(crate) fn redirect_response(url: &str) -> Response {
     let mut headers = HeaderMap::new();
@@ -37,19 +18,14 @@ pub(crate) fn redirect_response(url: &str) -> Response {
     }
 }
 
-pub(crate) fn thank_you_url(config: &AppConfig, locale: Option<&str>) -> String {
+pub(crate) fn thank_you_url(config: &AppConfig) -> String {
     let frontend_url = config.frontend_url().unwrap_or("https://canarybitcoin.com");
-    let base = format!("{}/donations/thank-you", frontend_url.trim_end_matches('/'));
-    match locale {
-        Some(l) => format!("{}?locale={}", base, l),
-        None => base,
-    }
+    format!("{}/donations/thank-you", frontend_url.trim_end_matches('/'))
 }
 
 pub async fn donate_one_time(
     State(btcpay): State<BtcPayClientState>,
     State(config): State<crate::api::ConfigState>,
-    Query(params): Query<DonationParams>,
 ) -> Response {
     let client = match &btcpay {
         Some(c) => c,
@@ -58,7 +34,7 @@ pub async fn donate_one_time(
         }
     };
 
-    let redirect_url = thank_you_url(&config, params.validated_locale());
+    let redirect_url = thank_you_url(&config);
 
     match client.create_invoice(&redirect_url).await {
         Ok(checkout_link) => redirect_response(&checkout_link),
@@ -72,7 +48,6 @@ pub async fn donate_one_time(
 pub async fn donate_recurring(
     State(btcpay): State<BtcPayClientState>,
     State(config): State<crate::api::ConfigState>,
-    Query(params): Query<DonationParams>,
 ) -> Response {
     let client = match &btcpay {
         Some(c) => c,
@@ -81,7 +56,7 @@ pub async fn donate_recurring(
         }
     };
 
-    let redirect_url = thank_you_url(&config, params.validated_locale());
+    let redirect_url = thank_you_url(&config);
 
     match client.create_plan_checkout(&redirect_url).await {
         Ok(checkout_url) => redirect_response(&checkout_url),

--- a/backend/src/tests/donations.rs
+++ b/backend/src/tests/donations.rs
@@ -117,7 +117,7 @@ fn test_thank_you_url_with_frontend_url() {
 
     let config = test_config();
     assert_eq!(
-        thank_you_url(&config, None),
+        thank_you_url(&config),
         "http://localhost:3001/donations/thank-you"
     );
 }
@@ -136,7 +136,7 @@ fn test_thank_you_url_strips_trailing_slash() {
         None,
     );
     assert_eq!(
-        thank_you_url(&config, None),
+        thank_you_url(&config),
         "http://localhost:3001/donations/thank-you"
     );
 }
@@ -155,29 +155,7 @@ fn test_thank_you_url_fallback_without_frontend_url() {
         None,
     );
     assert_eq!(
-        thank_you_url(&config, None),
+        thank_you_url(&config),
         "https://canarybitcoin.com/donations/thank-you"
-    );
-}
-
-#[test]
-fn test_thank_you_url_with_locale() {
-    use crate::handlers::donations::thank_you_url;
-
-    let config = test_config();
-    assert_eq!(
-        thank_you_url(&config, Some("nb")),
-        "http://localhost:3001/donations/thank-you?locale=nb"
-    );
-}
-
-#[test]
-fn test_thank_you_url_without_locale() {
-    use crate::handlers::donations::thank_you_url;
-
-    let config = test_config();
-    assert_eq!(
-        thank_you_url(&config, None),
-        "http://localhost:3001/donations/thank-you"
     );
 }

--- a/frontend/src/app/donations/page.tsx
+++ b/frontend/src/app/donations/page.tsx
@@ -2,13 +2,12 @@
 
 import { Heart } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
-import { useTranslations, useLocale } from "next-intl"
+import { useTranslations } from "next-intl"
 import { AppHeader } from "@/components/app-header"
 import { AppFooter } from "@/components/app-footer"
 
 export default function DonationsPage() {
   const t = useTranslations("donation")
-  const locale = useLocale()
 
   // Points to the backend API which handles BTCPay redirects.
   // In development this is localhost:3000 (backend), not localhost:3001 (frontend dev server).
@@ -36,7 +35,7 @@ export default function DonationsPage() {
                 {t("oneTimeDescription")}
               </p>
               <a
-                href={`${donationsBaseUrl}/api/donations/one-time?locale=${locale}`}
+                href={`${donationsBaseUrl}/api/donations/one-time`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-block w-full rounded-md border border-border bg-background px-4 py-2.5 text-center text-sm font-medium transition-colors hover:bg-accent"
@@ -53,7 +52,7 @@ export default function DonationsPage() {
                 {t("recurringDescription")}
               </p>
               <a
-                href={`${donationsBaseUrl}/api/donations/recurring?locale=${locale}`}
+                href={`${donationsBaseUrl}/api/donations/recurring`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-block w-full rounded-md bg-primary px-4 py-2.5 text-center text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"

--- a/frontend/src/i18n/request.ts
+++ b/frontend/src/i18n/request.ts
@@ -31,24 +31,17 @@ function detectLocale(acceptLanguage: string | null): Locale {
 }
 
 export default getRequestConfig(async () => {
-  const headerStore = await headers()
   const cookieStore = await cookies()
-
-  // Check for locale override from query param (set by middleware)
-  const localeOverride = headerStore.get('x-locale-override') as Locale | null
+  const cookieLocale = cookieStore.get('locale')?.value as Locale | undefined
 
   let locale: Locale
-  if (localeOverride && locales.includes(localeOverride)) {
-    locale = localeOverride
+  if (cookieLocale && locales.includes(cookieLocale)) {
+    locale = cookieLocale
   } else {
-    const cookieLocale = cookieStore.get('locale')?.value as Locale | undefined
-    if (cookieLocale && locales.includes(cookieLocale)) {
-      locale = cookieLocale
-    } else {
-      // No cookie yet - detect from Accept-Language header (first visit)
-      const acceptLanguage = headerStore.get('accept-language')
-      locale = detectLocale(acceptLanguage)
-    }
+    // No cookie yet - detect from Accept-Language header (first visit)
+    const headerStore = await headers()
+    const acceptLanguage = headerStore.get('accept-language')
+    locale = detectLocale(acceptLanguage)
   }
 
   return {

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -36,21 +36,6 @@ function detectLocale(acceptLanguage: string | null): Locale {
 }
 
 export function proxy(request: NextRequest) {
-  // If a locale query param is present and valid, use it to override the locale.
-  // This allows external redirects (e.g. BTCPay) to preserve the user's locale.
-  const localeParam = request.nextUrl.searchParams.get('locale')
-  if (localeParam && locales.includes(localeParam as Locale)) {
-    const requestHeaders = new Headers(request.headers)
-    requestHeaders.set('x-locale-override', localeParam)
-    const response = NextResponse.next({ request: { headers: requestHeaders } })
-    response.cookies.set('locale', localeParam as Locale, {
-      maxAge: 60 * 60 * 24 * 365, // 1 year
-      path: '/',
-      sameSite: 'lax',
-    })
-    return response
-  }
-
   const localeCookie = request.cookies.get('locale')?.value
 
   // Already has a valid locale preference


### PR DESCRIPTION
## Summary
- Remove the `?locale=` query param passthrough from the donation flow
- Both BTCPay checkout pages and the thank-you page now rely on the browser's `Accept-Language` header for language detection
- This ensures consistent behavior between one-time and recurring flows, since BTCPay's plan-checkout endpoint has no language parameter

## Test plan
- [ ] Visit `/donations`, click one-time donate — BTCPay checkout respects browser language
- [ ] Visit `/donations`, click recurring donate — BTCPay checkout respects browser language
- [ ] Complete a donation — thank-you page renders in browser language
- [ ] `cd frontend && pnpm build && pnpm test` passes
- [ ] `cd backend && cargo build && cargo test -- --test-threads=1` passes