### PR TITLE
Fix minimized transaction row icons

### DIFF
--- a/frontend/src/components/__tests__/transactions.test.tsx
+++ b/frontend/src/components/__tests__/transactions.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Transactions } from '../transactions'
-import { Transaction } from '../../types'
+import { NotificationStatus, Transaction } from '../../types'
 
 jest.mock('next-intl', () => ({
   useTranslations: (namespace: string) => (key: string, values?: Record<string, string | number>) => {
@@ -41,23 +41,6 @@ jest.mock('@/hooks/useFormatters', () => ({
   }),
 }))
 
-jest.mock('lucide-react', () => {
-  const icon = (testId: string) => (props: React.SVGProps<SVGSVGElement>) => (
-    <svg data-testid={testId} {...props} />
-  )
-
-  return {
-    ArrowRight: icon('arrow-right-icon'),
-    Baby: icon('baby-icon'),
-    CheckCircle: icon('check-circle-icon'),
-    ChevronRight: icon('chevron-right-icon'),
-    Loader2: icon('loader-icon'),
-    Mail: icon('mail-icon'),
-    MessageCircle: icon('message-circle-icon'),
-    XCircle: icon('x-circle-icon'),
-  }
-})
-
 jest.mock('../transaction-card', () => ({
   TransactionCard: ({ transaction }: { transaction: Transaction }) => (
     <div data-testid={`mobile-${transaction.txid}`}>{transaction.txid}</div>
@@ -65,9 +48,17 @@ jest.mock('../transaction-card', () => ({
 }))
 
 jest.mock('../transaction-details', () => ({
-  TransactionDetails: ({ transaction }: { transaction: Transaction }) => (
-    <div data-testid={`details-${transaction.txid}`}>details</div>
-  ),
+  TransactionDetails: ({
+    transaction,
+    notifications,
+  }: {
+    transaction: Transaction
+    notifications?: NotificationStatus[]
+  }) => {
+    const providerTypes = notifications?.map(({ provider_type }) => provider_type).join(',') ?? 'none'
+
+    return <div data-testid={`details-${transaction.txid}`}>{providerTypes}</div>
+  },
 }))
 
 describe('Transactions', () => {
@@ -192,7 +183,31 @@ describe('Transactions', () => {
     expect(screen.queryByText('1001')).not.toBeInTheDocument()
   })
 
-  it('does not render notification provider icons in the collapsed desktop row', () => {
+  it('shows notification details only after expanding the desktop row', async () => {
+    const user = userEvent.setup()
+    const rowNotifications: NotificationStatus[] = [
+      {
+        contact_name: 'Alice',
+        provider_name: 'email',
+        provider_type: 'email',
+        notification_type: 'confirmed',
+        status: 'sent',
+        notification_target: 'alice@example.com',
+        error_message: null,
+        created_at: '1001',
+      },
+      {
+        contact_name: 'Bob',
+        provider_name: 'ntfy',
+        provider_type: 'ntfy',
+        notification_type: 'confirmed',
+        status: 'sent',
+        notification_target: 'canary-topic',
+        error_message: null,
+        created_at: '1001',
+      },
+    ]
+
     render(
       <Transactions
         selectedWalletChecksum="wallet-1"
@@ -201,34 +216,16 @@ describe('Transactions', () => {
         lastUpdate={1001}
         walletsCount={1}
         transactionNotifications={{
-          [`${transactions[0].wallet_checksum}:${transactions[0].txid}`]: [
-            {
-              contact_name: 'Alice',
-              provider_name: 'email',
-              provider_type: 'email',
-              notification_type: 'confirmed',
-              status: 'sent',
-              notification_target: 'alice@example.com',
-              error_message: null,
-              created_at: 1001,
-            },
-            {
-              contact_name: 'Bob',
-              provider_name: 'sms',
-              provider_type: 'sms',
-              notification_type: 'confirmed',
-              status: 'sent',
-              notification_target: '+4712345678',
-              error_message: null,
-              created_at: 1001,
-            },
-          ],
+          [`${transactions[0].wallet_checksum}:${transactions[0].txid}`]: rowNotifications,
         }}
       />,
     )
 
-    expect(screen.queryByTestId('mail-icon')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('message-circle-icon')).not.toBeInTheDocument()
+    expect(screen.queryByText('email,ntfy')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Expand transaction details' }))
+
+    expect(screen.getByTestId(`details-${transactions[0].txid}`)).toHaveTextContent('email,ntfy')
   })
 
   it('only auto-loads notifications once per expansion when props are unchanged', () => {

--- a/frontend/src/components/__tests__/transactions.test.tsx
+++ b/frontend/src/components/__tests__/transactions.test.tsx
@@ -41,6 +41,23 @@ jest.mock('@/hooks/useFormatters', () => ({
   }),
 }))
 
+jest.mock('lucide-react', () => {
+  const icon = (testId: string) => (props: React.SVGProps<SVGSVGElement>) => (
+    <svg data-testid={testId} {...props} />
+  )
+
+  return {
+    ArrowRight: icon('arrow-right-icon'),
+    Baby: icon('baby-icon'),
+    CheckCircle: icon('check-circle-icon'),
+    ChevronRight: icon('chevron-right-icon'),
+    Loader2: icon('loader-icon'),
+    Mail: icon('mail-icon'),
+    MessageCircle: icon('message-circle-icon'),
+    XCircle: icon('x-circle-icon'),
+  }
+})
+
 jest.mock('../transaction-card', () => ({
   TransactionCard: ({ transaction }: { transaction: Transaction }) => (
     <div data-testid={`mobile-${transaction.txid}`}>{transaction.txid}</div>
@@ -173,6 +190,45 @@ describe('Transactions', () => {
 
     expect(screen.getByText('1000')).toBeInTheDocument()
     expect(screen.queryByText('1001')).not.toBeInTheDocument()
+  })
+
+  it('does not render notification provider icons in the collapsed desktop row', () => {
+    render(
+      <Transactions
+        selectedWalletChecksum="wallet-1"
+        transactions={transactions}
+        error={null}
+        lastUpdate={1001}
+        walletsCount={1}
+        transactionNotifications={{
+          [`${transactions[0].wallet_checksum}:${transactions[0].txid}`]: [
+            {
+              contact_name: 'Alice',
+              provider_name: 'email',
+              provider_type: 'email',
+              notification_type: 'confirmed',
+              status: 'sent',
+              notification_target: 'alice@example.com',
+              error_message: null,
+              created_at: 1001,
+            },
+            {
+              contact_name: 'Bob',
+              provider_name: 'sms',
+              provider_type: 'sms',
+              notification_type: 'confirmed',
+              status: 'sent',
+              notification_target: '+4712345678',
+              error_message: null,
+              created_at: 1001,
+            },
+          ],
+        }}
+      />,
+    )
+
+    expect(screen.queryByTestId('mail-icon')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('message-circle-icon')).not.toBeInTheDocument()
   })
 
   it('only auto-loads notifications once per expansion when props are unchanged', () => {

--- a/frontend/src/components/transactions.tsx
+++ b/frontend/src/components/transactions.tsx
@@ -21,12 +21,9 @@ import { useFormatters } from "@/hooks/useFormatters"
 import {
   ArrowRight,
   Baby,
-  Bell,
   CheckCircle,
   ChevronRight,
   Loader2,
-  Mail,
-  MessageCircle,
   XCircle,
 } from "lucide-react"
 interface TransactionsProps {
@@ -58,10 +55,6 @@ function getDisplayTimestamp(transaction: Transaction) {
   }
 
   return Math.min(transaction.first_seen_at, transaction.confirmed_at)
-}
-
-function normalizeProviderType(providerType?: string | null, providerName?: string) {
-  return (providerType || providerName || "ntfy").toLowerCase()
 }
 
 export function Transactions({
@@ -110,46 +103,6 @@ export function Transactions({
       ),
     [filteredTransactions],
   )
-
-  const getUniqueProviderSummary = (notifications?: NotificationStatus[]) => {
-    if (!notifications || notifications.length === 0) return null
-
-    const providerCounts = notifications.reduce((acc, notification) => {
-      const providerType = normalizeProviderType(
-        notification.provider_type,
-        notification.provider_name,
-      )
-      acc[providerType] = (acc[providerType] || 0) + 1
-      return acc
-    }, {} as Record<string, number>)
-
-    const getProviderIcon = (providerType: string) => {
-      switch (providerType) {
-        case "email":
-          return <Mail className="h-4 w-4" />
-        case "sms":
-        case "twilio":
-          return <MessageCircle className="h-4 w-4" />
-        case "ntfy":
-        default:
-          return <Bell className="h-4 w-4" />
-      }
-    }
-
-    const sortedProviderTypes = Object.keys(providerCounts).sort((a, b) => {
-      const order = { email: 1, sms: 2, twilio: 2, ntfy: 3 }
-      const aOrder = order[a as keyof typeof order] || 99
-      const bOrder = order[b as keyof typeof order] || 99
-      return aOrder - bOrder
-    })
-
-    return {
-      icons: sortedProviderTypes.map((providerType) => ({
-        icon: getProviderIcon(providerType),
-        type: providerType,
-      })),
-    }
-  }
 
   useEffect(() => {
     for (const rowKey of expandedRows) {
@@ -339,9 +292,6 @@ export function Transactions({
                     const rowKey = getTransactionRowKey(transaction)
                     const isExpanded = expandedRows.has(rowKey)
                     const detailsId = getTransactionDetailsId(transaction)
-                    const notificationSummary = getUniqueProviderSummary(
-                      transactionNotifications[rowKey],
-                    )
 
                     return (
                       <React.Fragment key={rowKey}>
@@ -405,13 +355,6 @@ export function Transactions({
                                   })}
                                 >
                                   <ArrowRight className="h-4 w-4 text-orange-500" />
-                                </span>
-                              )}
-                              {notificationSummary && (
-                                <span className="ml-1 flex items-center gap-1 text-muted-foreground">
-                                  {notificationSummary.icons.map((icon) => (
-                                    <span key={icon.type}>{icon.icon}</span>
-                                  ))}
                                 </span>
                               )}
                             </div>


### PR DESCRIPTION
## Summary
- remove notification provider icons from minimized desktop transaction rows
- keep notification details in the expanded panel only
- add a regression test covering collapsed rows with notification data

## Testing
- pnpm test -- --runTestsByPath frontend/src/components/__tests__/transactions.test.tsx