### PR TITLE
Replace O(n²) sync lookups with HashMap for O(1) access

### DIFF
--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -569,7 +569,11 @@ impl WalletSyncService {
         // Get ALL transactions (including non-canonical/conflicted ones) for RBF detection
         let canonical_txids: std::collections::HashSet<Txid> = canonical_transactions_data
             .iter()
-            .filter_map(|(txid, _, _, _, _, _)| Txid::from_str(txid).ok())
+            .filter_map(|(txid, _, _, _, _, _)| {
+                Txid::from_str(txid)
+                    .inspect_err(|e| warn!("[{}] Failed to parse canonical txid {}: {}", wallet_checksum, txid, e))
+                    .ok()
+            })
             .collect();
 
         // Find transactions that exist in full graph but NOT in canonical set (these are conflicted/replaced)


### PR DESCRIPTION
## Summary

- Replace all 8 `.find()` calls in `sync.rs` that linearly scanned transaction collections inside loops, creating O(n²) complexity
- Build `bdk_tx_map` and `existing_tx_map` HashMaps for O(1) lookups in RBF detection, CPFP detection, and address-based confirmation tracking

## Benchmark results

Tested with a 673-transaction stress wallet (48 unconfirmed, active CPFP chains) on regtest:

| Metric | Before (O(n²) `.find()`) | After (O(1) HashMap) | Speedup |
|--------|--------------------------|----------------------|---------|
| **CPFP detection** | 72.56ms, 74.02ms | 3.04ms, 3.05ms, 3.10ms | **~24x** |
| **End-to-end tx processing** | 120.39ms, 116.21ms | 36.13ms, 36.16ms, 36.58ms | **~3.3x** |

The improvement grows quadratically with transaction count — at 50K+ transactions the O(n²) pattern would take minutes.

## Changes

**Descriptor wallet sync** (RBF/CPFP detection):
- Build `bdk_tx_map` HashMap after collecting BDK transactions
- Replace 4 `.find()` calls in RBF conflict and CPFP child/parent lookups

**Address-based wallet sync** (confirmation tracking):
- Build `existing_tx_map` HashMap from existing transactions
- Replace 2 `.find()` calls in single-address sync
- Replace 2 `.find()` calls in grouped address watch sync

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test -- --test-threads=1` — all 147 tests pass
- [x] Stress tested with `./dev.sh create-stress-wallet 500` (624 transactions)
- [x] Benchmarked BEFORE vs AFTER with unconfirmed CPFP chains

Closes #236