### PR TITLE
refactor: extract verify_wallet_access helper

### DIFF
--- a/backend/src/handlers/balance_alerts.rs
+++ b/backend/src/handlers/balance_alerts.rs
@@ -3,6 +3,7 @@
 use crate::api::AppServicesState;
 use crate::exchange_rates;
 use crate::extractors::{require_non_demo, AuthenticatedUser};
+use crate::handlers::helpers::verify_wallet_access;
 use crate::metadata::BalanceAlertType;
 use crate::models::{BalanceAlertsResponse, CreateBalanceAlertRequest, ErrorResponse};
 use axum::{
@@ -18,36 +19,10 @@ pub async fn get_wallet_balance_alerts(
     State(app_services): State<AppServicesState>,
 ) -> Response {
     // Check if wallet exists and user has access
-    let wallet = match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&checksum)
-        .await
-    {
-        Ok(Some(wallet)) => wallet,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response()
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(format!("Database error: {}", e))),
-            )
-                .into_response()
-        }
+    let _wallet = match verify_wallet_access(&app_services, &user, &checksum).await {
+        Ok(wallet) => wallet,
+        Err(response) => return response,
     };
-
-    // Check user permission (unless admin)
-    if !user.is_admin && wallet.user_id != user.user_id {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::coded("access_denied", "Access denied")),
-        )
-            .into_response();
-    }
 
     // Get all balance alerts for the wallet
     match app_services
@@ -80,36 +55,10 @@ pub async fn create_wallet_balance_alert(
     }
 
     // Check if wallet exists and user has access
-    let wallet = match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&checksum)
-        .await
-    {
-        Ok(Some(wallet)) => wallet,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response()
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(format!("Database error: {}", e))),
-            )
-                .into_response()
-        }
+    let wallet = match verify_wallet_access(&app_services, &user, &checksum).await {
+        Ok(wallet) => wallet,
+        Err(response) => return response,
     };
-
-    // Check user permission (unless admin)
-    if !user.is_admin && wallet.user_id != user.user_id {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::coded("access_denied", "Access denied")),
-        )
-            .into_response();
-    }
 
     // Validate threshold type: exactly one must be provided (BTC OR fiat, not both or neither)
     let is_btc_threshold = request.threshold_sats.is_some();

--- a/backend/src/handlers/contact.rs
+++ b/backend/src/handlers/contact.rs
@@ -3,6 +3,7 @@
 use crate::api::AppServicesState;
 use crate::config::AppConfig;
 use crate::extractors::{require_non_demo, AuthenticatedUser};
+use crate::handlers::helpers::verify_wallet_access;
 use crate::metadata::ProviderType;
 use crate::models::{
     validate_phone_number, CreateContactResponse, CreateContactWithMethodsRequest, ErrorResponse,
@@ -60,51 +61,9 @@ pub async fn create_wallet_contact(
     }
 
     // Direct metadata access - no mutex blocking!
-    let _wallet = match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&wallet_checksum)
-        .await
-    {
-        Ok(Some(wallet)) => {
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&wallet_checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-            wallet
-        }
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(e.to_string())),
-            )
-                .into_response();
-        }
+    let _wallet = match verify_wallet_access(&app_services, &user, &wallet_checksum).await {
+        Ok(wallet) => wallet,
+        Err(response) => return response,
     };
 
     // Get user's subscription tier and check contact limit
@@ -414,50 +373,8 @@ pub async fn delete_wallet_contact(
     }
 
     // Direct metadata access - no mutex blocking!
-    match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&wallet_checksum)
-        .await
-    {
-        Ok(Some(_)) => {
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&wallet_checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-        }
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(format!("Database error: {}", e))),
-            )
-                .into_response();
-        }
+    if let Err(response) = verify_wallet_access(&app_services, &user, &wallet_checksum).await {
+        return response;
     }
 
     let delete_result = app_services
@@ -501,51 +418,9 @@ pub async fn update_wallet_contact(
     }
 
     // Check if wallet exists and user has access
-    let _wallet = match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&wallet_checksum)
-        .await
-    {
-        Ok(Some(wallet)) => {
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&wallet_checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-            wallet
-        }
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(e.to_string())),
-            )
-                .into_response();
-        }
+    let _wallet = match verify_wallet_access(&app_services, &user, &wallet_checksum).await {
+        Ok(wallet) => wallet,
+        Err(response) => return response,
     };
 
     // Get existing contact to compare notification methods
@@ -888,50 +763,8 @@ pub async fn get_wallet_contacts(
     let start_time = std::time::Instant::now();
 
     // Direct metadata access - no mutex blocking!
-    match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&wallet_checksum)
-        .await
-    {
-        Ok(Some(_)) => {
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&wallet_checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-        }
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(e.to_string())),
-            )
-                .into_response();
-        }
+    if let Err(response) = verify_wallet_access(&app_services, &user, &wallet_checksum).await {
+        return response;
     }
 
     let contacts_result = app_services

--- a/backend/src/handlers/contact_verification.rs
+++ b/backend/src/handlers/contact_verification.rs
@@ -4,6 +4,7 @@ use crate::api::AppServicesState;
 use crate::auth::{load_twilio_config_from_env, AuthService};
 use crate::config::AppConfig;
 use crate::extractors::AuthenticatedUser;
+use crate::handlers::helpers::verify_wallet_access;
 use crate::metadata::Language;
 use crate::models::{
     validate_phone_number, ErrorResponse, SendContactVerificationRequest, VerifyContactRequest,
@@ -35,50 +36,8 @@ pub async fn send_contact_verification(
         .unwrap_or(Language::English);
 
     // Check if wallet exists and user has access - no mutex blocking!
-    match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&wallet_checksum)
-        .await
-    {
-        Ok(Some(_)) => {
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&wallet_checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-        }
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(e.to_string())),
-            )
-                .into_response();
-        }
+    if let Err(response) = verify_wallet_access(&app_services, &user, &wallet_checksum).await {
+        return response;
     }
 
     // Determine verification type and validate input
@@ -567,50 +526,8 @@ pub async fn verify_contact(
     let start_time = std::time::Instant::now();
 
     // Check if wallet exists and user has access - no mutex blocking!
-    match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&wallet_checksum)
-        .await
-    {
-        Ok(Some(_)) => {
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&wallet_checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-        }
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(e.to_string())),
-            )
-                .into_response();
-        }
+    if let Err(response) = verify_wallet_access(&app_services, &user, &wallet_checksum).await {
+        return response;
     }
 
     // Determine what we're verifying and validate input

--- a/backend/src/handlers/helpers.rs
+++ b/backend/src/handlers/helpers.rs
@@ -1,0 +1,57 @@
+use crate::api::AppServicesState;
+use crate::auth::AuthUser;
+use crate::metadata::WalletMetadata;
+use crate::models::ErrorResponse;
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Json, Response},
+};
+
+pub async fn verify_wallet_access(
+    app_services: &AppServicesState,
+    user: &AuthUser,
+    checksum: &str,
+) -> Result<WalletMetadata, Response> {
+    let wallet = app_services
+        .metadata_db
+        .get_wallet_by_checksum(checksum)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(format!("Database error: {}", e))),
+            )
+                .into_response()
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
+            )
+                .into_response()
+        })?;
+
+    if !user.is_admin {
+        let owns_wallet = app_services
+            .metadata_db
+            .is_wallet_owned_by_user(checksum, &user.user_id)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(format!("Database error: {}", e))),
+                )
+                    .into_response()
+            })?;
+
+        if !owns_wallet {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse::coded("access_denied", "Access denied")),
+            )
+                .into_response());
+        }
+    }
+
+    Ok(wallet)
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -9,6 +9,7 @@ mod contact;
 mod contact_verification;
 pub(crate) mod donations;
 mod health;
+mod helpers;
 mod notifications;
 mod providers;
 mod user_preferences;

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -4,6 +4,7 @@ use crate::admin_notifications::AdminNotifications;
 use crate::api::{AppServicesState, ElectrumClientManagerState};
 use crate::config::{AppConfig, NetworkConfig};
 use crate::extractors::{require_non_demo, AuthenticatedUser};
+use crate::handlers::helpers::verify_wallet_access;
 use crate::metadata::{ProviderType, WalletDetailResponse};
 use crate::models::{
     CreateWalletRequest, CreateWalletResponse, ErrorResponse, UpdateWalletRequest,
@@ -442,51 +443,8 @@ pub async fn delete_wallet(
 
     // NON-BLOCKING: Use AppServices metadata_db directly (no wallet mutex)
     // Check if wallet exists and belongs to user (or user is admin)
-    match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&checksum)
-        .await
-    {
-        Ok(Some(_)) => {
-            // Check ownership
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-        }
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(format!("Database error: {}", e))),
-            )
-                .into_response();
-        }
+    if let Err(response) = verify_wallet_access(&app_services, &user, &checksum).await {
+        return response;
     }
 
     // SOFT DELETE: Mark wallet as deleted instead of immediate deletion
@@ -539,51 +497,8 @@ pub async fn update_wallet(
     let start_time = std::time::Instant::now();
 
     // Direct metadata access - no mutex blocking!
-    match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&checksum)
-        .await
-    {
-        Ok(Some(_)) => {
-            // Check ownership
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-        }
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(format!("Database error: {}", e))),
-            )
-                .into_response();
-        }
+    if let Err(response) = verify_wallet_access(&app_services, &user, &checksum).await {
+        return response;
     }
 
     let update_result = app_services
@@ -616,49 +531,9 @@ pub async fn get_wallet(
     State(app_services): State<AppServicesState>,
 ) -> Response {
     // No mutex blocking! Direct access to metadata database
-    match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&checksum)
-        .await
-    {
-        Ok(Some(wallet)) => {
-            // Check if user has access to this wallet
-            if !user.is_admin {
-                match app_services
-                    .metadata_db
-                    .is_wallet_owned_by_user(&checksum, &user.user_id)
-                    .await
-                {
-                    Ok(true) => {} // User owns the wallet
-                    Ok(false) => {
-                        return (
-                            StatusCode::FORBIDDEN,
-                            Json(ErrorResponse::coded("access_denied", "Access denied")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new(format!("Database error: {}", e))),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-
-            (StatusCode::OK, Json(wallet)).into_response()
-        }
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-        )
-            .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(e.to_string())),
-        )
-            .into_response(),
+    match verify_wallet_access(&app_services, &user, &checksum).await {
+        Ok(wallet) => (StatusCode::OK, Json(wallet)).into_response(),
+        Err(response) => response,
     }
 }
 
@@ -718,52 +593,10 @@ pub async fn get_wallet_detail(
         .as_secs();
 
     // Get the specific wallet - no mutex blocking!
-    let wallet = match app_services
-        .metadata_db
-        .get_wallet_by_checksum(&checksum)
-        .await
-    {
-        Ok(Some(wallet)) => wallet,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse::coded("wallet_not_found", "Wallet not found")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(format!("Database error: {}", e))),
-            )
-                .into_response();
-        }
+    let wallet = match verify_wallet_access(&app_services, &user, &checksum).await {
+        Ok(wallet) => wallet,
+        Err(response) => return response,
     };
-
-    // Check if user has permission to access this wallet
-    if !user.is_admin {
-        match app_services
-            .metadata_db
-            .is_wallet_owned_by_user(&checksum, &user.user_id)
-            .await
-        {
-            Ok(true) => {} // User owns the wallet
-            Ok(false) => {
-                return (
-                    StatusCode::FORBIDDEN,
-                    Json(ErrorResponse::coded("access_denied", "Access denied")),
-                )
-                    .into_response();
-            }
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new(format!("Database error: {}", e))),
-                )
-                    .into_response();
-            }
-        }
-    }
 
     // Check if wallet is pending - if so, return minimal data only
     if wallet.status == "pending" {


### PR DESCRIPTION
## Summary
- add a shared handler helper to verify wallet existence and ownership
- replace duplicated wallet-access checks in wallet, contact, contact verification, and balance alert handlers
- keep behavior aligned while centralizing the common response paths

Closes #60

## Testing
- cargo build
- cargo test -- --test-threads=1