### PR TITLE
Fix self-hosted auth token recovery

### DIFF
--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import { proxy } from './proxy'
+
+jest.mock('@formatjs/intl-localematcher', () => ({
+  match: jest.fn((languages: string[]) => (languages.some((language) => language.startsWith('nb')) ? 'nb' : 'en-US')),
+}))
+
+const originalCanaryMode = process.env.NEXT_PUBLIC_CANARY_MODE
+
+function base64UrlEncode(value: unknown): string {
+  return Buffer.from(JSON.stringify(value))
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+}
+
+function makeToken(payload: unknown): string {
+  return `${base64UrlEncode({ alg: 'none', typ: 'JWT' })}.${base64UrlEncode(payload)}.signature`
+}
+
+function makeRequest(path: string, cookie?: string, headers: Record<string, string> = {}) {
+  return new NextRequest(`http://localhost:3001${path}`, {
+    headers: {
+      ...headers,
+      ...(cookie ? { cookie } : {}),
+    },
+  })
+}
+
+function expectRedirectToSignIn(response: Response) {
+  expect(response.status).toBe(307)
+  expect(response.headers.get('location')).toBe('http://localhost:3001/sign-in')
+}
+
+describe('proxy self-hosted auth recovery', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_CANARY_MODE = 'self-hosted'
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+  })
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_CANARY_MODE = originalCanaryMode
+    jest.restoreAllMocks()
+  })
+
+  it('redirects page requests without an auth token to sign-in', () => {
+    const response = proxy(makeRequest('/wallets'))
+
+    expectRedirectToSignIn(response)
+    expect(response.headers.get('set-cookie')).toContain('locale=en-US')
+  })
+
+  it('redirects page requests with an expired auth token and clears it', () => {
+    const response = proxy(makeRequest('/wallets', `auth_token=${makeToken({ exp: 1_699_999_999 })}`))
+
+    expectRedirectToSignIn(response)
+    expect(response.headers.get('set-cookie')).toContain('auth_token=')
+  })
+
+  it('redirects page requests with a malformed auth token and clears it', () => {
+    const response = proxy(makeRequest('/wallets', 'auth_token=not-a-jwt'))
+
+    expectRedirectToSignIn(response)
+    expect(response.headers.get('set-cookie')).toContain('auth_token=')
+  })
+
+  it('allows page requests with an unexpired well-formed auth token', () => {
+    const response = proxy(makeRequest('/wallets', `auth_token=${makeToken({ exp: 1_700_000_001 })}; locale=nb`))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get('set-cookie')).toBeNull()
+  })
+
+  it('exempts sign-in and api paths from auth checks', () => {
+    const signInResponse = proxy(makeRequest('/sign-in', 'locale=nb'))
+    const apiResponse = proxy(makeRequest('/api/wallets', 'locale=nb'))
+
+    expect(signInResponse.status).toBe(200)
+    expect(signInResponse.headers.get('location')).toBeNull()
+    expect(apiResponse.status).toBe(200)
+    expect(apiResponse.headers.get('location')).toBeNull()
+  })
+})
+
+describe('proxy cloud mode locale behavior', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_CANARY_MODE = 'cloud'
+  })
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_CANARY_MODE = originalCanaryMode
+  })
+
+  it('does not require auth and keeps locale-only behavior', () => {
+    const response = proxy(makeRequest('/wallets', undefined, { 'accept-language': 'nb-NO,nb;q=0.9' }))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get('set-cookie')).toContain('locale=nb')
+  })
+})

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -6,6 +6,7 @@ import { locales, defaultLocale, type Locale } from './i18n/config'
 
 // Extended locales including Norwegian variants for matching
 const matcherLocales = ['en', 'en-US', 'nb', 'nn', 'no', 'es', 'es-419', 'pt', 'pt-BR', 'de', 'de-DE', 'fr', 'fr-FR', 'ja', 'da', 'sv']
+const selfHostedMode = 'self-hosted'
 
 function detectLocale(acceptLanguage: string | null): Locale {
   if (!acceptLanguage) return defaultLocale
@@ -35,12 +36,12 @@ function detectLocale(acceptLanguage: string | null): Locale {
   }
 }
 
-export function proxy(request: NextRequest) {
+function addLocaleCookie(request: NextRequest, response: NextResponse): NextResponse {
   const localeCookie = request.cookies.get('locale')?.value
 
   // Already has a valid locale preference
   if (localeCookie && locales.includes(localeCookie as Locale)) {
-    return NextResponse.next()
+    return response
   }
 
   // Detect from Accept-Language header
@@ -48,7 +49,6 @@ export function proxy(request: NextRequest) {
   const detectedLocale = detectLocale(acceptLanguage)
 
   // Set the locale cookie for future requests
-  const response = NextResponse.next()
   response.cookies.set('locale', detectedLocale, {
     maxAge: 60 * 60 * 24 * 365, // 1 year
     path: '/',
@@ -56,6 +56,69 @@ export function proxy(request: NextRequest) {
   })
 
   return response
+}
+
+function isAuthExemptPath(pathname: string): boolean {
+  return pathname === '/sign-in' || pathname.startsWith('/api/')
+}
+
+function decodeJwtPayload(token: string): unknown {
+  const parts = token.split('.')
+
+  if (parts.length !== 3 || !parts[1]) {
+    throw new Error('Malformed JWT')
+  }
+
+  const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+  const paddedBase64 = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=')
+
+  return JSON.parse(atob(paddedBase64))
+}
+
+function isExpiredAuthToken(token: string): boolean {
+  const payload = decodeJwtPayload(token)
+
+  if (!payload || typeof payload !== 'object' || !('exp' in payload)) {
+    throw new Error('Missing JWT exp')
+  }
+
+  const exp = (payload as { exp: unknown }).exp
+
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+    throw new Error('Invalid JWT exp')
+  }
+
+  return exp <= Math.floor(Date.now() / 1000)
+}
+
+function redirectToSignIn(request: NextRequest, shouldClearAuthToken = false): NextResponse {
+  const response = NextResponse.redirect(new URL('/sign-in', request.url))
+
+  if (shouldClearAuthToken) {
+    response.cookies.delete('auth_token')
+  }
+
+  return addLocaleCookie(request, response)
+}
+
+export function proxy(request: NextRequest) {
+  if (process.env.NEXT_PUBLIC_CANARY_MODE === selfHostedMode && !isAuthExemptPath(request.nextUrl.pathname)) {
+    const authToken = request.cookies.get('auth_token')?.value
+
+    if (!authToken) {
+      return redirectToSignIn(request)
+    }
+
+    try {
+      if (isExpiredAuthToken(authToken)) {
+        return redirectToSignIn(request, true)
+      }
+    } catch {
+      return redirectToSignIn(request, true)
+    }
+  }
+
+  return addLocaleCookie(request, NextResponse.next())
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- redirect self-hosted page requests with missing, expired, or malformed auth_token cookies to /sign-in
- clear expired or malformed auth_token cookies while preserving locale cookie behavior
- keep /sign-in, /api/*, and cloud mode behavior auth-exempt

## Testing
- npm test -- --runTestsByPath src/proxy.test.ts
- npm test
- npm run lint
- npm run build

Fixes #372