### PR TITLE
Enforce self-hosted session validation

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -425,10 +425,10 @@ impl AuthService {
         Ok(token)
     }
 
-    pub fn validate_token(&self, token: &str) -> Result<Claims> {
+    pub fn validate_token_with_secret(token: &str, jwt_secret: &str) -> Result<Claims> {
         let token_data = decode::<Claims>(
             token,
-            &DecodingKey::from_secret(self.jwt_secret.as_ref()),
+            &DecodingKey::from_secret(jwt_secret.as_ref()),
             &Validation::new(Algorithm::HS256),
         )?;
 
@@ -445,7 +445,7 @@ impl AuthService {
 /// Authenticate user from either a cookie token or Authorization header
 /// Cookie token takes precedence over Authorization header for security
 pub async fn authenticate_user(
-    metadata_db: Option<&MetadataDb>,
+    metadata_db: &MetadataDb,
     auth_header: Option<&str>,
     cookie_token: Option<&str>,
     jwt_secret: &str,
@@ -462,21 +462,17 @@ pub async fn authenticate_user(
         return Err(AuthError::Unauthorized);
     };
 
-    let auth_service = AuthService::new(jwt_secret.to_string(), None);
-    let claims = auth_service
-        .validate_token(&token)
+    let claims = AuthService::validate_token_with_secret(&token, jwt_secret)
         .map_err(|_| AuthError::Unauthorized)?;
 
-    if let Some(metadata_db) = metadata_db {
-        let token_hash = AuthService::hash_token(&token);
-        let has_session = metadata_db
-            .has_active_session(&token_hash)
-            .await
-            .map_err(AuthError::Internal)?;
+    let token_hash = AuthService::hash_token(&token);
+    let has_session = metadata_db
+        .has_active_session(&token_hash)
+        .await
+        .map_err(AuthError::Internal)?;
 
-        if !has_session {
-            return Err(AuthError::Unauthorized);
-        }
+    if !has_session {
+        return Err(AuthError::Unauthorized);
     }
 
     Ok(AuthUser {

--- a/backend/src/extractors/auth.rs
+++ b/backend/src/extractors/auth.rs
@@ -52,10 +52,8 @@ where
             .headers
             .get("authorization")
             .and_then(|h| h.to_str().ok());
-        let metadata_db = config.is_cloud_mode().then_some(&app_services.metadata_db);
-
         authenticate_user(
-            metadata_db,
+            &app_services.metadata_db,
             auth_header,
             cookie_token.as_deref(),
             jwt_secret,

--- a/backend/src/tests/auth.rs
+++ b/backend/src/tests/auth.rs
@@ -4,17 +4,19 @@ use crate::handlers::auth::update_password_and_revoke_sessions;
 use crate::metadata::MetadataDb;
 use tempfile::tempdir;
 
-async fn create_cloud_test_db() -> (MetadataDb, tempfile::TempDir) {
+async fn create_test_db(mode: OperatingMode) -> (MetadataDb, tempfile::TempDir) {
     let temp_dir = tempdir().unwrap();
     let db_path = temp_dir.path().join("test.db");
+    let frontend_url =
+        matches!(mode, OperatingMode::Cloud).then_some("http://localhost:3001".to_string());
 
     let test_config = AppConfig::new_for_test(
         NetworkConfig::Regtest,
         Some("tcp://127.0.0.1:50001".to_string()),
         "127.0.0.1:3000".to_string(),
         temp_dir.path().to_string_lossy().to_string(),
-        OperatingMode::Cloud,
-        Some("http://localhost:3001".to_string()),
+        mode,
+        frontend_url,
         Some("test-jwt-secret".to_string()),
     );
 
@@ -22,6 +24,14 @@ async fn create_cloud_test_db() -> (MetadataDb, tempfile::TempDir) {
         .await
         .unwrap();
     (db, temp_dir)
+}
+
+async fn create_cloud_test_db() -> (MetadataDb, tempfile::TempDir) {
+    create_test_db(OperatingMode::Cloud).await
+}
+
+async fn create_self_hosted_test_db() -> (MetadataDb, tempfile::TempDir) {
+    create_test_db(OperatingMode::SelfHosted).await
 }
 
 #[tokio::test]
@@ -45,7 +55,7 @@ async fn authenticate_user_rejects_token_without_active_session() {
         .unwrap();
     let auth_header = format!("Bearer {token}");
 
-    let err = authenticate_user(Some(&db), Some(&auth_header), None, "test-jwt-secret")
+    let err = authenticate_user(&db, Some(&auth_header), None, "test-jwt-secret")
         .await
         .unwrap_err();
 
@@ -82,14 +92,14 @@ async fn authenticate_user_rejects_token_after_logout() {
         .await
         .unwrap();
 
-    let user = authenticate_user(Some(&db), Some(&auth_header), None, "test-jwt-secret")
+    let user = authenticate_user(&db, Some(&auth_header), None, "test-jwt-secret")
         .await
         .unwrap();
     assert_eq!(user.user_id, user_id);
 
     db.delete_session(&token_hash).await.unwrap();
 
-    let err = authenticate_user(Some(&db), Some(&auth_header), None, "test-jwt-secret")
+    let err = authenticate_user(&db, Some(&auth_header), None, "test-jwt-secret")
         .await
         .unwrap_err();
     assert!(
@@ -142,10 +152,10 @@ async fn password_reset_helper_revokes_all_existing_tokens() {
         .await
         .unwrap();
 
-    let err_a = authenticate_user(Some(&db), Some(&auth_header_a), None, "test-jwt-secret")
+    let err_a = authenticate_user(&db, Some(&auth_header_a), None, "test-jwt-secret")
         .await
         .unwrap_err();
-    let err_b = authenticate_user(Some(&db), Some(&auth_header_b), None, "test-jwt-secret")
+    let err_b = authenticate_user(&db, Some(&auth_header_b), None, "test-jwt-secret")
         .await
         .unwrap_err();
 
@@ -154,4 +164,76 @@ async fn password_reset_helper_revokes_all_existing_tokens() {
 
     let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
     assert_eq!(user.password_hash, "new-hash");
+}
+
+#[tokio::test]
+async fn authenticate_user_rejects_self_hosted_token_without_active_session() {
+    let (db, _temp_dir) = create_self_hosted_test_db().await;
+    let auth_service = AuthService::new("test-jwt-secret".to_string(), None);
+
+    let token = auth_service
+        .generate_token("foss-user", "admin@local", true, false)
+        .unwrap();
+    let auth_header = format!("Bearer {token}");
+
+    let err = authenticate_user(&db, Some(&auth_header), None, "test-jwt-secret")
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("Authentication required"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn authenticate_user_accepts_self_hosted_token_with_active_session() {
+    let (db, _temp_dir) = create_self_hosted_test_db().await;
+    let auth_service = AuthService::new("test-jwt-secret".to_string(), None);
+
+    let token = auth_service
+        .generate_token("foss-user", "admin@local", true, false)
+        .unwrap();
+    db.create_session(
+        "foss-user",
+        &AuthService::hash_token(&token),
+        chrono::Utc::now() + chrono::Duration::days(7),
+    )
+    .await
+    .unwrap();
+
+    let auth_header = format!("Bearer {token}");
+    let user = authenticate_user(&db, Some(&auth_header), None, "test-jwt-secret")
+        .await
+        .unwrap();
+
+    assert_eq!(user.user_id, "foss-user");
+    assert!(user.is_admin);
+}
+
+#[tokio::test]
+async fn authenticate_user_rejects_token_with_expired_session() {
+    let (db, _temp_dir) = create_self_hosted_test_db().await;
+    let auth_service = AuthService::new("test-jwt-secret".to_string(), None);
+
+    let token = auth_service
+        .generate_token("foss-user", "admin@local", true, false)
+        .unwrap();
+    db.create_session(
+        "foss-user",
+        &AuthService::hash_token(&token),
+        chrono::Utc::now() - chrono::Duration::minutes(1),
+    )
+    .await
+    .unwrap();
+
+    let auth_header = format!("Bearer {token}");
+    let err = authenticate_user(&db, Some(&auth_header), None, "test-jwt-secret")
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("Authentication required"),
+        "unexpected error: {err}"
+    );
 }

--- a/backend/tests/auth_flow_tests.rs
+++ b/backend/tests/auth_flow_tests.rs
@@ -507,7 +507,7 @@ async fn test_cookie_auth_ignores_malformed_authorization_header() {
 }
 
 #[tokio::test]
-async fn test_self_hosted_allows_authenticated_route_with_jwt() {
+async fn test_self_hosted_rejects_jwt_without_session() {
     let test_app = create_test_app(OperatingMode::SelfHosted).await;
 
     let token = AuthService::new(TEST_SELF_HOSTED_JWT_SECRET.to_string(), None)
@@ -522,5 +522,103 @@ async fn test_self_hosted_allows_authenticated_route_with_jwt() {
         .unwrap();
 
     let response = test_app.router.oneshot(request).await.unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_self_hosted_login_me_logout_invalidates_session() {
+    let test_app = create_test_app(OperatingMode::SelfHosted).await;
+
+    let login_request = Request::builder()
+        .uri("/api/auth/login")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "email": "admin@local",
+                "password": "test-self-hosted-password"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let login_response = test_app
+        .router
+        .clone()
+        .oneshot(login_request)
+        .await
+        .unwrap();
+    assert_eq!(login_response.status(), StatusCode::OK);
+
+    let auth_cookie = extract_auth_cookie(
+        login_response
+            .headers()
+            .get("set-cookie")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+    )
+    .to_string();
+
+    let body = body_to_json(login_response.into_body()).await;
+    assert_eq!(body["user"]["email"], "admin@local");
+    let bearer_token = body["token"].as_str().unwrap().to_string();
+
+    let me_request = Request::builder()
+        .uri("/api/auth/me")
+        .method("GET")
+        .header("cookie", auth_cookie.clone())
+        .body(Body::empty())
+        .unwrap();
+
+    let me_response = test_app.router.clone().oneshot(me_request).await.unwrap();
+    assert_eq!(me_response.status(), StatusCode::OK);
+
+    let logout_request = Request::builder()
+        .uri("/api/auth/logout")
+        .method("POST")
+        .header("cookie", auth_cookie.clone())
+        .body(Body::empty())
+        .unwrap();
+
+    let logout_response = test_app
+        .router
+        .clone()
+        .oneshot(logout_request)
+        .await
+        .unwrap();
+    assert_eq!(logout_response.status(), StatusCode::OK);
+
+    let me_after_logout_request = Request::builder()
+        .uri("/api/auth/me")
+        .method("GET")
+        .header("cookie", auth_cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let me_after_logout_response = test_app
+        .router
+        .clone()
+        .oneshot(me_after_logout_request)
+        .await
+        .unwrap();
+    assert_eq!(me_after_logout_response.status(), StatusCode::UNAUTHORIZED);
+
+    let me_after_logout_bearer_request = Request::builder()
+        .uri("/api/auth/me")
+        .method("GET")
+        .header("authorization", format!("Bearer {}", bearer_token))
+        .body(Body::empty())
+        .unwrap();
+
+    let me_after_logout_bearer_response = test_app
+        .router
+        .clone()
+        .oneshot(me_after_logout_bearer_request)
+        .await
+        .unwrap();
+    assert_eq!(
+        me_after_logout_bearer_response.status(),
+        StatusCode::UNAUTHORIZED
+    );
 }

--- a/backend/tests/database_integrity_tests.rs
+++ b/backend/tests/database_integrity_tests.rs
@@ -5,7 +5,7 @@ use axum::{
 use bdk_wallet::rusqlite::{params, Connection};
 use canary::{
     api::{create_router_with_services, AppServices},
-    auth::AuthService,
+    auth::{AuthService, Claims},
     config::{AppConfig, NetworkConfig, OperatingMode},
     electrum::ElectrumClientManager,
     metadata::ProviderType,
@@ -13,6 +13,7 @@ use canary::{
     wallet::{WalletCreationService, WalletManager},
 };
 use http_body_util::BodyExt;
+use jsonwebtoken::{encode, EncodingKey, Header};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use tempfile::{tempdir, TempDir};
@@ -77,6 +78,26 @@ async fn create_test_app() -> TestApp {
             wallet_creation_service,
         })
     };
+    create_session_for_user(&app_services, "foss-user", "admin@local", true).await;
+    let regular_user_id = app_services
+        .metadata_db
+        .create_user(
+            "regular@example.com",
+            "hash",
+            Some("Regular User"),
+            true,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    create_session_for_user(
+        &app_services,
+        &regular_user_id,
+        "regular@example.com",
+        false,
+    )
+    .await;
 
     let notification_manager = Arc::new(Mutex::new(NotificationManager::new()));
     let electrum_manager = Some(Arc::new(ElectrumClientManager::new_mock_connected()));
@@ -97,9 +118,40 @@ async fn create_test_app() -> TestApp {
 }
 
 fn auth_token(user_id: &str, email: &str, is_admin: bool) -> String {
-    AuthService::new(TEST_JWT_SECRET.to_string(), None)
-        .generate_token(user_id, email, is_admin, false)
-        .unwrap()
+    let claims = Claims {
+        sub: user_id.to_string(),
+        email: email.to_string(),
+        is_admin,
+        is_demo: false,
+        exp: 4_102_444_800,
+        iat: 1_700_000_000,
+        jti: format!("test-{user_id}-{email}-{is_admin}"),
+    };
+
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_ref()),
+    )
+    .unwrap()
+}
+
+async fn create_session_for_user(
+    app_services: &AppServices,
+    user_id: &str,
+    email: &str,
+    is_admin: bool,
+) {
+    let token = auth_token(user_id, email, is_admin);
+    app_services
+        .metadata_db
+        .create_session(
+            user_id,
+            &AuthService::hash_token(&token),
+            chrono::Utc::now() + chrono::Duration::days(7),
+        )
+        .await
+        .unwrap();
 }
 
 async fn body_to_json(body: Body) -> Value {
@@ -494,7 +546,14 @@ fn assert_notification_log_method_is_null(db_path: &str, id: &str) {
 #[tokio::test]
 async fn database_health_and_integrity_require_admin_access() {
     let app = create_test_app().await;
-    let non_admin = auth_token("regular-user", "regular@example.com", false);
+    let regular_user = app
+        .app_services
+        .metadata_db
+        .get_user_by_email("regular@example.com")
+        .await
+        .unwrap()
+        .unwrap();
+    let non_admin = auth_token(&regular_user.id, "regular@example.com", false);
 
     let status = request_without_auth(&app.router, "GET", "/api/health/database").await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);

--- a/backend/tests/health_rate_limit_tests.rs
+++ b/backend/tests/health_rate_limit_tests.rs
@@ -4,12 +4,13 @@ use axum::{
 };
 use canary::{
     api::{create_router_with_services, AppServices},
-    auth::AuthService,
+    auth::{AuthService, Claims},
     config::{AppConfig, NetworkConfig, OperatingMode},
     notifications::NotificationManager,
     wallet::{WalletCreationService, WalletManager},
 };
 use http_body_util::BodyExt;
+use jsonwebtoken::{encode, EncodingKey, Header};
 use serde_json::Value;
 use std::sync::Arc;
 use tempfile::{tempdir, TempDir};
@@ -66,6 +67,7 @@ async fn create_self_hosted_test_app() -> TestApp {
             wallet_creation_service,
         })
     };
+    create_self_hosted_admin_session(&app_services).await;
 
     let notification_manager = Arc::new(Mutex::new(NotificationManager::new()));
     let router =
@@ -78,9 +80,35 @@ async fn create_self_hosted_test_app() -> TestApp {
 }
 
 fn self_hosted_admin_token() -> String {
-    AuthService::new(TEST_JWT_SECRET.to_string(), None)
-        .generate_token("foss-user", "admin@local", true, false)
-        .unwrap()
+    let claims = Claims {
+        sub: "foss-user".to_string(),
+        email: "admin@local".to_string(),
+        is_admin: true,
+        is_demo: false,
+        exp: 4_102_444_800,
+        iat: 1_700_000_000,
+        jti: "test-foss-user-admin".to_string(),
+    };
+
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_ref()),
+    )
+    .unwrap()
+}
+
+async fn create_self_hosted_admin_session(app_services: &AppServices) {
+    let token = self_hosted_admin_token();
+    app_services
+        .metadata_db
+        .create_session(
+            "foss-user",
+            &AuthService::hash_token(&token),
+            chrono::Utc::now() + chrono::Duration::days(7),
+        )
+        .await
+        .unwrap();
 }
 
 async fn body_to_json(body: Body) -> Value {

--- a/backend/tests/resource_limit_handlers_tests.rs
+++ b/backend/tests/resource_limit_handlers_tests.rs
@@ -6,13 +6,14 @@ use bdk_wallet::bitcoin::Network;
 use bdk_wallet::keys::DescriptorPublicKey;
 use canary::{
     api::{create_router_with_services, AppServices},
-    auth::{AuthService, DEV_TEST_PASSWORD},
+    auth::{AuthService, Claims, DEV_TEST_PASSWORD},
     config::{AppConfig, NetworkConfig, OperatingMode},
     electrum::ElectrumClientManager,
     notifications::NotificationManager,
     wallet::{WalletCreationService, WalletManager},
 };
 use http_body_util::BodyExt;
+use jsonwebtoken::{encode, EncodingKey, Header};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use tempfile::{tempdir, TempDir};
@@ -74,6 +75,10 @@ async fn create_test_app(
         })
     };
 
+    if test_config.is_self_hosted_mode() {
+        create_self_hosted_admin_session(&app_services).await;
+    }
+
     let notification_manager = Arc::new(Mutex::new(NotificationManager::new()));
     let electrum_manager = Some(Arc::new(ElectrumClientManager::new_mock_connected()));
 
@@ -131,9 +136,35 @@ async fn login_admin_user(app: &axum::Router) -> String {
 }
 
 fn self_hosted_admin_token() -> String {
-    AuthService::new(TEST_JWT_SECRET.to_string(), None)
-        .generate_token("foss-user", "admin@local", true, false)
-        .unwrap()
+    let claims = Claims {
+        sub: "foss-user".to_string(),
+        email: "admin@local".to_string(),
+        is_admin: true,
+        is_demo: false,
+        exp: 4_102_444_800,
+        iat: 1_700_000_000,
+        jti: "test-foss-user-admin".to_string(),
+    };
+
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_ref()),
+    )
+    .unwrap()
+}
+
+async fn create_self_hosted_admin_session(app_services: &AppServices) {
+    let token = self_hosted_admin_token();
+    app_services
+        .metadata_db
+        .create_session(
+            "foss-user",
+            &AuthService::hash_token(&token),
+            chrono::Utc::now() + chrono::Duration::days(7),
+        )
+        .await
+        .unwrap();
 }
 
 async fn create_wallet(app: &axum::Router, token: &str, name: &str, descriptor: &str) -> Value {

--- a/backend/tests/wallet_handlers_tests.rs
+++ b/backend/tests/wallet_handlers_tests.rs
@@ -10,7 +10,7 @@ use axum::{
 use bdk_wallet::rusqlite::Connection;
 use canary::{
     api::{create_router_with_services, AppServices},
-    auth::AuthService,
+    auth::{AuthService, Claims},
     config::{AppConfig, NetworkConfig, OperatingMode},
     electrum::ElectrumClientManager,
     metadata::{EventType, TransactionCursor, TransactionInsert},
@@ -19,6 +19,7 @@ use canary::{
     WalletDetailResponse, WalletMetadata, WalletsListResponse,
 };
 use http_body_util::BodyExt;
+use jsonwebtoken::{encode, EncodingKey, Header};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use tempfile::{tempdir, TempDir};
@@ -91,6 +92,8 @@ async fn create_test_app_with_services() -> (axum::Router, TempDir, Arc<AppServi
         })
     };
 
+    create_session_for_user(&app_services, "foss-user", "admin@local", true).await;
+
     let notification_manager = Arc::new(Mutex::new(NotificationManager::new()));
     let stripe_billing = None;
     // Use mock electrum manager that reports as connected (for testing without real server)
@@ -123,14 +126,49 @@ fn authorized_request_for_user(
     email: &str,
     is_admin: bool,
 ) -> Request<Body> {
-    let token = AuthService::new(TEST_SELF_HOSTED_JWT_SECRET.to_string(), None)
-        .generate_token(user_id, email, is_admin, false)
-        .unwrap();
+    let token = test_token_for_user(user_id, email, is_admin);
     let (mut parts, body) = request.into_parts();
     parts
         .headers
         .insert(AUTHORIZATION, format!("Bearer {}", token).parse().unwrap());
     Request::from_parts(parts, body)
+}
+
+fn test_token_for_user(user_id: &str, email: &str, is_admin: bool) -> String {
+    let claims = Claims {
+        sub: user_id.to_string(),
+        email: email.to_string(),
+        is_admin,
+        is_demo: false,
+        exp: 4_102_444_800,
+        iat: 1_700_000_000,
+        jti: format!("test-{user_id}-{email}-{is_admin}"),
+    };
+
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_SELF_HOSTED_JWT_SECRET.as_ref()),
+    )
+    .unwrap()
+}
+
+async fn create_session_for_user(
+    app_services: &AppServices,
+    user_id: &str,
+    email: &str,
+    is_admin: bool,
+) {
+    let token = test_token_for_user(user_id, email, is_admin);
+    app_services
+        .metadata_db
+        .create_session(
+            user_id,
+            &AuthService::hash_token(&token),
+            chrono::Utc::now() + chrono::Duration::days(7),
+        )
+        .await
+        .unwrap();
 }
 
 // =============================================================================
@@ -1032,6 +1070,14 @@ async fn test_get_transaction_notifications_forbidden_for_non_owner() {
         .await
         .unwrap();
 
+    let other_email = "other@example.com";
+    let other_user_id = app_services
+        .metadata_db
+        .create_user(other_email, "hash", Some("Other User"), true, None, None)
+        .await
+        .unwrap();
+    create_session_for_user(&app_services, &other_user_id, other_email, false).await;
+
     let request = Request::builder()
         .uri(format!(
             "/api/wallets/{}/transactions/{}/notifications",
@@ -1042,8 +1088,8 @@ async fn test_get_transaction_notifications_forbidden_for_non_owner() {
     let response = app
         .oneshot(authorized_request_for_user(
             request,
-            "other-user",
-            "other@example.com",
+            &other_user_id,
+            other_email,
             false,
         ))
         .await
@@ -1066,6 +1112,7 @@ async fn test_get_transaction_notifications_success_for_non_admin_owner() {
         .create_user(owner_email, "hash", Some("Owner User"), true, None, None)
         .await
         .unwrap();
+    create_session_for_user(&app_services, &owner_user_id, owner_email, false).await;
 
     let request = Request::builder()
         .uri("/api/wallets")


### PR DESCRIPTION
## Summary
- require active session rows for authenticated requests in self-hosted mode, matching cloud auth semantics
- remove the cloud-only session validation gate from the auth extractor
- update backend tests so self-hosted tokens are session-backed and logout invalidation is covered

## Testing
- cargo test authenticate_user -- --test-threads=1
- cargo test --test auth_flow_tests -- --test-threads=1
- cargo test --test wallet_handlers_tests -- --test-threads=1
- cargo test --test resource_limit_handlers_tests -- --test-threads=1
- cargo test --test health_rate_limit_tests -- --test-threads=1
- cargo test --test database_integrity_tests -- --test-threads=1
- cargo test -- --test-threads=1
- cargo fmt --check

## Notes
- cargo clippy --all-targets --all-features -- -D warnings was attempted but is currently blocked by existing unrelated lint failures in system tests and other modules.

Fixes #313