### PR TITLE
Make plans modal responsive for mobile devices

### DIFF
--- a/frontend/src/components/plan-comparison.tsx
+++ b/frontend/src/components/plan-comparison.tsx
@@ -276,7 +276,7 @@ function PlanComparisonContent({
             </CardContent>
 
             {onUpgrade && (!isCurrentTier || isTrialUser) && !showCallToAction && (
-              <CardFooter className={isModal ? "sticky bottom-0 bg-background pt-4 pb-4 border-t md:static md:border-t-0" : ""}>
+              <CardFooter className={isModal ? "sticky bottom-0 bg-inherit pb-4 border-t md:static md:border-t-0" : ""}>
                 <Button
                   className="w-full"
                   variant={isUpgrade ? "default" : "outline"}

--- a/frontend/src/components/plans-modal.tsx
+++ b/frontend/src/components/plans-modal.tsx
@@ -112,7 +112,7 @@ export function PlansModal({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
-        className="!max-w-none !w-[calc(100%-1rem)] sm:!w-[calc(100%-2rem)] md:!w-[85vw] max-h-[90vh] overflow-y-auto p-4 sm:p-6 md:p-8"
+        className="!max-w-none !w-[calc(100%_-_1rem)] sm:!w-[calc(100%_-_2rem)] md:!w-[85vw] max-h-[90vh] overflow-y-auto p-4 sm:p-6 md:p-8"
       >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Replace fixed 85vw modal width with responsive breakpoints (full-width on mobile, 85vw on desktop)
- Add responsive padding (`p-4` mobile → `p-8` desktop) and tighter spacing for small screens
- Make upgrade buttons sticky on mobile so they remain accessible while scrolling feature lists

## Test plan
- [ ] Verify modal displays near-full-width on mobile viewports (<640px)
- [ ] Verify modal retains 85vw width on desktop (>768px)
- [ ] Verify upgrade buttons are visible without scrolling on mobile
- [ ] Verify all 15 existing plans-modal tests pass
- [ ] Verify build succeeds with no errors

Fixes #6