### PR TITLE
Fix #247: Use borrowed &str keys for existing_tx_map in process_wallet_transactions

### DIFF
--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -412,11 +412,11 @@ impl WalletSyncService {
 
         // Create HashMap for O(1) transaction lookups to avoid individual database queries
         let existing_tx_map: std::collections::HashMap<
-            String,
+            &str,
             &crate::metadata::TransactionWithWallet,
         > = existing_transactions
             .iter()
-            .map(|tx| (tx.txid.clone(), tx))
+            .map(|tx| (tx.txid.as_str(), tx))
             .collect();
 
         // Sort existing transactions by first_seen_at ASC (oldest first) for proper balance calculation
@@ -448,7 +448,7 @@ impl WalletSyncService {
 
                 // Preserve existing timestamp if transaction already exists, otherwise use current time
                 let first_seen_at = existing_tx_map
-                    .get(&txid)
+                    .get(txid.as_str())
                     .map(|tx| tx.first_seen_at)
                     .unwrap_or_else(|| {
                         std::time::SystemTime::now()
@@ -489,7 +489,7 @@ impl WalletSyncService {
             ) = tx_data;
 
             // Check if this is an existing transaction
-            let existing_tx = existing_tx_map.get(txid).copied();
+            let existing_tx = existing_tx_map.get(txid.as_str()).copied();
 
             if let Some(existing) = existing_tx {
                 // Existing transaction - check if it's transitioning from pending to confirmed
@@ -612,7 +612,7 @@ impl WalletSyncService {
             &all_transactions
         {
             // Check if we already know about this transaction using in-memory lookup
-            let existing_tx = existing_tx_map.get(txid);
+            let existing_tx = existing_tx_map.get(txid.as_str());
 
             match existing_tx {
                 None => {
@@ -732,7 +732,7 @@ impl WalletSyncService {
             for conflicted_txid in &conflicted_txids {
                 let conflicted_txid_str = conflicted_txid.to_string();
                 // Check if this conflicted transaction is in our pending transactions using in-memory lookup
-                if let Some(pending_tx) = existing_tx_map.get(&conflicted_txid_str) {
+                if let Some(pending_tx) = existing_tx_map.get(conflicted_txid_str.as_str()) {
                     if pending_tx.transaction_status == "pending" {
                         // Find the conflicted transaction's inputs
                         let conflicted_tx_inputs: Option<Vec<_>> = bdk_tx_map


### PR DESCRIPTION
Closes #247

# Hatchery Report Back for Issue #247

Title: Use borrowed &str keys for existing_tx_map in process_wallet_transactions

## Summary
Update `backend/src/sync.rs` so `process_wallet_transactions` uses a borrowed `HashMap<&str, &TransactionWithWallet>` for `existing_tx_map`, matching the two other sync paths in the same file. This removes one `String` clone per existing transaction during wallet sync and standardizes lookup behavior across wallet/address-watch flows.

## Changed Files
- backend/src/sync.rs

## Worker Results
- backend-1773304997: completed (backend)

## Lead Agent Results
- report: warning - I have the spec and current placeholder report. Next I’m pulling the worker and validation logs so the handoff stays tied to what actually ran, especially the remaining warning.
- rework: completed - - `cargo test --lib` failed, but on an unrelated pre-existing config test: [`backend/src/config.rs`#L774](\/Users\/schjonhaug\/.hatchery\/worktrees\/issue-247\/backend\/src\/config.rs#L774) expected `CANARY_SYNC_INTERVAL=42` and got `300`. - `cargo test --test two_stage_send_scenarios test_alice_partial_send_bob_two_stage -- --ignored --nocapture` failed during environment setup with `No available ports found after extensive search`. - `cargo test --test advanced_transactions test_single_rbf_sender_and_receiver_perspective -- --ignored --nocapture` failed for the same port-allocation reason. No reviewer-facing code questions remain for issue #247. The only open items are the unrelated test failure and the local system-test environment constraint. tokens used 38 360 The reviewer’s requested fix is already present on this branch, so I did not make an additional code edit. In [`backend/src/sync.rs`#L414](\/Users\/schjonhaug\/.hatchery\/worktrees\/issue-247\/backend\/src\/sync.rs#L414), `process_wallet_transactions` now builds `existing_tx_map` as `HashMap<&str, &TransactionWithWallet>` using `tx.txid.as_str()`, and the lookups in the same flow were updated to use borrowed `&str` keys at [`backend/src/sync.rs`#L450](\/Users\/schjonhaug\/.hatchery\/worktrees\/issue-247\/backend\/src\/sync.rs#L450), [`backend/src/sync.rs`#L492](\/Users\/schjonhaug\/.hatchery\/worktrees\/issue-247\/backend\/src\/sync.rs#L492), [`backend/src/sync.rs`#L615](\/Users\/schjonhaug\/.hatchery\/worktrees\/issue-247\/backend\/src\/sync.rs#L615), and [`backend/src/sync.rs`#L735](\/Users\/schjonhaug\/.hatchery\/worktrees\/issue-247\/backend\/src\/sync.rs#L735). Validation: - `cargo test --lib` failed, but on an unrelated pre-existing config test: [`backend/src/config.rs`#L774](\/Users\/schjonhaug\/.hatchery\/worktrees\/issue-247\/backend\/src\/config.rs#L774) expected `CANARY_SYNC_INTERVAL=42` and got `300`. - `cargo test --test two_stage_send_scenarios test_alice_partial_send_bob_two_stage -- --ignored --nocapture` failed during environment setup with `No available ports found after extensive search`. - `cargo test --test advanced_transactions test_single_rbf_sender_and_receiver_perspective -- --ignored --nocapture` failed for the same port-allocation reason. No reviewer-facing code questions remain for issue #247. The only open items are the unrelated test failure and the local system-test environment constraint.

## Validation Results
- backend: completed - Executable tests/wallet_key_format_tests.rs (backend/target/debug/deps/wallet_key_format_tests-a06fd220e9c39e50)
- backend-log: warning - backend log file missing


## Browser Validation
No browser validation summary recorded.



## PR Status
- State: created
- URL: https://github.com/schjonhaug/canary/pull/261
- Review: PR review status: ready (CLEAN, MERGEABLE, approvals=0, comments=4)
- Context: PR review status: ready (CLEAN, MERGEABLE, approvals=0, comments=4)
- Checks:
- build: completed (success)
- claude-review: completed (success)
- codex: completed (success)
- gemini-review: completed (success)
- post_feedback: completed (success)





## Warnings
- backend-log: warning - backend log file missing

## Ready for Human Review
- Review the changed files listed above.
- Confirm the validation results are acceptable for the issue scope.
- Follow the issue-specific verification checklist below when it exists.
- Inspect .hatchery/pr-review.md after PR review starts so change requests and comments are explicit.
- If runtime behavior matters, inspect the tmux runtime console before approving the solution.

## Suggested Verification Checklist
- `cd backend && cargo test --lib`
- `cd backend && cargo test --test two_stage_send_scenarios test_alice_partial_send_bob_two_stage -- --ignored --nocapture`
- `cd backend && cargo test --test advanced_transactions test_single_rbf_sender_and_receiver_perspective -- --ignored --nocapture`
- If Docker-based tests are not available, at minimum ensure the backend test suite compiles and note the skipped system-test coverage in the handoff.
