### PR TITLE
Fix recurring donations config gating

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -438,10 +438,15 @@ pub fn create_router_with_services(
 
     // Donation routes - BTCPay redirect endpoints (no auth required)
     let donation_routes = if config_state.is_btcpay_enabled() {
-        Router::new()
-            .route("/donations/one-time", get(donate_one_time))
-            .route("/donations/recurring", get(donate_recurring))
-            .with_state(app_state.clone())
+        let router = Router::new().route("/donations/one-time", get(donate_one_time));
+
+        let router = if config_state.is_btcpay_recurring_enabled() {
+            router.route("/donations/recurring", get(donate_recurring))
+        } else {
+            router
+        };
+
+        router.with_state(app_state.clone())
     } else {
         Router::new()
     };

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -399,6 +399,13 @@ impl AppConfig {
         self.btcpay_url.is_some() && self.btcpay_api_key.is_some() && self.btcpay_store_id.is_some()
     }
 
+    /// Check if recurring BTCPay donations are fully configured.
+    pub fn is_btcpay_recurring_enabled(&self) -> bool {
+        self.is_btcpay_enabled()
+            && self.btcpay_offering_id.is_some()
+            && self.btcpay_plan_id.is_some()
+    }
+
     /// Get BTCPay Server URL
     pub fn btcpay_url(&self) -> Option<&str> {
         self.btcpay_url.as_deref()

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -402,8 +402,16 @@ impl AppConfig {
     /// Check if recurring BTCPay donations are fully configured.
     pub fn is_btcpay_recurring_enabled(&self) -> bool {
         self.is_btcpay_enabled()
-            && self.btcpay_offering_id.is_some()
-            && self.btcpay_plan_id.is_some()
+            && self
+                .btcpay_offering_id
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty())
+            && self
+                .btcpay_plan_id
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty())
     }
 
     /// Get BTCPay Server URL

--- a/backend/src/handlers/donations.rs
+++ b/backend/src/handlers/donations.rs
@@ -53,6 +53,14 @@ pub async fn donate_recurring(
     State(btcpay): State<BtcPayClientState>,
     State(config): State<crate::api::ConfigState>,
 ) -> Response {
+    if !config.is_btcpay_recurring_enabled() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Recurring BTCPay donations are not configured",
+        )
+            .into_response();
+    }
+
     let client = match &btcpay {
         Some(c) => c,
         None => {

--- a/backend/src/tests/donations.rs
+++ b/backend/src/tests/donations.rs
@@ -82,8 +82,23 @@ fn test_btcpay_client_creation_without_recurring() {
     );
 
     assert!(config.is_btcpay_enabled());
+    assert!(!config.is_btcpay_recurring_enabled());
     assert_eq!(config.btcpay_offering_id(), None);
     assert_eq!(config.btcpay_plan_id(), None);
+}
+
+#[test]
+fn test_btcpay_recurring_enabled_with_full_config() {
+    let config = test_config().with_btcpay(
+        Some("http://localhost:14142".to_string()),
+        Some("api-key-123".to_string()),
+        Some("store-id-456".to_string()),
+        Some("offering-789".to_string()),
+        Some("plan-abc".to_string()),
+    );
+
+    assert!(config.is_btcpay_enabled());
+    assert!(config.is_btcpay_recurring_enabled());
 }
 
 #[test]

--- a/backend/src/tests/donations.rs
+++ b/backend/src/tests/donations.rs
@@ -102,6 +102,36 @@ fn test_btcpay_recurring_enabled_with_full_config() {
 }
 
 #[test]
+fn test_btcpay_recurring_requires_non_empty_fields() {
+    let missing_plan = test_config().with_btcpay(
+        Some("http://localhost:14142".to_string()),
+        Some("api-key-123".to_string()),
+        Some("store-id-456".to_string()),
+        Some("offering-789".to_string()),
+        None,
+    );
+    assert!(!missing_plan.is_btcpay_recurring_enabled());
+
+    let blank_plan = test_config().with_btcpay(
+        Some("http://localhost:14142".to_string()),
+        Some("api-key-123".to_string()),
+        Some("store-id-456".to_string()),
+        Some("offering-789".to_string()),
+        Some("   ".to_string()),
+    );
+    assert!(!blank_plan.is_btcpay_recurring_enabled());
+
+    let blank_offering = test_config().with_btcpay(
+        Some("http://localhost:14142".to_string()),
+        Some("api-key-123".to_string()),
+        Some("store-id-456".to_string()),
+        Some("".to_string()),
+        Some("plan-abc".to_string()),
+    );
+    assert!(!blank_offering.is_btcpay_recurring_enabled());
+}
+
+#[test]
 fn test_redirect_response_valid_url() {
     use crate::handlers::donations::redirect_response;
     use axum::response::IntoResponse;

--- a/frontend/src/app/donations/layout.tsx
+++ b/frontend/src/app/donations/layout.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { AppHeader } from "@/components/app-header"
 import { AppFooter } from "@/components/app-footer"
 import { DemoBanner } from "@/components/demo-banner"


### PR DESCRIPTION
## Summary
- only mount the recurring donation endpoint when recurring BTCPay config is present
- return a clear service-unavailable response when recurring BTCPay donations are not configured
- fix the donations page layout wrapper so header and footer render consistently

## Testing
- cargo test test_btcpay --manifest-path backend/Cargo.toml
- pnpm exec jest --runInBand --runTestsByPath './src/app/api/[...slug]/route.test.ts'