### PR TITLE
Restore v1.4.0 transaction table layout

### DIFF
--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "Erstatning",
     "walletLabel": "Wallet: {name}",
-    "loadOlder": "Indlæs ældre"
+    "loadOlder": "Indlæs ældre",
+    "expandDetails": "Udvid transaktionsdetaljer",
+    "collapseDetails": "Skjul transaktionsdetaljer"
   },
   "billing": {
     "title": "Abonnement",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "Ersatz",
     "walletLabel": "Wallet: {name}",
-    "loadOlder": "Ältere laden"
+    "loadOlder": "Ältere laden",
+    "expandDetails": "Transaktionsdetails ausklappen",
+    "collapseDetails": "Transaktionsdetails einklappen"
   },
   "billing": {
     "title": "Abonnement",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "Replacement",
     "walletLabel": "Wallet: {name}",
-    "loadOlder": "Load older"
+    "loadOlder": "Load older",
+    "expandDetails": "Expand transaction details",
+    "collapseDetails": "Collapse transaction details"
   },
   "billing": {
     "title": "Subscription",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "Reemplazo",
     "walletLabel": "Billetera: {name}",
-    "loadOlder": "Cargar anteriores"
+    "loadOlder": "Cargar anteriores",
+    "expandDetails": "Expandir detalles de la transacción",
+    "collapseDetails": "Ocultar detalles de la transacción"
   },
   "billing": {
     "title": "Suscripción",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "Remplacement",
     "walletLabel": "Portefeuille : {name}",
-    "loadOlder": "Charger les plus anciennes"
+    "loadOlder": "Charger les plus anciennes",
+    "expandDetails": "Afficher les détails de la transaction",
+    "collapseDetails": "Masquer les détails de la transaction"
   },
   "billing": {
     "title": "Abonnement",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "置換",
     "walletLabel": "ウォレット: {name}",
-    "loadOlder": "古い取引を読み込む"
+    "loadOlder": "古い取引を読み込む",
+    "expandDetails": "取引の詳細を表示",
+    "collapseDetails": "取引の詳細を非表示"
   },
   "billing": {
     "title": "サブスクリプション",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "Erstatning",
     "walletLabel": "Lommebok: {name}",
-    "loadOlder": "Last inn eldre"
+    "loadOlder": "Last inn eldre",
+    "expandDetails": "Utvid transaksjonsdetaljer",
+    "collapseDetails": "Skjul transaksjonsdetaljer"
   },
   "billing": {
     "title": "Abonnement",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "Substituição",
     "walletLabel": "Carteira: {name}",
-    "loadOlder": "Carregar anteriores"
+    "loadOlder": "Carregar anteriores",
+    "expandDetails": "Expandir detalhes da transação",
+    "collapseDetails": "Ocultar detalhes da transação"
   },
   "billing": {
     "title": "Assinatura",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -832,7 +832,9 @@
     "cpfp": "CPFP",
     "replacement": "Ersättning",
     "walletLabel": "Plånbok: {name}",
-    "loadOlder": "Ladda äldre"
+    "loadOlder": "Ladda äldre",
+    "expandDetails": "Visa transaktionsdetaljer",
+    "collapseDetails": "Dölj transaktionsdetaljer"
   },
   "billing": {
     "title": "Prenumeration",

--- a/frontend/src/components/__tests__/transactions.test.tsx
+++ b/frontend/src/components/__tests__/transactions.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Transactions } from '../transactions'
 import { Transaction } from '../../types'
 
@@ -77,7 +78,7 @@ describe('Transactions', () => {
 
     expect(screen.queryByTestId(`details-${transactions[0].txid}`)).not.toBeInTheDocument()
 
-    const expandButton = screen.getByRole('button')
+    const expandButton = screen.getByRole('button', { name: 'Expand transaction details' })
     expect(expandButton).toHaveAttribute('aria-expanded', 'false')
     expect(expandButton).toHaveAttribute(
       'aria-controls',
@@ -87,6 +88,31 @@ describe('Transactions', () => {
     fireEvent.click(expandButton)
 
     expect(expandButton).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId(`details-${transactions[0].txid}`)).toBeInTheDocument()
+  })
+
+  it('supports keyboard expansion on the desktop toggle button', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Transactions
+        selectedWalletChecksum="wallet-1"
+        transactions={transactions}
+        error={null}
+        lastUpdate={1001}
+        walletsCount={1}
+      />,
+    )
+
+    const expandButton = screen.getByRole('button', { name: 'Expand transaction details' })
+    expandButton.focus()
+
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByRole('button', { name: 'Collapse transaction details' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
     expect(screen.getByTestId(`details-${transactions[0].txid}`)).toBeInTheDocument()
   })
 
@@ -139,7 +165,7 @@ describe('Transactions', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'Expand transaction details' }))
 
     expect(loadTransactionNotifications).toHaveBeenCalledTimes(1)
     expect(loadTransactionNotifications).toHaveBeenCalledWith(

--- a/frontend/src/components/__tests__/transactions.test.tsx
+++ b/frontend/src/components/__tests__/transactions.test.tsx
@@ -22,6 +22,14 @@ jest.mock('next-intl', () => ({
       return 'Load older'
     }
 
+    if (key === 'expandDetails') {
+      return 'Expand transaction details'
+    }
+
+    if (key === 'collapseDetails') {
+      return 'Collapse transaction details'
+    }
+
     return key
   },
 }))
@@ -113,6 +121,22 @@ describe('Transactions', () => {
       'aria-expanded',
       'true',
     )
+    expect(screen.getByTestId(`details-${transactions[0].txid}`)).toBeInTheDocument()
+  })
+
+  it('expands when the desktop row is clicked', () => {
+    render(
+      <Transactions
+        selectedWalletChecksum="wallet-1"
+        transactions={transactions}
+        error={null}
+        lastUpdate={1001}
+        walletsCount={1}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('1000'))
+
     expect(screen.getByTestId(`details-${transactions[0].txid}`)).toBeInTheDocument()
   })
 

--- a/frontend/src/components/transactions.tsx
+++ b/frontend/src/components/transactions.tsx
@@ -193,10 +193,6 @@ export function Transactions({
     return undefined
   }
 
-  const getTableCaption = () => {
-    return t("count", { count: filteredTransactions.length })
-  }
-
   const loadedCountLabel = useMemo(
     () => t("count", { count: filteredTransactions.length }),
     [filteredTransactions.length, t],
@@ -331,7 +327,7 @@ export function Transactions({
 
             <div className="hidden md:block">
               <Table>
-                <TableCaption>{getTableCaption()}</TableCaption>
+                <TableCaption>{loadedCountLabel}</TableCaption>
                 <TableHeader>
                   <TableRow>
                     <TableHead>{t("tableHeaders.dateTime")}</TableHead>
@@ -353,8 +349,18 @@ export function Transactions({
                     return (
                       <React.Fragment key={rowKey}>
                         <TableRow
-                          className={`cursor-pointer transition-colors hover:bg-muted/50 ${isExpanded ? "bg-muted/30" : ""}`}
+                          role="button"
+                          tabIndex={0}
+                          aria-controls={detailsId}
+                          aria-expanded={isExpanded}
+                          className={`cursor-pointer ${isExpanded ? "bg-muted/30" : ""}`}
                           onClick={() => toggleRowExpansion(transaction)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault()
+                              toggleRowExpansion(transaction)
+                            }
+                          }}
                         >
                           <TableCell className="text-sm">
                             {formatDateTime(getDisplayTimestamp(transaction))}
@@ -388,13 +394,13 @@ export function Transactions({
                                 )}
                                 {transaction.transaction_status === "replaced"
                                   ? t("status.replaced")
-                                  : transaction.block_height !== null
-                                    ? transaction.transaction_type === "receive"
-                                      ? t("types.receive")
-                                      : t("types.send")
-                                    : transaction.transaction_type === "receive"
-                                      ? t("types.receiving")
-                                      : t("types.sending")}
+                                    : transaction.block_height !== null
+                                      ? transaction.transaction_type === "receive"
+                                        ? t("types.receive")
+                                        : t("types.send")
+                                      : transaction.transaction_type === "receive"
+                                        ? t("types.receiving")
+                                        : t("types.sending")}
                               </Badge>
                               {transaction.parent_txid && (
                                 <span
@@ -402,7 +408,7 @@ export function Transactions({
                                     txid: transaction.parent_txid,
                                   })}
                                 >
-                                  <Baby className="ml-1 h-4 w-4" />
+                                  <Baby className="h-4 w-4" />
                                 </span>
                               )}
                               {transaction.replaced_by_txid && (
@@ -411,7 +417,7 @@ export function Transactions({
                                     txid: transaction.replaced_by_txid,
                                   })}
                                 >
-                                  <ArrowRight className="ml-1 h-4 w-4 text-orange-500" />
+                                  <ArrowRight className="h-4 w-4 text-orange-500" />
                                 </span>
                               )}
                               {notificationSummary && (
@@ -431,31 +437,27 @@ export function Transactions({
                           </TableCell>
                           <TableCell className="text-center">
                             {isExpanded ? (
-                              <ChevronDown className="h-4 w-4 transition-transform duration-200" />
+                              <ChevronDown className="h-4 w-4" />
                             ) : (
-                              <ChevronRight className="h-4 w-4 transition-transform duration-200" />
+                              <ChevronRight className="h-4 w-4" />
                             )}
                           </TableCell>
                         </TableRow>
-                        <TableRow
-                          className={`bg-muted/20 transition-all duration-300 ease-out overflow-hidden ${isExpanded ? "h-auto" : "h-0"}`}
-                          style={{ lineHeight: isExpanded ? "normal" : "0" }}
-                        >
-                          <TableCell
-                            colSpan={walletsCount > 1 ? 5 : 4}
-                            className={`overflow-hidden transition-all duration-300 ease-out ${isExpanded ? "p-0" : "h-0 p-0"}`}
-                          >
-                            <div id={detailsId}>
-                              <TransactionDetails
-                                transaction={transaction}
-                                isExpanded={isExpanded}
-                                notifications={transactionNotifications[rowKey]}
-                                isLoadingNotifications={loadingTransactionNotifications[rowKey]}
-                                notificationError={transactionNotificationErrors[rowKey]}
-                              />
-                            </div>
-                          </TableCell>
-                        </TableRow>
+                        {isExpanded && (
+                          <TableRow className="bg-muted/20">
+                            <TableCell colSpan={walletsCount > 1 ? 5 : 4} className="p-0">
+                              <div id={detailsId}>
+                                <TransactionDetails
+                                  transaction={transaction}
+                                  isExpanded={isExpanded}
+                                  notifications={transactionNotifications[rowKey]}
+                                  isLoadingNotifications={loadingTransactionNotifications[rowKey]}
+                                  notificationError={transactionNotificationErrors[rowKey]}
+                                />
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        )}
                       </React.Fragment>
                     )
                   })}

--- a/frontend/src/components/transactions.tsx
+++ b/frontend/src/components/transactions.tsx
@@ -8,7 +8,6 @@ import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table,
   TableBody,
-  TableCaption,
   TableCell,
   TableHead,
   TableHeader,
@@ -24,7 +23,6 @@ import {
   Baby,
   Bell,
   CheckCircle,
-  ChevronDown,
   ChevronRight,
   Loader2,
   Mail,
@@ -327,14 +325,13 @@ export function Transactions({
 
             <div className="hidden md:block">
               <Table>
-                <TableCaption>{loadedCountLabel}</TableCaption>
                 <TableHeader>
                   <TableRow>
                     <TableHead>{t("tableHeaders.dateTime")}</TableHead>
                     {walletsCount > 1 && <TableHead>{t("tableHeaders.wallet")}</TableHead>}
                     <TableHead>{t("tableHeaders.transaction")}</TableHead>
                     <TableHead>{t("tableHeaders.amount")}</TableHead>
-                    <TableHead className="w-8"></TableHead>
+                    <TableHead className="w-8" aria-hidden="true"></TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -349,18 +346,8 @@ export function Transactions({
                     return (
                       <React.Fragment key={rowKey}>
                         <TableRow
-                          role="button"
-                          tabIndex={0}
-                          aria-controls={detailsId}
-                          aria-expanded={isExpanded}
                           className={`cursor-pointer ${isExpanded ? "bg-muted/30" : ""}`}
                           onClick={() => toggleRowExpansion(transaction)}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter" || event.key === " ") {
-                              event.preventDefault()
-                              toggleRowExpansion(transaction)
-                            }
-                          }}
                         >
                           <TableCell className="text-sm">
                             {formatDateTime(getDisplayTimestamp(transaction))}
@@ -369,7 +356,7 @@ export function Transactions({
                             <TableCell className="font-medium">{transaction.wallet_name}</TableCell>
                           )}
                           <TableCell>
-                            <div className="flex items-center gap-1">
+                            <div className="flex items-center gap-1 whitespace-normal break-words">
                               <Badge
                                 variant={
                                   transaction.transaction_status === "replaced"
@@ -436,16 +423,33 @@ export function Transactions({
                             )}
                           </TableCell>
                           <TableCell className="text-center">
-                            {isExpanded ? (
-                              <ChevronDown className="h-4 w-4" />
-                            ) : (
-                              <ChevronRight className="h-4 w-4" />
-                            )}
+                            <button
+                              type="button"
+                              aria-label={
+                                isExpanded ? "Collapse transaction details" : "Expand transaction details"
+                              }
+                              aria-controls={detailsId}
+                              aria-expanded={isExpanded}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                toggleRowExpansion(transaction)
+                              }}
+                            >
+                              <ChevronRight
+                                className={`h-4 w-4 transition-transform duration-200 ${
+                                  isExpanded ? "rotate-90" : ""
+                                }`}
+                              />
+                            </button>
                           </TableCell>
                         </TableRow>
                         {isExpanded && (
                           <TableRow className="bg-muted/20">
-                            <TableCell colSpan={walletsCount > 1 ? 5 : 4} className="p-0">
+                            <TableCell
+                              colSpan={walletsCount > 1 ? 5 : 4}
+                              className="p-0 whitespace-normal"
+                            >
                               <div id={detailsId}>
                                 <TransactionDetails
                                   transaction={transaction}

--- a/frontend/src/components/transactions.tsx
+++ b/frontend/src/components/transactions.tsx
@@ -232,7 +232,7 @@ export function Transactions({
                   {walletsCount > 1 && <TableHead>{t("tableHeaders.wallet")}</TableHead>}
                   <TableHead>{t("tableHeaders.transaction")}</TableHead>
                   <TableHead>{t("tableHeaders.amount")}</TableHead>
-                  <TableHead className="w-8"></TableHead>
+                  <TableHead className="w-8" aria-hidden="true"></TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -426,7 +426,7 @@ export function Transactions({
                             <button
                               type="button"
                               aria-label={
-                                isExpanded ? "Collapse transaction details" : "Expand transaction details"
+                                isExpanded ? t("collapseDetails") : t("expandDetails")
                               }
                               aria-controls={detailsId}
                               aria-expanded={isExpanded}

--- a/frontend/src/components/transactions.tsx
+++ b/frontend/src/components/transactions.tsx
@@ -5,6 +5,15 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 import { NotificationStatus, Transaction } from "../types"
 import { TransactionCard } from "./transaction-card"
 import { TransactionDetails } from "./transaction-details"
@@ -22,12 +31,6 @@ import {
   MessageCircle,
   XCircle,
 } from "lucide-react"
-
-const DESKTOP_GRID_COLUMNS_MULTI =
-  "grid-cols-[180px_140px_minmax(0,1fr)_140px_32px]"
-const DESKTOP_GRID_COLUMNS_SINGLE =
-  "grid-cols-[180px_minmax(0,1fr)_140px_32px]"
-
 interface TransactionsProps {
   selectedWalletChecksum?: string | null
   transactions: Transaction[]
@@ -190,6 +193,10 @@ export function Transactions({
     return undefined
   }
 
+  const getTableCaption = () => {
+    return t("count", { count: filteredTransactions.length })
+  }
+
   const loadedCountLabel = useMemo(
     () => t("count", { count: filteredTransactions.length }),
     [filteredTransactions.length, t],
@@ -223,23 +230,41 @@ export function Transactions({
             ))}
           </div>
 
-          <div className="hidden md:block space-y-2">
-            {[1, 2, 3, 4, 5].map((item) => (
-              <div
-                key={item}
-                className={`grid items-center gap-3 rounded-md border px-4 py-3 ${
-                  walletsCount > 1
-                    ? DESKTOP_GRID_COLUMNS_MULTI
-                    : DESKTOP_GRID_COLUMNS_SINGLE
-                }`}
-              >
-                <Skeleton className="h-4 w-28" />
-                {walletsCount > 1 && <Skeleton className="h-4 w-24" />}
-                <Skeleton className="h-6 w-28" />
-                <Skeleton className="h-4 w-24" />
-                <Skeleton className="h-4 w-4" />
-              </div>
-            ))}
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("tableHeaders.dateTime")}</TableHead>
+                  {walletsCount > 1 && <TableHead>{t("tableHeaders.wallet")}</TableHead>}
+                  <TableHead>{t("tableHeaders.transaction")}</TableHead>
+                  <TableHead>{t("tableHeaders.amount")}</TableHead>
+                  <TableHead className="w-8"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {[1, 2, 3, 4, 5].map((item) => (
+                  <TableRow key={item}>
+                    <TableCell>
+                      <Skeleton className="h-4 w-32" />
+                    </TableCell>
+                    {walletsCount > 1 && (
+                      <TableCell>
+                        <Skeleton className="h-6 w-20" />
+                      </TableCell>
+                    )}
+                    <TableCell>
+                      <Skeleton className="h-4 w-28" />
+                    </TableCell>
+                    <TableCell>
+                      <Skeleton className="h-4 w-28" />
+                    </TableCell>
+                    <TableCell>
+                      <Skeleton className="h-4 w-4" />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
           </div>
         </CardContent>
       </Card>
@@ -304,145 +329,138 @@ export function Transactions({
               </div>
             )}
 
-            <div className="hidden md:block space-y-2">
-              <div
-                className={`grid items-center gap-3 rounded-md border bg-muted/30 px-4 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground ${
-                  walletsCount > 1
-                    ? DESKTOP_GRID_COLUMNS_MULTI
-                    : DESKTOP_GRID_COLUMNS_SINGLE
-                }`}
-              >
-                <span>{t("tableHeaders.dateTime")}</span>
-                {walletsCount > 1 && <span>{t("tableHeaders.wallet")}</span>}
-                <span>{t("tableHeaders.transaction")}</span>
-                <span>{t("tableHeaders.amount")}</span>
-                <span />
-              </div>
+            <div className="hidden md:block">
+              <Table>
+                <TableCaption>{getTableCaption()}</TableCaption>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("tableHeaders.dateTime")}</TableHead>
+                    {walletsCount > 1 && <TableHead>{t("tableHeaders.wallet")}</TableHead>}
+                    <TableHead>{t("tableHeaders.transaction")}</TableHead>
+                    <TableHead>{t("tableHeaders.amount")}</TableHead>
+                    <TableHead className="w-8"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredTransactions.map((transaction) => {
+                    const rowKey = getTransactionRowKey(transaction)
+                    const isExpanded = expandedRows.has(rowKey)
+                    const detailsId = getTransactionDetailsId(transaction)
+                    const notificationSummary = getUniqueProviderSummary(
+                      transactionNotifications[rowKey],
+                    )
 
-              <div className="rounded-md border">
-                {filteredTransactions.map((transaction) => {
-                  const rowKey = getTransactionRowKey(transaction)
-                  const isExpanded = expandedRows.has(rowKey)
-                  const detailsId = getTransactionDetailsId(transaction)
-                  const notificationSummary = getUniqueProviderSummary(
-                    transactionNotifications[rowKey],
-                  )
-
-                  return (
-                    <div key={rowKey} className="border-b bg-card last:border-b-0">
-                      <button
-                        type="button"
-                        aria-controls={detailsId}
-                        aria-expanded={isExpanded}
-                        className={`grid w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/50 ${
-                          walletsCount > 1
-                            ? DESKTOP_GRID_COLUMNS_MULTI
-                            : DESKTOP_GRID_COLUMNS_SINGLE
-                        } ${isExpanded ? "bg-muted/30" : ""}`}
-                        onClick={() => toggleRowExpansion(transaction)}
-                      >
-                        <span className="text-sm">
-                          {formatDateTime(getDisplayTimestamp(transaction))}
-                        </span>
-
-                        {walletsCount > 1 && (
-                          <span className="font-medium">{transaction.wallet_name}</span>
-                        )}
-
-                        <span className="flex min-w-0 items-center gap-2">
-                          <Badge
-                            variant={
-                              transaction.transaction_status === "replaced"
-                                ? "secondary"
-                                : "outline"
-                            }
-                            className="flex items-center gap-1"
-                            title={`${transaction.transaction_type === "receive" ? t("types.receive") : t("types.send")} - ${
-                              transaction.transaction_status === "replaced"
-                                ? t("tooltips.rbfReplaced")
-                                : transaction.block_height !== null
-                                  ? t("status.confirmed")
-                                  : t("status.pending")
-                            }`}
-                          >
-                            {transaction.transaction_status === "replaced" ? (
-                              <XCircle className="h-3 w-3 text-orange-500" />
-                            ) : transaction.block_height !== null ? (
-                              <CheckCircle className="h-3 w-3 text-green-500" />
-                            ) : (
-                              <Loader2 className="h-3 w-3 animate-spin text-yellow-500" />
+                    return (
+                      <React.Fragment key={rowKey}>
+                        <TableRow
+                          className={`cursor-pointer transition-colors hover:bg-muted/50 ${isExpanded ? "bg-muted/30" : ""}`}
+                          onClick={() => toggleRowExpansion(transaction)}
+                        >
+                          <TableCell className="text-sm">
+                            {formatDateTime(getDisplayTimestamp(transaction))}
+                          </TableCell>
+                          {walletsCount > 1 && (
+                            <TableCell className="font-medium">{transaction.wallet_name}</TableCell>
+                          )}
+                          <TableCell>
+                            <div className="flex items-center gap-1">
+                              <Badge
+                                variant={
+                                  transaction.transaction_status === "replaced"
+                                    ? "secondary"
+                                    : "outline"
+                                }
+                                className="flex items-center gap-1"
+                                title={`${transaction.transaction_type === "receive" ? t("types.receive") : t("types.send")} - ${
+                                  transaction.transaction_status === "replaced"
+                                    ? t("tooltips.rbfReplaced")
+                                    : transaction.block_height !== null
+                                      ? t("status.confirmed")
+                                      : t("status.pending")
+                                }`}
+                              >
+                                {transaction.transaction_status === "replaced" ? (
+                                  <XCircle className="h-3 w-3 text-orange-500" />
+                                ) : transaction.block_height !== null ? (
+                                  <CheckCircle className="h-3 w-3 text-green-500" />
+                                ) : (
+                                  <Loader2 className="h-3 w-3 animate-spin text-yellow-500" />
+                                )}
+                                {transaction.transaction_status === "replaced"
+                                  ? t("status.replaced")
+                                  : transaction.block_height !== null
+                                    ? transaction.transaction_type === "receive"
+                                      ? t("types.receive")
+                                      : t("types.send")
+                                    : transaction.transaction_type === "receive"
+                                      ? t("types.receiving")
+                                      : t("types.sending")}
+                              </Badge>
+                              {transaction.parent_txid && (
+                                <span
+                                  title={t("tooltips.cpfpChild", {
+                                    txid: transaction.parent_txid,
+                                  })}
+                                >
+                                  <Baby className="ml-1 h-4 w-4" />
+                                </span>
+                              )}
+                              {transaction.replaced_by_txid && (
+                                <span
+                                  title={t("tooltips.replacedByTx", {
+                                    txid: transaction.replaced_by_txid,
+                                  })}
+                                >
+                                  <ArrowRight className="ml-1 h-4 w-4 text-orange-500" />
+                                </span>
+                              )}
+                              {notificationSummary && (
+                                <span className="ml-1 flex items-center gap-1 text-muted-foreground">
+                                  {notificationSummary.icons.map((icon) => (
+                                    <span key={icon.type}>{icon.icon}</span>
+                                  ))}
+                                </span>
+                              )}
+                            </div>
+                          </TableCell>
+                          <TableCell className="font-mono">
+                            {formatTransactionAmount(
+                              transaction.amount_sats,
+                              transaction.transaction_type,
                             )}
-                            {transaction.transaction_status === "replaced"
-                              ? t("status.replaced")
-                              : transaction.block_height !== null
-                                ? transaction.transaction_type === "receive"
-                                  ? t("types.receive")
-                                  : t("types.send")
-                                : transaction.transaction_type === "receive"
-                                  ? t("types.receiving")
-                                  : t("types.sending")}
-                          </Badge>
-
-                          {transaction.parent_txid && (
-                            <span
-                              title={t("tooltips.cpfpChild", {
-                                txid: transaction.parent_txid,
-                              })}
-                            >
-                              <Baby className="h-4 w-4" />
-                            </span>
-                          )}
-
-                          {transaction.replaced_by_txid && (
-                            <span
-                              title={t("tooltips.replacedByTx", {
-                                txid: transaction.replaced_by_txid,
-                              })}
-                            >
-                              <ArrowRight className="h-4 w-4 text-orange-500" />
-                            </span>
-                          )}
-
-                          {notificationSummary && (
-                            <span className="ml-1 flex items-center gap-1 text-muted-foreground">
-                              {notificationSummary.icons.map((icon) => (
-                                <span key={icon.type}>{icon.icon}</span>
-                              ))}
-                            </span>
-                          )}
-                        </span>
-
-                        <span className="font-mono">
-                          {formatTransactionAmount(
-                            transaction.amount_sats,
-                            transaction.transaction_type,
-                          )}
-                        </span>
-
-                        <span className="flex justify-center">
-                          {isExpanded ? (
-                            <ChevronDown className="h-4 w-4" />
-                          ) : (
-                            <ChevronRight className="h-4 w-4" />
-                          )}
-                        </span>
-                      </button>
-
-                      {isExpanded && (
-                        <div id={detailsId}>
-                          <TransactionDetails
-                            transaction={transaction}
-                            isExpanded={isExpanded}
-                            notifications={transactionNotifications[rowKey]}
-                            isLoadingNotifications={loadingTransactionNotifications[rowKey]}
-                            notificationError={transactionNotificationErrors[rowKey]}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
+                          </TableCell>
+                          <TableCell className="text-center">
+                            {isExpanded ? (
+                              <ChevronDown className="h-4 w-4 transition-transform duration-200" />
+                            ) : (
+                              <ChevronRight className="h-4 w-4 transition-transform duration-200" />
+                            )}
+                          </TableCell>
+                        </TableRow>
+                        <TableRow
+                          className={`bg-muted/20 transition-all duration-300 ease-out overflow-hidden ${isExpanded ? "h-auto" : "h-0"}`}
+                          style={{ lineHeight: isExpanded ? "normal" : "0" }}
+                        >
+                          <TableCell
+                            colSpan={walletsCount > 1 ? 5 : 4}
+                            className={`overflow-hidden transition-all duration-300 ease-out ${isExpanded ? "p-0" : "h-0 p-0"}`}
+                          >
+                            <div id={detailsId}>
+                              <TransactionDetails
+                                transaction={transaction}
+                                isExpanded={isExpanded}
+                                notifications={transactionNotifications[rowKey]}
+                                isLoadingNotifications={loadingTransactionNotifications[rowKey]}
+                                notificationError={transactionNotificationErrors[rowKey]}
+                              />
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      </React.Fragment>
+                    )
+                  })}
+                </TableBody>
+              </Table>
 
               {hasMoreTransactions && onLoadMore && (
                 <div className="mt-4 hidden justify-center md:flex">


### PR DESCRIPTION
## Summary
- restore the denser desktop transaction table layout from tag v1.4.0
- replace the newer custom grid-based desktop rows with the older table structure
- keep the newer data loading and transaction detail behavior intact

## Testing
- compared the layout locally against v1.4.0 and confirmed the denser row styling
