### PR TITLE
test: add auth flow coverage

### DIFF
--- a/backend/tests/auth_flow_tests.rs
+++ b/backend/tests/auth_flow_tests.rs
@@ -216,6 +216,52 @@ async fn test_login_me_logout_invalidates_session() {
 }
 
 #[tokio::test]
+async fn test_cloud_mode_accepts_valid_bearer_token_with_session() {
+    let test_app = create_test_app(OperatingMode::Cloud).await;
+    create_user(
+        &test_app.app_services,
+        "bearer-user@example.com",
+        "password123",
+        true,
+    )
+    .await;
+
+    let login_request = Request::builder()
+        .uri("/api/auth/login")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "email": "bearer-user@example.com",
+                "password": "password123"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let login_response = test_app
+        .router
+        .clone()
+        .oneshot(login_request)
+        .await
+        .unwrap();
+    assert_eq!(login_response.status(), StatusCode::OK);
+
+    let body = body_to_json(login_response.into_body()).await;
+    let token = body["token"].as_str().unwrap();
+
+    let me_request = Request::builder()
+        .uri("/api/auth/me")
+        .method("GET")
+        .header("authorization", format!("Bearer {}", token))
+        .body(Body::empty())
+        .unwrap();
+
+    let me_response = test_app.router.oneshot(me_request).await.unwrap();
+    assert_eq!(me_response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn test_login_rejects_invalid_password_and_unverified_email() {
     let test_app = create_test_app(OperatingMode::Cloud).await;
     create_user(


### PR DESCRIPTION
## Summary

Closes #101.

Adds automated backend coverage for the main authentication flows and tightens cloud-mode auth so logout actually invalidates access.

## What changed

- add integration tests for login success/failure, email verification, password reset, invalid JWT rejection, and self-hosted protected-route behavior
- require an active session record for cloud-mode authenticated routes so deleted sessions cannot keep using an otherwise valid JWT
- track an unrelated broader test failure separately in #301

## Testing

```bash
cd backend
cargo test --test auth_flow_tests
cargo test
```

`cargo test` still has one unrelated existing failure:
`config::tests::test_self_hosted_mode_sync_interval_legacy_fallback` (tracked in #301).