### PR TITLE
Detect Umbrel ntfy in self-hosted settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Real-time notifications in 9 languages via **[ntfy.sh](https://ntfy.sh)** push n
 
 **Supported Languages:** English, Norwegian, Spanish, Portuguese, German, French, Japanese, Danish, Swedish
 
-> **Umbrel / Docker note:** When running on Umbrel, the ntfy server URL in Settings must use the Docker internal hostname — not the URL you use in your browser. For example, if you access ntfy at `http://umbrel.local:13119`, the correct value in Canary's Settings is typically `http://ntfy_app_1` (the Docker container name). This is because the Canary backend sends notifications server-side from within the Docker network. Use "Send Test Notification" in Settings to verify your configuration.
+> **Umbrel / Docker note:** On Umbrel, Canary auto-detects the local ntfy app through the Docker-internal URL provided by the Umbrel package. You should not need to enter `http://ntfy_app_1` manually. Use "Send Test Notification" in Settings to verify your configuration.
 
 ## Self-Hosted vs. canarybitcoin.com
 

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -33,7 +33,6 @@ CANARY_SELF_HOSTED_ADMIN_PASSWORD=replace-with-a-strong-password
 # Default: https://ntfy.sh (public server)
 # Self-host your own ntfy server: https://ntfy.sh/docs/install/
 # NTFY_SERVER_URL=https://ntfy.example.com
-# On Umbrel, exports.sh sets this automatically when the ntfy app is installed.
 # Most operators should not set this manually; Umbrel exports.sh sets it automatically.
 # Use NTFY_SERVER_URL for custom servers outside detected app integrations.
 # CANARY_UMBREL_NTFY_URL=http://ntfy_app_1

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -33,7 +33,8 @@ CANARY_SELF_HOSTED_ADMIN_PASSWORD=replace-with-a-strong-password
 # Default: https://ntfy.sh (public server)
 # Self-host your own ntfy server: https://ntfy.sh/docs/install/
 # NTFY_SERVER_URL=https://ntfy.example.com
-# On Umbrel, local ntfy can be auto-detected via exports.sh:
+# On Umbrel, exports.sh sets this automatically when the ntfy app is installed.
+# Most operators should not set this manually; use NTFY_SERVER_URL for custom servers.
 # CANARY_UMBREL_NTFY_URL=http://ntfy_app_1
 
 #############################################

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -34,7 +34,8 @@ CANARY_SELF_HOSTED_ADMIN_PASSWORD=replace-with-a-strong-password
 # Self-host your own ntfy server: https://ntfy.sh/docs/install/
 # NTFY_SERVER_URL=https://ntfy.example.com
 # On Umbrel, exports.sh sets this automatically when the ntfy app is installed.
-# Most operators should not set this manually; use NTFY_SERVER_URL for custom servers.
+# Most operators should not set this manually; Umbrel exports.sh sets it automatically.
+# Use NTFY_SERVER_URL for custom servers outside detected app integrations.
 # CANARY_UMBREL_NTFY_URL=http://ntfy_app_1
 
 #############################################

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -33,6 +33,8 @@ CANARY_SELF_HOSTED_ADMIN_PASSWORD=replace-with-a-strong-password
 # Default: https://ntfy.sh (public server)
 # Self-host your own ntfy server: https://ntfy.sh/docs/install/
 # NTFY_SERVER_URL=https://ntfy.example.com
+# On Umbrel, local ntfy can be auto-detected via exports.sh:
+# CANARY_UMBREL_NTFY_URL=http://ntfy_app_1
 
 #############################################
 # SELF-HOSTED MODE FEATURES

--- a/backend/src/admin_notifications.rs
+++ b/backend/src/admin_notifications.rs
@@ -1,6 +1,9 @@
 use std::future::Future;
+use std::time::Duration;
 
 use reqwest::Client;
+
+const ADMIN_NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct AdminNotifications {
     client: Client,
@@ -25,7 +28,10 @@ impl AdminNotifications {
         };
 
         Self {
-            client: Client::new(),
+            client: Client::builder()
+                .timeout(ADMIN_NOTIFICATION_TIMEOUT)
+                .build()
+                .expect("failed to build admin notification HTTP client"),
             topic,
             server_url: server_url.into().trim_end_matches('/').to_string(),
         }

--- a/backend/src/admin_notifications.rs
+++ b/backend/src/admin_notifications.rs
@@ -1,9 +1,11 @@
 use std::future::Future;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use reqwest::Client;
 
 const ADMIN_NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(10);
+static ADMIN_NOTIFICATION_CLIENT: OnceLock<Client> = OnceLock::new();
 
 pub struct AdminNotifications {
     client: Client,
@@ -28,13 +30,21 @@ impl AdminNotifications {
         };
 
         Self {
-            client: Client::builder()
-                .timeout(ADMIN_NOTIFICATION_TIMEOUT)
-                .build()
-                .expect("failed to build admin notification HTTP client"),
+            client: Self::default_client(),
             topic,
             server_url: server_url.into().trim_end_matches('/').to_string(),
         }
+    }
+
+    fn default_client() -> Client {
+        ADMIN_NOTIFICATION_CLIENT
+            .get_or_init(|| {
+                Client::builder()
+                    .timeout(ADMIN_NOTIFICATION_TIMEOUT)
+                    .build()
+                    .expect("failed to build admin notification HTTP client")
+            })
+            .clone()
     }
 
     pub fn is_enabled(&self) -> bool {

--- a/backend/src/admin_notifications.rs
+++ b/backend/src/admin_notifications.rs
@@ -17,22 +17,17 @@ impl AdminNotifications {
         is_cloud_mode && std::env::var("ADMIN_NOTIFICATION_TOPIC").is_ok()
     }
 
-    pub fn new() -> Self {
+    pub fn new(server_url: impl Into<String>) -> Self {
         let topic = if Self::is_enabled_for_env() {
             std::env::var("ADMIN_NOTIFICATION_TOPIC").ok()
         } else {
             None
         };
 
-        let server_url = std::env::var("NTFY_SERVER_URL")
-            .unwrap_or_else(|_| "https://ntfy.sh".to_string())
-            .trim_end_matches('/')
-            .to_string();
-
         Self {
             client: Client::new(),
             topic,
-            server_url,
+            server_url: server_url.into().trim_end_matches('/').to_string(),
         }
     }
 
@@ -40,12 +35,12 @@ impl AdminNotifications {
         self.topic.is_some()
     }
 
-    pub fn spawn_if_enabled<F, Fut>(notification_fn: F) -> bool
+    pub fn spawn_if_enabled<F, Fut>(server_url: impl Into<String>, notification_fn: F) -> bool
     where
         F: FnOnce(AdminNotifications) -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
-        let admin_notifications = Self::new();
+        let admin_notifications = Self::new(server_url);
         if !admin_notifications.is_enabled() {
             return false;
         }
@@ -200,7 +195,9 @@ impl AdminNotifications {
 
 impl Default for AdminNotifications {
     fn default() -> Self {
-        Self::new()
+        Self::new(
+            std::env::var("NTFY_SERVER_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string()),
+        )
     }
 }
 
@@ -279,9 +276,10 @@ mod tests {
         std::env::remove_var("ADMIN_NOTIFICATION_TOPIC");
 
         let (sender, receiver) = tokio::sync::oneshot::channel();
-        let spawned = AdminNotifications::spawn_if_enabled(move |_| async move {
-            let _ = sender.send(());
-        });
+        let spawned =
+            AdminNotifications::spawn_if_enabled("https://ntfy.sh", move |_| async move {
+                let _ = sender.send(());
+            });
 
         assert!(!spawned);
         assert!(matches!(
@@ -301,9 +299,10 @@ mod tests {
         std::env::set_var("ADMIN_NOTIFICATION_TOPIC", "admin-topic");
 
         let (sender, receiver) = tokio::sync::oneshot::channel();
-        let spawned = AdminNotifications::spawn_if_enabled(move |_| async move {
-            let _ = sender.send(());
-        });
+        let spawned =
+            AdminNotifications::spawn_if_enabled("https://ntfy.sh", move |_| async move {
+                let _ = sender.send(());
+            });
 
         assert!(spawned);
         assert!(tokio::time::timeout(Duration::from_secs(1), receiver)

--- a/backend/src/admin_notifications.rs
+++ b/backend/src/admin_notifications.rs
@@ -193,14 +193,6 @@ impl AdminNotifications {
     }
 }
 
-impl Default for AdminNotifications {
-    fn default() -> Self {
-        Self::new(
-            std::env::var("NTFY_SERVER_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string()),
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::AdminNotifications;

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -340,14 +340,18 @@ impl AppConfig {
                 "⚠️  CANARY_UMBREL_NTFY_URL is only used in self-hosted mode; ignoring detected ntfy server in cloud mode"
             );
         }
-        let ntfy_servers = [NtfyServerConfig::new(
-            "umbrel-ntfy",
-            "ntfy",
-            umbrel_ntfy_url,
-        )]
-        .into_iter()
-        .flatten()
-        .collect();
+        let ntfy_servers = if operating_mode == OperatingMode::SelfHosted {
+            [NtfyServerConfig::new(
+                "umbrel-ntfy",
+                "ntfy",
+                umbrel_ntfy_url,
+            )]
+            .into_iter()
+            .flatten()
+            .collect()
+        } else {
+            Vec::new()
+        };
         let ntfy_fallback_url =
             std::env::var("NTFY_SERVER_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string());
 
@@ -459,10 +463,18 @@ impl AppConfig {
         &self.ntfy_servers
     }
 
+    fn single_detected_ntfy_server(&self) -> Option<&NtfyServerConfig> {
+        if self.is_self_hosted_mode() && self.ntfy_servers.len() == 1 {
+            self.ntfy_servers.first()
+        } else {
+            None
+        }
+    }
+
     /// Get the default ntfy server id for API config responses.
     pub fn default_ntfy_server_id(&self) -> String {
-        if self.is_self_hosted_mode() && self.ntfy_servers.len() == 1 {
-            self.ntfy_servers[0].id.clone()
+        if let Some(server) = self.single_detected_ntfy_server() {
+            server.id.clone()
         } else {
             "ntfy-sh".to_string()
         }
@@ -522,8 +534,8 @@ impl AppConfig {
     /// Get the default ntfy server URL.
     /// Detected self-hosted integrations take precedence over environment fallback.
     pub fn ntfy_server_url(&self) -> String {
-        if self.is_self_hosted_mode() && self.ntfy_servers.len() == 1 {
-            return self.ntfy_servers[0].base_url.clone();
+        if let Some(server) = self.single_detected_ntfy_server() {
+            return server.base_url.clone();
         }
 
         self.ntfy_fallback_url.clone()

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -520,6 +520,16 @@ impl AppConfig {
         self.ntfy_fallback_url.clone()
     }
 
+    /// Check whether a URL is one of the currently detected self-hosted ntfy servers.
+    pub fn is_detected_ntfy_server_url(&self, server_url: &str) -> bool {
+        let normalized_server_url = server_url.trim_end_matches('/');
+        self.is_self_hosted_mode()
+            && self
+                .ntfy_servers
+                .iter()
+                .any(|server| server.base_url.trim_end_matches('/') == normalized_server_url)
+    }
+
     /// Check if Twilio SMS provider should be enabled
     pub fn is_twilio_enabled(&self) -> bool {
         // Only allow Twilio in cloud mode, and only if configured
@@ -1098,6 +1108,8 @@ mod tests {
 
         assert_eq!(config.default_ntfy_server_id(), "umbrel-ntfy");
         assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
+        assert!(config.is_detected_ntfy_server_url("http://ntfy_app_1/"));
+        assert!(!config.is_detected_ntfy_server_url("https://ntfy.sh"));
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1157,6 +1157,7 @@ mod tests {
 
     #[test]
     fn test_ntfy_server_url_falls_back_to_env_without_detected_local() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = test_config_self_hosted(NetworkConfig::Regtest)
             .with_ntfy_fallback_url("https://ntfy.example.com");
 
@@ -1166,6 +1167,7 @@ mod tests {
 
     #[test]
     fn test_detected_ntfy_server_takes_precedence_over_fallback_url() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = test_config_self_hosted(NetworkConfig::Regtest)
             .with_ntfy_fallback_url("https://ntfy.example.com")
             .with_ntfy_servers(vec![NtfyServerConfig::new(
@@ -1181,6 +1183,7 @@ mod tests {
 
     #[test]
     fn test_ntfy_auth_only_allowed_for_matching_saved_or_detected_url() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let config = test_config_self_hosted(NetworkConfig::Regtest).with_ntfy_servers(vec![
             NtfyServerConfig::new(
                 "umbrel-ntfy",

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -16,10 +16,11 @@ pub struct NtfyServerConfig {
     pub id: String,
     pub name: String,
     pub base_url: String,
+    pub platform: Option<String>,
 }
 
 impl NtfyServerConfig {
-    fn new(id: &str, name: &str, base_url: Option<String>) -> Option<Self> {
+    fn new(id: &str, name: &str, base_url: Option<String>, platform: Option<&str>) -> Option<Self> {
         let normalized_base_url = base_url
             .map(|url| url.trim().trim_end_matches('/').to_string())
             .filter(|url| !url.is_empty());
@@ -28,6 +29,7 @@ impl NtfyServerConfig {
             id: id.to_string(),
             name: name.to_string(),
             base_url,
+            platform: platform.map(str::to_string),
         })
     }
 }
@@ -185,14 +187,15 @@ impl AppConfig {
         std::env::var(var_name).ok().and_then(|url| {
             let trimmed_url = url.trim();
             if trimmed_url.is_empty() {
-                eprintln!("⚠️  {} is blank and will be ignored", var_name);
+                tracing::warn!("{} is blank and will be ignored", var_name);
                 None
             } else if trimmed_url.starts_with("http://") || trimmed_url.starts_with("https://") {
                 Some(trimmed_url.trim_end_matches('/').to_string())
             } else {
-                eprintln!(
-                    "⚠️  {} must start with http:// or https://: '{}' — ignoring",
-                    var_name, url
+                tracing::warn!(
+                    "{} must start with http:// or https://: '{}' - ignoring",
+                    var_name,
+                    url
                 );
                 None
             }
@@ -278,47 +281,15 @@ impl AppConfig {
         let self_hosted_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
 
         // Load self-hosted tx explorer configuration (optional)
-        let mempool_url = std::env::var("CANARY_MEMPOOL_URL").ok().and_then(|url| {
-            if url.starts_with("http://") || url.starts_with("https://") {
-                Some(url)
-            } else {
-                eprintln!(
-                    "⚠️  CANARY_MEMPOOL_URL must start with http:// or https://: '{}' — ignoring",
-                    url
-                );
-                None
-            }
-        });
+        let mempool_url = Self::parse_url_env("CANARY_MEMPOOL_URL");
         let mempool_port = std::env::var("CANARY_MEMPOOL_PORT")
             .ok()
             .and_then(|s| s.parse().ok());
-        let bitfeed_url = std::env::var("CANARY_BITFEED_URL").ok().and_then(|url| {
-            if url.starts_with("http://") || url.starts_with("https://") {
-                Some(url)
-            } else {
-                eprintln!(
-                    "⚠️  CANARY_BITFEED_URL must start with http:// or https://: '{}' — ignoring",
-                    url
-                );
-                None
-            }
-        });
+        let bitfeed_url = Self::parse_url_env("CANARY_BITFEED_URL");
         let bitfeed_port = std::env::var("CANARY_BITFEED_PORT")
             .ok()
             .and_then(|s| s.parse().ok());
-        let btc_rpc_explorer_url = std::env::var("CANARY_BTC_RPC_EXPLORER_URL")
-            .ok()
-            .and_then(|url| {
-                if url.starts_with("http://") || url.starts_with("https://") {
-                    Some(url)
-                } else {
-                    eprintln!(
-                        "⚠️  CANARY_BTC_RPC_EXPLORER_URL must start with http:// or https://: '{}' — ignoring",
-                        url
-                    );
-                    None
-                }
-            });
+        let btc_rpc_explorer_url = Self::parse_url_env("CANARY_BTC_RPC_EXPLORER_URL");
         let btc_rpc_explorer_port = std::env::var("CANARY_BTC_RPC_EXPLORER_PORT")
             .ok()
             .and_then(|s| s.parse().ok());
@@ -338,8 +309,8 @@ impl AppConfig {
 
         let umbrel_ntfy_url = Self::parse_url_env("CANARY_UMBREL_NTFY_URL");
         if operating_mode == OperatingMode::Cloud && umbrel_ntfy_url.is_some() {
-            eprintln!(
-                "⚠️  CANARY_UMBREL_NTFY_URL is only used in self-hosted mode; ignoring detected ntfy server in cloud mode"
+            tracing::warn!(
+                "CANARY_UMBREL_NTFY_URL is only used in self-hosted mode; ignoring detected ntfy server in cloud mode"
             );
         }
         let ntfy_servers = if operating_mode == OperatingMode::SelfHosted {
@@ -347,6 +318,7 @@ impl AppConfig {
                 "umbrel-ntfy",
                 "ntfy",
                 umbrel_ntfy_url,
+                Some("umbrel"),
             )]
             .into_iter()
             .flatten()
@@ -559,7 +531,13 @@ impl AppConfig {
         server_url: &str,
         user_configured_server_url: Option<&str>,
     ) -> bool {
-        user_configured_server_url.is_some() || self.is_detected_ntfy_server_url(server_url)
+        let normalized_server_url = server_url.trim().trim_end_matches('/');
+        let matches_user_configured_url = user_configured_server_url
+            .map(|url| url.trim().trim_end_matches('/'))
+            .filter(|url| !url.is_empty())
+            .is_some_and(|url| url == normalized_server_url);
+
+        matches_user_configured_url || self.is_detected_ntfy_server_url(server_url)
     }
 
     /// Check if Twilio SMS provider should be enabled
@@ -1134,12 +1112,14 @@ mod tests {
                 "umbrel-ntfy",
                 "ntfy",
                 Some("http://ntfy_app_1/".to_string()),
+                Some("umbrel"),
             )
             .unwrap(),
         ]);
 
         assert_eq!(config.default_ntfy_server_id(), "umbrel-ntfy");
         assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
+        assert_eq!(config.ntfy_servers()[0].platform.as_deref(), Some("umbrel"));
         assert!(config.is_detected_ntfy_server_url("http://ntfy_app_1/"));
         assert!(config.is_detected_ntfy_server_url(" http://ntfy_app_1/"));
         assert!(!config.is_detected_ntfy_server_url("https://ntfy.sh"));
@@ -1147,7 +1127,13 @@ mod tests {
 
     #[test]
     fn test_ntfy_server_config_rejects_blank_url() {
-        assert!(NtfyServerConfig::new("umbrel-ntfy", "ntfy", Some("   ".to_string())).is_none());
+        assert!(NtfyServerConfig::new(
+            "umbrel-ntfy",
+            "ntfy",
+            Some("   ".to_string()),
+            Some("umbrel")
+        )
+        .is_none());
     }
 
     #[test]
@@ -1186,10 +1172,33 @@ mod tests {
                 "umbrel-ntfy",
                 "ntfy",
                 Some("http://ntfy_app_1".to_string()),
+                Some("umbrel"),
             )
             .unwrap()]);
 
         assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
+    }
+
+    #[test]
+    fn test_ntfy_auth_only_allowed_for_matching_saved_or_detected_url() {
+        let config = test_config_self_hosted(NetworkConfig::Regtest).with_ntfy_servers(vec![
+            NtfyServerConfig::new(
+                "umbrel-ntfy",
+                "ntfy",
+                Some("http://ntfy_app_1".to_string()),
+                Some("umbrel"),
+            )
+            .unwrap(),
+        ]);
+
+        assert!(config.should_use_ntfy_auth_for_url(
+            "https://ntfy.example.com/",
+            Some(" https://ntfy.example.com ")
+        ));
+        assert!(config.should_use_ntfy_auth_for_url("http://ntfy_app_1", None));
+        assert!(!config
+            .should_use_ntfy_auth_for_url("https://ntfy.sh", Some("https://ntfy.example.com")));
+        assert!(!config.should_use_ntfy_auth_for_url("https://ntfy.sh", Some("")));
     }
 
     #[test]
@@ -1201,6 +1210,7 @@ mod tests {
                 "umbrel-ntfy",
                 "ntfy",
                 Some("http://ntfy_app_1".to_string()),
+                Some("umbrel"),
             )
             .unwrap()]);
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -107,7 +107,7 @@ impl std::str::FromStr for NetworkConfig {
 #[derive(Debug, Clone, Parser)]
 #[command(name = "canary")]
 #[command(about = "Bitcoin wallet management service")]
-struct AppConfigArgs {
+pub(crate) struct AppConfigArgs {
     /// Bitcoin network to use
     #[arg(long, value_enum)]
     pub network: Option<NetworkConfig>,
@@ -223,7 +223,7 @@ impl AppConfig {
         Self::load_from_args(args)
     }
 
-    fn load_from_args(args: AppConfigArgs) -> Result<Self> {
+    pub(crate) fn load_from_args(args: AppConfigArgs) -> Result<Self> {
         // Resolve network configuration (CLI args override env vars)
         let network = match args.network.or_else(|| {
             std::env::var("CANARY_NETWORK")

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1251,6 +1251,7 @@ mod tests {
     #[test]
     fn test_ntfy_fallback_url_env_validates_configured_url() {
         let _guard = ENV_LOCK.lock().unwrap();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
 
         std::env::set_var("NTFY_SERVER_URL", "   ");
         assert!(AppConfig::parse_url_env("NTFY_SERVER_URL").is_none());
@@ -1264,12 +1265,11 @@ mod tests {
             Some("https://ntfy.example.com")
         );
 
-        std::env::remove_var("NTFY_SERVER_URL");
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
     }
 
     #[test]
     fn test_ntfy_server_url_falls_back_to_env_without_detected_local() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let config = test_config_self_hosted(NetworkConfig::Regtest)
             .with_ntfy_fallback_url("https://ntfy.example.com");
 
@@ -1295,7 +1295,6 @@ mod tests {
 
     #[test]
     fn test_ntfy_auth_only_allowed_for_matching_saved_or_detected_url() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let config = test_config_self_hosted(NetworkConfig::Regtest).with_ntfy_servers(vec![
             NtfyServerConfig::new(
                 "umbrel-ntfy",
@@ -1314,6 +1313,13 @@ mod tests {
         assert!(!config
             .should_use_ntfy_auth_for_url("https://ntfy.sh", Some("https://ntfy.example.com")));
         assert!(!config.should_use_ntfy_auth_for_url("https://ntfy.sh", Some("")));
+    }
+
+    #[test]
+    fn test_ntfy_auth_allowed_for_matching_configured_url_in_cloud_mode() {
+        let config = test_config(NetworkConfig::Mainnet);
+
+        assert!(config.should_use_ntfy_auth_for_url("https://ntfy.sh", Some("https://ntfy.sh")));
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -11,6 +11,27 @@ pub struct TxExplorerConfig {
     pub port: Option<u16>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NtfyServerConfig {
+    pub id: String,
+    pub name: String,
+    pub base_url: String,
+}
+
+impl NtfyServerConfig {
+    fn new(id: &str, name: &str, base_url: Option<String>) -> Option<Self> {
+        let normalized_base_url = base_url
+            .map(|url| url.trim_end_matches('/').to_string())
+            .filter(|url| !url.is_empty());
+
+        normalized_base_url.map(|base_url| Self {
+            id: id.to_string(),
+            name: name.to_string(),
+            base_url,
+        })
+    }
+}
+
 impl TxExplorerConfig {
     fn new(id: &str, name: &str, base_url: Option<String>, port: Option<u16>) -> Option<Self> {
         let normalized_base_url = base_url.map(|url| url.trim_end_matches('/').to_string());
@@ -143,6 +164,8 @@ pub struct AppConfig {
     self_hosted_admin_password: Option<String>,
     /// Available self-hosted transaction explorers.
     tx_explorers: Vec<TxExplorerConfig>,
+    /// Available self-hosted ntfy servers.
+    ntfy_servers: Vec<NtfyServerConfig>,
     /// BTCPay Server URL (e.g., https://btcpay.enogtjue.no)
     btcpay_url: Option<String>,
     /// BTCPay Server API key
@@ -293,6 +316,28 @@ impl AppConfig {
         .flatten()
         .collect();
 
+        let umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL")
+            .ok()
+            .and_then(|url| {
+                if url.starts_with("http://") || url.starts_with("https://") {
+                    Some(url)
+                } else {
+                    eprintln!(
+                        "⚠️  CANARY_UMBREL_NTFY_URL must start with http:// or https://: '{}' — ignoring",
+                        url
+                    );
+                    None
+                }
+            });
+        let ntfy_servers = [NtfyServerConfig::new(
+            "umbrel-ntfy",
+            "ntfy",
+            umbrel_ntfy_url,
+        )]
+        .into_iter()
+        .flatten()
+        .collect();
+
         // Load BTCPay configuration (optional, cloud mode only)
         let btcpay_url = std::env::var("BTCPAY_URL").ok();
         let btcpay_api_key = std::env::var("BTCPAY_API_KEY").ok();
@@ -334,6 +379,7 @@ impl AppConfig {
             jwt_secret,
             self_hosted_admin_password,
             tx_explorers,
+            ntfy_servers,
             btcpay_url,
             btcpay_api_key,
             btcpay_store_id,
@@ -394,6 +440,20 @@ impl AppConfig {
         &self.tx_explorers
     }
 
+    /// Get configured self-hosted ntfy servers.
+    pub fn ntfy_servers(&self) -> &[NtfyServerConfig] {
+        &self.ntfy_servers
+    }
+
+    /// Get the default ntfy server id for API config responses.
+    pub fn default_ntfy_server_id(&self) -> String {
+        if self.is_self_hosted_mode() && self.ntfy_servers.len() == 1 {
+            self.ntfy_servers[0].id.clone()
+        } else {
+            "ntfy-sh".to_string()
+        }
+    }
+
     /// Check if BTCPay Server integration is fully configured
     pub fn is_btcpay_enabled(&self) -> bool {
         self.btcpay_url.is_some() && self.btcpay_api_key.is_some() && self.btcpay_store_id.is_some()
@@ -445,9 +505,13 @@ impl AppConfig {
         true
     }
 
-    /// Get the ntfy server URL (defaults to https://ntfy.sh)
-    /// Self-hosted users can configure their own ntfy server via NTFY_SERVER_URL
+    /// Get the default ntfy server URL.
+    /// Detected self-hosted integrations take precedence over environment fallback.
     pub fn ntfy_server_url(&self) -> String {
+        if self.is_self_hosted_mode() && self.ntfy_servers.len() == 1 {
+            return self.ntfy_servers[0].base_url.clone();
+        }
+
         std::env::var("NTFY_SERVER_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string())
     }
 
@@ -659,6 +723,7 @@ impl AppConfig {
             jwt_secret,
             self_hosted_admin_password,
             tx_explorers: Vec::new(),
+            ntfy_servers: Vec::new(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -670,6 +735,12 @@ impl AppConfig {
     /// Set tx explorers on a test config (builder pattern)
     pub fn with_tx_explorers(mut self, tx_explorers: Vec<TxExplorerConfig>) -> Self {
         self.tx_explorers = tx_explorers;
+        self
+    }
+
+    /// Set ntfy servers on a test config (builder pattern)
+    pub fn with_ntfy_servers(mut self, ntfy_servers: Vec<NtfyServerConfig>) -> Self {
+        self.ntfy_servers = ntfy_servers;
         self
     }
 
@@ -694,6 +765,9 @@ impl AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_network_config_parsing() {
@@ -747,6 +821,7 @@ mod tests {
             jwt_secret: Some("test-jwt-secret".to_string()),
             self_hosted_admin_password: None,
             tx_explorers: Vec::new(),
+            ntfy_servers: Vec::new(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -766,6 +841,7 @@ mod tests {
             jwt_secret: Some("test-jwt-secret".to_string()),
             self_hosted_admin_password: None,
             tx_explorers: Vec::new(),
+            ntfy_servers: Vec::new(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -785,6 +861,7 @@ mod tests {
             jwt_secret: Some("test-self-hosted-jwt-secret".to_string()),
             self_hosted_admin_password: Some("self-hosted-password".to_string()),
             tx_explorers: Vec::new(),
+            ntfy_servers: Vec::new(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -948,6 +1025,7 @@ mod tests {
             jwt_secret: Some("test-jwt-secret".to_string()),
             self_hosted_admin_password: None,
             tx_explorers: Vec::new(),
+            ntfy_servers: Vec::new(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -990,6 +1068,51 @@ mod tests {
     }
 
     #[test]
+    fn test_detected_ntfy_server_becomes_self_hosted_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("NTFY_SERVER_URL");
+        let config = test_config_self_hosted(NetworkConfig::Regtest).with_ntfy_servers(vec![
+            NtfyServerConfig::new(
+                "umbrel-ntfy",
+                "ntfy",
+                Some("http://ntfy_app_1/".to_string()),
+            )
+            .unwrap(),
+        ]);
+
+        assert_eq!(config.default_ntfy_server_id(), "umbrel-ntfy");
+        assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
+    }
+
+    #[test]
+    fn test_ntfy_server_url_falls_back_to_env_without_detected_local() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("NTFY_SERVER_URL", "https://ntfy.example.com");
+        let config = test_config_self_hosted(NetworkConfig::Regtest);
+
+        assert_eq!(config.default_ntfy_server_id(), "ntfy-sh");
+        assert_eq!(config.ntfy_server_url(), "https://ntfy.example.com");
+
+        std::env::remove_var("NTFY_SERVER_URL");
+    }
+
+    #[test]
+    fn test_cloud_mode_ignores_detected_ntfy_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("NTFY_SERVER_URL");
+        let config =
+            test_config(NetworkConfig::Regtest).with_ntfy_servers(vec![NtfyServerConfig::new(
+                "umbrel-ntfy",
+                "ntfy",
+                Some("http://ntfy_app_1".to_string()),
+            )
+            .unwrap()]);
+
+        assert_eq!(config.default_ntfy_server_id(), "ntfy-sh");
+        assert_eq!(config.ntfy_server_url(), "https://ntfy.sh");
+    }
+
+    #[test]
     fn test_get_jwt_secret_cloud_mode_with_secret() {
         let config = test_config(NetworkConfig::Regtest);
         assert_eq!(config.get_jwt_secret().unwrap(), "test-jwt-secret");
@@ -1007,6 +1130,7 @@ mod tests {
             jwt_secret: None, // Missing JWT secret
             self_hosted_admin_password: None,
             tx_explorers: Vec::new(),
+            ntfy_servers: Vec::new(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1058,6 +1182,7 @@ mod tests {
             jwt_secret: Some("   ".to_string()),
             self_hosted_admin_password: Some("self-hosted-password".to_string()),
             tx_explorers: Vec::new(),
+            ntfy_servers: Vec::new(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1083,6 +1208,7 @@ mod tests {
             jwt_secret: Some("test-self-hosted-jwt-secret".to_string()),
             self_hosted_admin_password: Some("   ".to_string()),
             tx_explorers: Vec::new(),
+            ntfy_servers: Vec::new(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -21,8 +21,8 @@ pub struct NtfyServerConfig {
 impl NtfyServerConfig {
     fn new(id: &str, name: &str, base_url: Option<String>) -> Option<Self> {
         let normalized_base_url = base_url
-            .map(|url| url.trim_end_matches('/').to_string())
-            .filter(|url| !url.trim().is_empty());
+            .map(|url| url.trim().trim_end_matches('/').to_string())
+            .filter(|url| !url.is_empty());
 
         normalized_base_url.map(|base_url| Self {
             id: id.to_string(),
@@ -318,19 +318,28 @@ impl AppConfig {
         .flatten()
         .collect();
 
-        let umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL")
-            .ok()
-            .and_then(|url| {
-                if url.starts_with("http://") || url.starts_with("https://") {
-                    Some(url)
-                } else {
-                    eprintln!(
-                        "⚠️  CANARY_UMBREL_NTFY_URL must start with http:// or https://: '{}' — ignoring",
-                        url
-                    );
-                    None
-                }
-            });
+        let umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok().and_then(|url| {
+            let trimmed_url = url.trim();
+            if trimmed_url.is_empty() {
+                eprintln!("⚠️  CANARY_UMBREL_NTFY_URL is blank and will be ignored");
+                None
+            } else if trimmed_url.starts_with("http://")
+                || trimmed_url.starts_with("https://")
+            {
+                Some(trimmed_url.to_string())
+            } else {
+                eprintln!(
+                    "⚠️  CANARY_UMBREL_NTFY_URL must start with http:// or https://: '{}' — ignoring",
+                    url
+                );
+                None
+            }
+        });
+        if operating_mode == OperatingMode::Cloud && umbrel_ntfy_url.is_some() {
+            eprintln!(
+                "⚠️  CANARY_UMBREL_NTFY_URL is only used in self-hosted mode; ignoring detected ntfy server in cloud mode"
+            );
+        }
         let ntfy_servers = [NtfyServerConfig::new(
             "umbrel-ntfy",
             "ntfy",

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -354,6 +354,11 @@ impl AppConfig {
         } else {
             Vec::new()
         };
+        if ntfy_servers.len() > 1 {
+            eprintln!(
+                "⚠️  Multiple local ntfy servers detected; falling back to configured public/default ntfy server"
+            );
+        }
         let ntfy_fallback_url =
             Self::parse_url_env("NTFY_SERVER_URL").unwrap_or_else(|| "https://ntfy.sh".to_string());
 
@@ -469,11 +474,6 @@ impl AppConfig {
         if self.is_self_hosted_mode() && self.ntfy_servers.len() == 1 {
             self.ntfy_servers.first()
         } else {
-            if self.is_self_hosted_mode() && self.ntfy_servers.len() > 1 {
-                eprintln!(
-                    "⚠️  Multiple local ntfy servers detected; falling back to configured public/default ntfy server"
-                );
-            }
             None
         }
     }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -314,9 +314,18 @@ impl AppConfig {
         .collect();
 
         let umbrel_ntfy_url = Self::parse_url_env("CANARY_UMBREL_NTFY_URL");
+        let configured_ntfy_fallback_url = Self::parse_url_env("NTFY_SERVER_URL");
         if operating_mode == OperatingMode::Cloud && umbrel_ntfy_url.is_some() {
             tracing::warn!(
                 "CANARY_UMBREL_NTFY_URL is only used in self-hosted mode; ignoring detected ntfy server in cloud mode"
+            );
+        }
+        if operating_mode == OperatingMode::SelfHosted
+            && umbrel_ntfy_url.is_some()
+            && configured_ntfy_fallback_url.is_some()
+        {
+            tracing::warn!(
+                "CANARY_UMBREL_NTFY_URL is set; detected Umbrel ntfy server will take precedence over NTFY_SERVER_URL"
             );
         }
         let ntfy_servers = if operating_mode == OperatingMode::SelfHosted {
@@ -333,7 +342,7 @@ impl AppConfig {
             Vec::new()
         };
         let ntfy_fallback_url =
-            Self::parse_url_env("NTFY_SERVER_URL").unwrap_or_else(|| "https://ntfy.sh".to_string());
+            configured_ntfy_fallback_url.unwrap_or_else(|| "https://ntfy.sh".to_string());
 
         // Load BTCPay configuration (optional, cloud mode only)
         let btcpay_url = std::env::var("BTCPAY_URL").ok();
@@ -451,7 +460,7 @@ impl AppConfig {
         match self.ntfy_servers.as_slice() {
             [server] => Some(server),
             servers if servers.len() > 1 => {
-                tracing::info!(
+                tracing::debug!(
                     count = servers.len(),
                     "Multiple detected ntfy servers configured; falling back to explicit default selection"
                 );
@@ -1187,6 +1196,39 @@ mod tests {
         assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
         assert_eq!(config.ntfy_servers().len(), 1);
         assert_eq!(config.ntfy_servers()[0].platform.as_deref(), Some("umbrel"));
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("JWT_SECRET", previous_jwt);
+        restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
+        restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
+    }
+
+    #[test]
+    fn test_detected_umbrel_ntfy_url_takes_precedence_over_fallback_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_jwt = std::env::var("JWT_SECRET").ok();
+        let previous_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
+        let previous_umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
+        std::env::set_var("CANARY_MODE", "self-hosted");
+        std::env::set_var("JWT_SECRET", "test-jwt-secret");
+        std::env::set_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", "test-admin-password");
+        std::env::set_var("CANARY_UMBREL_NTFY_URL", "http://ntfy_app_1");
+        std::env::set_var("NTFY_SERVER_URL", "https://ntfy.example.com");
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Mainnet),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .expect("self-hosted config should load");
+
+        assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
+        assert_eq!(config.default_ntfy_server_id(), UMBREL_NTFY_SERVER_ID);
 
         restore_env_var("CANARY_MODE", previous_mode);
         restore_env_var("JWT_SECRET", previous_jwt);

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -354,11 +354,6 @@ impl AppConfig {
         } else {
             Vec::new()
         };
-        if ntfy_servers.len() > 1 {
-            eprintln!(
-                "⚠️  Multiple local ntfy servers detected; falling back to configured public/default ntfy server"
-            );
-        }
         let ntfy_fallback_url =
             Self::parse_url_env("NTFY_SERVER_URL").unwrap_or_else(|| "https://ntfy.sh".to_string());
 
@@ -556,6 +551,15 @@ impl AppConfig {
                 .ntfy_servers
                 .iter()
                 .any(|server| server.base_url.trim_end_matches('/') == normalized_server_url)
+    }
+
+    /// Auth may be sent only to explicitly configured user URLs or detected local integrations.
+    pub fn should_use_ntfy_auth_for_url(
+        &self,
+        server_url: &str,
+        user_configured_server_url: Option<&str>,
+    ) -> bool {
+        user_configured_server_url.is_some() || self.is_detected_ntfy_server_url(server_url)
     }
 
     /// Check if Twilio SMS provider should be enabled

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1137,6 +1137,8 @@ mod tests {
     #[test]
     fn test_detected_ntfy_server_becomes_self_hosted_default() {
         let _guard = ENV_LOCK.lock().unwrap();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
         std::env::remove_var("NTFY_SERVER_URL");
         let config = test_config_self_hosted(NetworkConfig::Regtest).with_ntfy_servers(vec![
             NtfyServerConfig::new(
@@ -1154,6 +1156,8 @@ mod tests {
         assert!(config.is_detected_ntfy_server_url("http://ntfy_app_1/"));
         assert!(config.is_detected_ntfy_server_url(" http://ntfy_app_1/"));
         assert!(!config.is_detected_ntfy_server_url("https://ntfy.sh"));
+
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
     }
 
     #[test]
@@ -1273,6 +1277,8 @@ mod tests {
     #[test]
     fn test_cloud_mode_ignores_detected_ntfy_default() {
         let _guard = ENV_LOCK.lock().unwrap();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
         std::env::remove_var("NTFY_SERVER_URL");
         let config =
             test_config(NetworkConfig::Regtest).with_ntfy_servers(vec![NtfyServerConfig::new(
@@ -1285,6 +1291,8 @@ mod tests {
 
         assert_eq!(config.default_ntfy_server_id(), "ntfy-sh");
         assert_eq!(config.ntfy_server_url(), "https://ntfy.sh");
+
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -3,6 +3,9 @@ use bdk_wallet::bitcoin::Network;
 use clap::{Parser, ValueEnum};
 use serde::Serialize;
 
+pub const PUBLIC_NTFY_SERVER_ID: &str = "ntfy-sh";
+pub const UMBREL_NTFY_SERVER_ID: &str = "umbrel-ntfy";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TxExplorerConfig {
     pub id: String,
@@ -318,7 +321,7 @@ impl AppConfig {
         }
         let ntfy_servers = if operating_mode == OperatingMode::SelfHosted {
             [NtfyServerConfig::new(
-                "umbrel-ntfy",
+                UMBREL_NTFY_SERVER_ID,
                 "ntfy",
                 umbrel_ntfy_url,
                 Some("umbrel"),
@@ -441,10 +444,20 @@ impl AppConfig {
     }
 
     fn single_detected_ntfy_server(&self) -> Option<&NtfyServerConfig> {
-        if self.is_self_hosted_mode() && self.ntfy_servers.len() == 1 {
-            self.ntfy_servers.first()
-        } else {
-            None
+        if !self.is_self_hosted_mode() {
+            return None;
+        }
+
+        match self.ntfy_servers.as_slice() {
+            [server] => Some(server),
+            servers if servers.len() > 1 => {
+                tracing::info!(
+                    count = servers.len(),
+                    "Multiple detected ntfy servers configured; falling back to explicit default selection"
+                );
+                None
+            }
+            _ => None,
         }
     }
 
@@ -453,7 +466,7 @@ impl AppConfig {
         if let Some(server) = self.single_detected_ntfy_server() {
             server.id.clone()
         } else {
-            "ntfy-sh".to_string()
+            PUBLIC_NTFY_SERVER_ID.to_string()
         }
     }
 
@@ -1029,18 +1042,23 @@ mod tests {
 
     #[test]
     fn test_self_hosted_mode_sync_interval_legacy_fallback() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_sync_interval = std::env::var("CANARY_SYNC_INTERVAL").ok();
+
         // Set CANARY_SYNC_INTERVAL for self-hosted mode
         std::env::set_var("CANARY_SYNC_INTERVAL", "42");
 
         let config = test_config_self_hosted(NetworkConfig::Mainnet);
         assert_eq!(config.get_sync_interval(), 42);
 
-        // Clean up
-        std::env::remove_var("CANARY_SYNC_INTERVAL");
+        restore_env_var("CANARY_SYNC_INTERVAL", previous_sync_interval);
     }
 
     #[test]
     fn test_self_hosted_mode_sync_interval_network_defaults() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_sync_interval = std::env::var("CANARY_SYNC_INTERVAL").ok();
+
         // No CANARY_SYNC_INTERVAL, should use network defaults
         std::env::remove_var("CANARY_SYNC_INTERVAL");
 
@@ -1049,6 +1067,8 @@ mod tests {
 
         let mainnet_config = test_config_self_hosted(NetworkConfig::Mainnet);
         assert_eq!(mainnet_config.get_sync_interval(), 300);
+
+        restore_env_var("CANARY_SYNC_INTERVAL", previous_sync_interval);
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -181,6 +181,24 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
+    fn parse_url_env(var_name: &str) -> Option<String> {
+        std::env::var(var_name).ok().and_then(|url| {
+            let trimmed_url = url.trim();
+            if trimmed_url.is_empty() {
+                eprintln!("⚠️  {} is blank and will be ignored", var_name);
+                None
+            } else if trimmed_url.starts_with("http://") || trimmed_url.starts_with("https://") {
+                Some(trimmed_url.trim_end_matches('/').to_string())
+            } else {
+                eprintln!(
+                    "⚠️  {} must start with http:// or https://: '{}' — ignoring",
+                    var_name, url
+                );
+                None
+            }
+        })
+    }
+
     fn require_non_empty_config<'a>(
         value: Option<&'a str>,
         missing_message: &'static str,
@@ -318,23 +336,7 @@ impl AppConfig {
         .flatten()
         .collect();
 
-        let umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok().and_then(|url| {
-            let trimmed_url = url.trim();
-            if trimmed_url.is_empty() {
-                eprintln!("⚠️  CANARY_UMBREL_NTFY_URL is blank and will be ignored");
-                None
-            } else if trimmed_url.starts_with("http://")
-                || trimmed_url.starts_with("https://")
-            {
-                Some(trimmed_url.to_string())
-            } else {
-                eprintln!(
-                    "⚠️  CANARY_UMBREL_NTFY_URL must start with http:// or https://: '{}' — ignoring",
-                    url
-                );
-                None
-            }
-        });
+        let umbrel_ntfy_url = Self::parse_url_env("CANARY_UMBREL_NTFY_URL");
         if operating_mode == OperatingMode::Cloud && umbrel_ntfy_url.is_some() {
             eprintln!(
                 "⚠️  CANARY_UMBREL_NTFY_URL is only used in self-hosted mode; ignoring detected ntfy server in cloud mode"
@@ -353,7 +355,7 @@ impl AppConfig {
             Vec::new()
         };
         let ntfy_fallback_url =
-            std::env::var("NTFY_SERVER_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string());
+            Self::parse_url_env("NTFY_SERVER_URL").unwrap_or_else(|| "https://ntfy.sh".to_string());
 
         // Load BTCPay configuration (optional, cloud mode only)
         let btcpay_url = std::env::var("BTCPAY_URL").ok();
@@ -467,6 +469,11 @@ impl AppConfig {
         if self.is_self_hosted_mode() && self.ntfy_servers.len() == 1 {
             self.ntfy_servers.first()
         } else {
+            if self.is_self_hosted_mode() && self.ntfy_servers.len() > 1 {
+                eprintln!(
+                    "⚠️  Multiple local ntfy servers detected; falling back to configured public/default ntfy server"
+                );
+            }
             None
         }
     }
@@ -543,7 +550,7 @@ impl AppConfig {
 
     /// Check whether a URL is one of the currently detected self-hosted ntfy servers.
     pub fn is_detected_ntfy_server_url(&self, server_url: &str) -> bool {
-        let normalized_server_url = server_url.trim_end_matches('/');
+        let normalized_server_url = server_url.trim().trim_end_matches('/');
         self.is_self_hosted_mode()
             && self
                 .ntfy_servers
@@ -1130,6 +1137,7 @@ mod tests {
         assert_eq!(config.default_ntfy_server_id(), "umbrel-ntfy");
         assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
         assert!(config.is_detected_ntfy_server_url("http://ntfy_app_1/"));
+        assert!(config.is_detected_ntfy_server_url(" http://ntfy_app_1/"));
         assert!(!config.is_detected_ntfy_server_url("https://ntfy.sh"));
     }
 
@@ -1139,12 +1147,45 @@ mod tests {
     }
 
     #[test]
+    fn test_ntfy_fallback_url_env_validates_configured_url() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        std::env::set_var("NTFY_SERVER_URL", "   ");
+        assert!(AppConfig::parse_url_env("NTFY_SERVER_URL").is_none());
+
+        std::env::set_var("NTFY_SERVER_URL", "ntfy.example.com");
+        assert!(AppConfig::parse_url_env("NTFY_SERVER_URL").is_none());
+
+        std::env::set_var("NTFY_SERVER_URL", " https://ntfy.example.com/ ");
+        assert_eq!(
+            AppConfig::parse_url_env("NTFY_SERVER_URL").as_deref(),
+            Some("https://ntfy.example.com")
+        );
+
+        std::env::remove_var("NTFY_SERVER_URL");
+    }
+
+    #[test]
     fn test_ntfy_server_url_falls_back_to_env_without_detected_local() {
         let config = test_config_self_hosted(NetworkConfig::Regtest)
             .with_ntfy_fallback_url("https://ntfy.example.com");
 
         assert_eq!(config.default_ntfy_server_id(), "ntfy-sh");
         assert_eq!(config.ntfy_server_url(), "https://ntfy.example.com");
+    }
+
+    #[test]
+    fn test_detected_ntfy_server_takes_precedence_over_fallback_url() {
+        let config = test_config_self_hosted(NetworkConfig::Regtest)
+            .with_ntfy_fallback_url("https://ntfy.example.com")
+            .with_ntfy_servers(vec![NtfyServerConfig::new(
+                "umbrel-ntfy",
+                "ntfy",
+                Some("http://ntfy_app_1".to_string()),
+            )
+            .unwrap()]);
+
+        assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -217,7 +217,10 @@ impl AppConfig {
 
         // Parse command line arguments
         let args = AppConfigArgs::parse();
+        Self::load_from_args(args)
+    }
 
+    fn load_from_args(args: AppConfigArgs) -> Result<Self> {
         // Resolve network configuration (CLI args override env vars)
         let network = match args.network.or_else(|| {
             std::env::var("CANARY_NETWORK")
@@ -801,6 +804,14 @@ mod tests {
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    fn restore_env_var(name: &str, value: Option<String>) {
+        if let Some(value) = value {
+            std::env::set_var(name, value);
+        } else {
+            std::env::remove_var(name);
+        }
+    }
+
     #[test]
     fn test_network_config_parsing() {
         assert!(matches!(
@@ -1123,6 +1134,41 @@ mod tests {
         assert!(config.is_detected_ntfy_server_url("http://ntfy_app_1/"));
         assert!(config.is_detected_ntfy_server_url(" http://ntfy_app_1/"));
         assert!(!config.is_detected_ntfy_server_url("https://ntfy.sh"));
+    }
+
+    #[test]
+    fn test_load_detects_umbrel_ntfy_url_in_self_hosted_mode() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_jwt = std::env::var("JWT_SECRET").ok();
+        let previous_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
+        let previous_umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
+        std::env::set_var("CANARY_MODE", "self-hosted");
+        std::env::set_var("JWT_SECRET", "test-jwt-secret");
+        std::env::set_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", "test-admin-password");
+        std::env::set_var("CANARY_UMBREL_NTFY_URL", "http://ntfy_app_1/");
+        std::env::remove_var("NTFY_SERVER_URL");
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Regtest),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(config.default_ntfy_server_id(), "umbrel-ntfy");
+        assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
+        assert_eq!(config.ntfy_servers().len(), 1);
+        assert_eq!(config.ntfy_servers()[0].platform.as_deref(), Some("umbrel"));
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("JWT_SECRET", previous_jwt);
+        restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
+        restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -22,7 +22,7 @@ impl NtfyServerConfig {
     fn new(id: &str, name: &str, base_url: Option<String>) -> Option<Self> {
         let normalized_base_url = base_url
             .map(|url| url.trim_end_matches('/').to_string())
-            .filter(|url| !url.is_empty());
+            .filter(|url| !url.trim().is_empty());
 
         normalized_base_url.map(|base_url| Self {
             id: id.to_string(),
@@ -1082,6 +1082,11 @@ mod tests {
 
         assert_eq!(config.default_ntfy_server_id(), "umbrel-ntfy");
         assert_eq!(config.ntfy_server_url(), "http://ntfy_app_1");
+    }
+
+    #[test]
+    fn test_ntfy_server_config_rejects_blank_url() {
+        assert!(NtfyServerConfig::new("umbrel-ntfy", "ntfy", Some("   ".to_string())).is_none());
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -166,6 +166,8 @@ pub struct AppConfig {
     tx_explorers: Vec<TxExplorerConfig>,
     /// Available self-hosted ntfy servers.
     ntfy_servers: Vec<NtfyServerConfig>,
+    /// Default ntfy server URL used when no user or local server preference applies.
+    ntfy_fallback_url: String,
     /// BTCPay Server URL (e.g., https://btcpay.enogtjue.no)
     btcpay_url: Option<String>,
     /// BTCPay Server API key
@@ -337,6 +339,8 @@ impl AppConfig {
         .into_iter()
         .flatten()
         .collect();
+        let ntfy_fallback_url =
+            std::env::var("NTFY_SERVER_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string());
 
         // Load BTCPay configuration (optional, cloud mode only)
         let btcpay_url = std::env::var("BTCPAY_URL").ok();
@@ -380,6 +384,7 @@ impl AppConfig {
             self_hosted_admin_password,
             tx_explorers,
             ntfy_servers,
+            ntfy_fallback_url,
             btcpay_url,
             btcpay_api_key,
             btcpay_store_id,
@@ -512,7 +517,7 @@ impl AppConfig {
             return self.ntfy_servers[0].base_url.clone();
         }
 
-        std::env::var("NTFY_SERVER_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string())
+        self.ntfy_fallback_url.clone()
     }
 
     /// Check if Twilio SMS provider should be enabled
@@ -724,6 +729,7 @@ impl AppConfig {
             self_hosted_admin_password,
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
+            ntfy_fallback_url: "https://ntfy.sh".to_string(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -741,6 +747,12 @@ impl AppConfig {
     /// Set ntfy servers on a test config (builder pattern)
     pub fn with_ntfy_servers(mut self, ntfy_servers: Vec<NtfyServerConfig>) -> Self {
         self.ntfy_servers = ntfy_servers;
+        self
+    }
+
+    /// Set ntfy fallback URL on a test config (builder pattern)
+    pub fn with_ntfy_fallback_url(mut self, ntfy_fallback_url: &str) -> Self {
+        self.ntfy_fallback_url = ntfy_fallback_url.to_string();
         self
     }
 
@@ -822,6 +834,7 @@ mod tests {
             self_hosted_admin_password: None,
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
+            ntfy_fallback_url: "https://ntfy.sh".to_string(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -842,6 +855,7 @@ mod tests {
             self_hosted_admin_password: None,
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
+            ntfy_fallback_url: "https://ntfy.sh".to_string(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -862,6 +876,7 @@ mod tests {
             self_hosted_admin_password: Some("self-hosted-password".to_string()),
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
+            ntfy_fallback_url: "https://ntfy.sh".to_string(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1026,6 +1041,7 @@ mod tests {
             self_hosted_admin_password: None,
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
+            ntfy_fallback_url: "https://ntfy.sh".to_string(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1091,14 +1107,11 @@ mod tests {
 
     #[test]
     fn test_ntfy_server_url_falls_back_to_env_without_detected_local() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        std::env::set_var("NTFY_SERVER_URL", "https://ntfy.example.com");
-        let config = test_config_self_hosted(NetworkConfig::Regtest);
+        let config = test_config_self_hosted(NetworkConfig::Regtest)
+            .with_ntfy_fallback_url("https://ntfy.example.com");
 
         assert_eq!(config.default_ntfy_server_id(), "ntfy-sh");
         assert_eq!(config.ntfy_server_url(), "https://ntfy.example.com");
-
-        std::env::remove_var("NTFY_SERVER_URL");
     }
 
     #[test]
@@ -1136,6 +1149,7 @@ mod tests {
             self_hosted_admin_password: None,
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
+            ntfy_fallback_url: "https://ntfy.sh".to_string(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1188,6 +1202,7 @@ mod tests {
             self_hosted_admin_password: Some("self-hosted-password".to_string()),
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
+            ntfy_fallback_url: "https://ntfy.sh".to_string(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1214,6 +1229,7 @@ mod tests {
             self_hosted_admin_password: Some("   ".to_string()),
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
+            ntfy_fallback_url: "https://ntfy.sh".to_string(),
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -320,11 +320,14 @@ pub async fn register(
     {
         let email = request.email.clone();
         let name = request.name.clone();
-        AdminNotifications::spawn_if_enabled(move |admin_notifications| async move {
-            admin_notifications
-                .notify_user_signup(&email, Some(&name))
-                .await;
-        });
+        AdminNotifications::spawn_if_enabled(
+            config.ntfy_server_url(),
+            move |admin_notifications| async move {
+                admin_notifications
+                    .notify_user_signup(&email, Some(&name))
+                    .await;
+            },
+        );
     }
 
     // Create Stripe trial subscription for the user

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -36,7 +36,7 @@ pub async fn get_config(State(config): State<Arc<AppConfig>>) -> Json<ConfigResp
             tx_explorers: Vec::new(),
             default_tx_explorer_id: "mempool-space".to_string(),
             ntfy_servers: Vec::new(),
-            default_ntfy_server_id: "ntfy-sh".to_string(),
+            default_ntfy_server_id: config.default_ntfy_server_id(),
         })
     }
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -1,6 +1,6 @@
 //! Application configuration handler
 
-use crate::config::{AppConfig, TxExplorerConfig};
+use crate::config::{AppConfig, NtfyServerConfig, TxExplorerConfig};
 use axum::{extract::State, response::Json};
 use serde::Serialize;
 use std::sync::Arc;
@@ -9,6 +9,8 @@ use std::sync::Arc;
 pub struct ConfigResponse {
     tx_explorers: Vec<TxExplorerConfig>,
     default_tx_explorer_id: String,
+    ntfy_servers: Vec<NtfyServerConfig>,
+    default_ntfy_server_id: String,
 }
 
 /// GET /api/config - Returns public application configuration
@@ -26,11 +28,15 @@ pub async fn get_config(State(config): State<Arc<AppConfig>>) -> Json<ConfigResp
         Json(ConfigResponse {
             tx_explorers,
             default_tx_explorer_id,
+            ntfy_servers: config.ntfy_servers().to_vec(),
+            default_ntfy_server_id: config.default_ntfy_server_id(),
         })
     } else {
         Json(ConfigResponse {
             tx_explorers: Vec::new(),
             default_tx_explorer_id: "mempool-space".to_string(),
+            ntfy_servers: Vec::new(),
+            default_ntfy_server_id: "ntfy-sh".to_string(),
         })
     }
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -41,3 +41,27 @@ pub async fn get_config(State(config): State<Arc<AppConfig>>) -> Json<ConfigResp
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{NetworkConfig, OperatingMode};
+
+    #[tokio::test]
+    async fn cloud_config_does_not_expose_self_hosted_ntfy_servers() {
+        let config = Arc::new(AppConfig::new_for_test(
+            NetworkConfig::Mainnet,
+            None,
+            "127.0.0.1:3000".to_string(),
+            "./database".to_string(),
+            OperatingMode::Cloud,
+            Some("http://localhost:3001".to_string()),
+            Some("test-jwt-secret".to_string()),
+        ));
+
+        let Json(response) = get_config(State(config)).await;
+
+        assert!(response.ntfy_servers.is_empty());
+        assert_eq!(response.default_ntfy_server_id, "ntfy-sh");
+    }
+}

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -14,8 +14,9 @@ pub struct ConfigResponse {
 }
 
 /// GET /api/config - Returns public application configuration
-/// Custom mempool settings are only exposed in self-hosted mode;
-/// cloud mode always uses mempool.space.
+/// Custom mempool and ntfy settings are only exposed in self-hosted mode.
+/// Detected ntfy URLs are returned so the frontend can select local integrations,
+/// but browser-facing links still hide Docker-internal hostnames.
 pub async fn get_config(State(config): State<Arc<AppConfig>>) -> Json<ConfigResponse> {
     if config.is_self_hosted_mode() {
         let tx_explorers = config.tx_explorers().to_vec();

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 
 #[derive(Serialize)]
 pub struct ConfigResponse {
-    pub(crate) tx_explorers: Vec<TxExplorerConfig>,
-    pub(crate) default_tx_explorer_id: String,
-    pub(crate) ntfy_servers: Vec<NtfyServerConfig>,
-    pub(crate) default_ntfy_server_id: String,
+    tx_explorers: Vec<TxExplorerConfig>,
+    default_tx_explorer_id: String,
+    ntfy_servers: Vec<NtfyServerConfig>,
+    default_ntfy_server_id: String,
 }
 
 /// GET /api/config - Returns public application configuration

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 
 #[derive(Serialize)]
 pub struct ConfigResponse {
-    pub tx_explorers: Vec<TxExplorerConfig>,
-    pub default_tx_explorer_id: String,
-    pub ntfy_servers: Vec<NtfyServerConfig>,
-    pub default_ntfy_server_id: String,
+    pub(crate) tx_explorers: Vec<TxExplorerConfig>,
+    pub(crate) default_tx_explorer_id: String,
+    pub(crate) ntfy_servers: Vec<NtfyServerConfig>,
+    pub(crate) default_ntfy_server_id: String,
 }
 
 /// GET /api/config - Returns public application configuration

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 
 #[derive(Serialize)]
 pub struct ConfigResponse {
-    tx_explorers: Vec<TxExplorerConfig>,
-    default_tx_explorer_id: String,
-    ntfy_servers: Vec<NtfyServerConfig>,
-    default_ntfy_server_id: String,
+    pub tx_explorers: Vec<TxExplorerConfig>,
+    pub default_tx_explorer_id: String,
+    pub ntfy_servers: Vec<NtfyServerConfig>,
+    pub default_ntfy_server_id: String,
 }
 
 /// GET /api/config - Returns public application configuration

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -4,7 +4,7 @@ use crate::api::AppServicesState;
 use crate::config::AppConfig;
 use crate::extractors::AuthenticatedUser;
 use crate::models::{ErrorResponse, TestNtfyRequest, TestNtfyResponse};
-use crate::ntfy_provider::NtfyAuth;
+use crate::ntfy_provider::{NtfyAuth, NtfyProvider};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -111,10 +111,7 @@ pub async fn send_test_ntfy_notification(
     let ntfy_url = format!("{}/{}", ntfy_server.trim_end_matches('/'), topic);
 
     // Build and send the HTTP request
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .unwrap_or_default();
+    let client = NtfyProvider::default_client();
     let mut request = client
         .post(&ntfy_url)
         .header("Content-Type", "text/plain; charset=utf-8")

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -70,7 +70,7 @@ pub async fn send_test_ntfy_notification(
         .await
     {
         Ok(Some(url)) if !url.is_empty() => url,
-        _ => std::env::var("NTFY_SERVER_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string()),
+        _ => config.ntfy_server_url(),
     };
 
     // Look up user's ntfy auth credentials

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -76,7 +76,7 @@ pub async fn send_test_ntfy_notification(
         .clone()
         .unwrap_or_else(|| config.ntfy_server_url());
     let should_use_ntfy_auth =
-        user_ntfy_server_url.is_some() || config.is_detected_ntfy_server_url(&ntfy_server);
+        config.should_use_ntfy_auth_for_url(&ntfy_server, user_ntfy_server_url.as_deref());
 
     // Look up user's ntfy auth credentials
     let ntfy_auth = if should_use_ntfy_auth {

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -64,24 +64,35 @@ pub async fn send_test_ntfy_notification(
     }
 
     // Look up user's ntfy server URL
-    let ntfy_server = match app_services
+    let user_ntfy_server_url = match app_services
         .metadata_db
         .get_user_ntfy_server_url(&user.user_id)
         .await
     {
-        Ok(Some(url)) if !url.is_empty() => url,
-        _ => config.ntfy_server_url(),
+        Ok(Some(url)) if !url.is_empty() => Some(url),
+        _ => None,
     };
+    let ntfy_server = user_ntfy_server_url
+        .clone()
+        .unwrap_or_else(|| config.ntfy_server_url());
+    let should_use_ntfy_auth =
+        user_ntfy_server_url.is_some() || config.is_detected_ntfy_server_url(&ntfy_server);
 
     // Look up user's ntfy auth credentials
-    let ntfy_auth = match app_services
-        .metadata_db
-        .get_user_ntfy_auth(&user.user_id)
-        .await
-    {
-        Ok((Some(token), _, _)) => NtfyAuth::AccessToken(token),
-        Ok((None, Some(username), Some(password))) => NtfyAuth::BasicAuth { username, password },
-        _ => NtfyAuth::None,
+    let ntfy_auth = if should_use_ntfy_auth {
+        match app_services
+            .metadata_db
+            .get_user_ntfy_auth(&user.user_id)
+            .await
+        {
+            Ok((Some(token), _, _)) => NtfyAuth::AccessToken(token),
+            Ok((None, Some(username), Some(password))) => {
+                NtfyAuth::BasicAuth { username, password }
+            }
+            _ => NtfyAuth::None,
+        }
+    } else {
+        NtfyAuth::None
     };
 
     // Look up user's preferred language

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -380,6 +380,7 @@ pub async fn create_wallet_non_blocking(
                     {
                         let user_email = user_record.email;
                         AdminNotifications::spawn_if_enabled(
+                            config.ntfy_server_url(),
                             move |admin_notifications| async move {
                                 admin_notifications
                                     .notify_wallet_creation(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -201,6 +201,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create notification manager and register providers based on operating mode
     let mut notification_manager = NotificationManager::new();
+    let ntfy_http_client = reqwest::Client::new();
 
     if config.is_self_hosted_mode() {
         // Self-hosted mode: Only ntfy provider
@@ -209,7 +210,11 @@ async fn main() -> anyhow::Result<()> {
             "🔔 Self-hosted mode: Registering ntfy notifications (server: {})",
             ntfy_server
         );
-        notification_manager.register_provider(Arc::new(NtfyProvider::new(ntfy_server)));
+        notification_manager.register_provider(Arc::new(NtfyProvider::with_client(
+            ntfy_http_client.clone(),
+            ntfy_server,
+            NtfyAuth::None,
+        )));
     } else {
         // Cloud mode: Register all configured providers
         println!("🔔 Cloud mode: Registering all notification providers");
@@ -218,7 +223,11 @@ async fn main() -> anyhow::Result<()> {
         if config.is_ntfy_enabled() {
             let ntfy_server = config.ntfy_server_url();
             println!("  - ntfy notification provider (server: {})", ntfy_server);
-            notification_manager.register_provider(Arc::new(NtfyProvider::new(ntfy_server)));
+            notification_manager.register_provider(Arc::new(NtfyProvider::with_client(
+                ntfy_http_client.clone(),
+                ntfy_server,
+                NtfyAuth::None,
+            )));
         }
 
         // Register Twilio SMS provider if enabled and configured
@@ -922,7 +931,11 @@ async fn main() -> anyhow::Result<()> {
                                     NtfyAuth::None
                                 };
 
-                                let ntfy_provider = NtfyProvider::with_auth(ntfy_server, ntfy_auth);
+                                let ntfy_provider = NtfyProvider::with_client(
+                                    ntfy_http_client.clone(),
+                                    ntfy_server,
+                                    ntfy_auth,
+                                );
                                 use crate::notifications::NotificationProvider;
                                 Ok(ntfy_provider
                                     .send_notification(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -832,6 +832,7 @@ async fn main() -> anyhow::Result<()> {
     let notification_worker_manager = notification_manager.clone();
     let notification_wallet_manager = wallet_manager.clone();
     let notification_event_rx = notification_tx.subscribe();
+    let notification_config = config.clone();
     tokio::spawn(async move {
         let mut rx = notification_event_rx;
 
@@ -893,12 +894,10 @@ async fn main() -> anyhow::Result<()> {
 
                             // For ntfy, use user's preferred server URL and auth if set
                             let results = if provider_name == "ntfy" {
-                                // Determine the ntfy server URL: user preference > env var > default
-                                let ntfy_server =
-                                    user_ntfy_server_url.clone().unwrap_or_else(|| {
-                                        std::env::var("NTFY_SERVER_URL")
-                                            .unwrap_or_else(|_| "https://ntfy.sh".to_string())
-                                    });
+                                // Determine the ntfy server URL: user preference > detected local > env var > default
+                                let ntfy_server = user_ntfy_server_url
+                                    .clone()
+                                    .unwrap_or_else(|| notification_config.ntfy_server_url());
 
                                 // Get ntfy authentication credentials
                                 let ntfy_auth = match notification_wallet_manager

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -898,18 +898,25 @@ async fn main() -> anyhow::Result<()> {
                                 let ntfy_server = user_ntfy_server_url
                                     .clone()
                                     .unwrap_or_else(|| notification_config.ntfy_server_url());
+                                let should_use_ntfy_auth = user_ntfy_server_url.is_some()
+                                    || notification_config
+                                        .is_detected_ntfy_server_url(&ntfy_server);
 
                                 // Get ntfy authentication credentials
-                                let ntfy_auth = match notification_wallet_manager
-                                    .metadata_db
-                                    .get_user_ntfy_auth(&wallet_info.user_id)
-                                    .await
-                                {
-                                    Ok((Some(token), _, _)) => NtfyAuth::AccessToken(token),
-                                    Ok((None, Some(username), Some(password))) => {
-                                        NtfyAuth::BasicAuth { username, password }
+                                let ntfy_auth = if should_use_ntfy_auth {
+                                    match notification_wallet_manager
+                                        .metadata_db
+                                        .get_user_ntfy_auth(&wallet_info.user_id)
+                                        .await
+                                    {
+                                        Ok((Some(token), _, _)) => NtfyAuth::AccessToken(token),
+                                        Ok((None, Some(username), Some(password))) => {
+                                            NtfyAuth::BasicAuth { username, password }
+                                        }
+                                        _ => NtfyAuth::None,
                                     }
-                                    _ => NtfyAuth::None,
+                                } else {
+                                    NtfyAuth::None
                                 };
 
                                 let ntfy_provider = NtfyProvider::with_auth(ntfy_server, ntfy_auth);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -898,9 +898,11 @@ async fn main() -> anyhow::Result<()> {
                                 let ntfy_server = user_ntfy_server_url
                                     .clone()
                                     .unwrap_or_else(|| notification_config.ntfy_server_url());
-                                let should_use_ntfy_auth = user_ntfy_server_url.is_some()
-                                    || notification_config
-                                        .is_detected_ntfy_server_url(&ntfy_server);
+                                let should_use_ntfy_auth = notification_config
+                                    .should_use_ntfy_auth_for_url(
+                                        &ntfy_server,
+                                        user_ntfy_server_url.as_deref(),
+                                    );
 
                                 // Get ntfy authentication credentials
                                 let ntfy_auth = if should_use_ntfy_auth {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1035,7 +1035,9 @@ async fn main() -> anyhow::Result<()> {
                                             // Check if we should send recovery notification
                                             if tracker.record_success() {
                                                 let admin =
-                                                    admin_notifications::AdminNotifications::new();
+                                                    admin_notifications::AdminNotifications::new(
+                                                        notification_config.ntfy_server_url(),
+                                                    );
                                                 if admin.is_enabled() {
                                                     admin
                                                         .notify_provider_recovery(display_name)
@@ -1049,7 +1051,9 @@ async fn main() -> anyhow::Result<()> {
                                                 .await;
                                             if should_alert {
                                                 let admin =
-                                                    admin_notifications::AdminNotifications::new();
+                                                    admin_notifications::AdminNotifications::new(
+                                                        notification_config.ntfy_server_url(),
+                                                    );
                                                 if admin.is_enabled() {
                                                     admin
                                                         .notify_provider_failure(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -872,7 +872,8 @@ async fn main() -> anyhow::Result<()> {
                             .get_user_ntfy_server_url(&wallet_info.user_id)
                             .await
                             .ok()
-                            .flatten();
+                            .flatten()
+                            .filter(|url| !url.is_empty());
 
                         // Look up user's preferred language for notifications
                         let user_language = notification_wallet_manager

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -201,7 +201,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create notification manager and register providers based on operating mode
     let mut notification_manager = NotificationManager::new();
-    let ntfy_http_client = reqwest::Client::new();
+    let ntfy_http_client = NtfyProvider::default_client();
 
     if config.is_self_hosted_mode() {
         // Self-hosted mode: Only ntfy provider

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -9,9 +9,11 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use rust_i18n::t;
 use serde_json::json;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 const NTFY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+static NTFY_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 /// Authentication method for ntfy server
 #[derive(Clone, Debug)]
@@ -50,10 +52,14 @@ impl NtfyProvider {
     }
 
     pub fn default_client() -> reqwest::Client {
-        reqwest::Client::builder()
-            .timeout(NTFY_REQUEST_TIMEOUT)
-            .build()
-            .expect("failed to build ntfy HTTP client")
+        NTFY_CLIENT
+            .get_or_init(|| {
+                reqwest::Client::builder()
+                    .timeout(NTFY_REQUEST_TIMEOUT)
+                    .build()
+                    .expect("failed to build ntfy HTTP client")
+            })
+            .clone()
     }
 
     /// Build the Authorization header value based on auth method

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -9,6 +9,9 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use rust_i18n::t;
 use serde_json::json;
+use std::time::Duration;
+
+const NTFY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Authentication method for ntfy server
 #[derive(Clone, Debug)]
@@ -33,7 +36,7 @@ impl NtfyProvider {
     }
 
     pub fn with_auth(server_url: String, auth: NtfyAuth) -> Self {
-        Self::with_client(reqwest::Client::new(), server_url, auth)
+        Self::with_client(Self::default_client(), server_url, auth)
     }
 
     pub fn with_client(client: reqwest::Client, server_url: String, auth: NtfyAuth) -> Self {
@@ -44,6 +47,13 @@ impl NtfyProvider {
             server_url,
             auth,
         }
+    }
+
+    pub fn default_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(NTFY_REQUEST_TIMEOUT)
+            .build()
+            .expect("failed to build ntfy HTTP client")
     }
 
     /// Build the Authorization header value based on auth method

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -33,10 +33,14 @@ impl NtfyProvider {
     }
 
     pub fn with_auth(server_url: String, auth: NtfyAuth) -> Self {
+        Self::with_client(reqwest::Client::new(), server_url, auth)
+    }
+
+    pub fn with_client(client: reqwest::Client, server_url: String, auth: NtfyAuth) -> Self {
         // Ensure the server URL doesn't have a trailing slash
         let server_url = server_url.trim_end_matches('/').to_string();
         Self {
-            client: reqwest::Client::new(),
+            client,
             server_url,
             auth,
         }

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -153,7 +153,8 @@ impl WalletSyncService {
                                 info!("[{}] Reconnection successful", wallet_checksum);
                                 // Send reconnected notification if we had previous failures (atomic check)
                                 if manager.should_send_reconnected_notification() {
-                                    let admin_notifications = AdminNotifications::new();
+                                    let admin_notifications =
+                                        AdminNotifications::new(self.config.ntfy_server_url());
                                     if admin_notifications.is_enabled() {
                                         admin_notifications
                                             .notify_electrum_reconnected(manager.url())
@@ -186,7 +187,8 @@ impl WalletSyncService {
                                 if failures >= ALERT_FAILURE_THRESHOLD
                                     && !manager.has_alert_been_sent()
                                 {
-                                    let admin_notifications = AdminNotifications::new();
+                                    let admin_notifications =
+                                        AdminNotifications::new(self.config.ntfy_server_url());
                                     if admin_notifications.is_enabled() {
                                         admin_notifications
                                             .notify_electrum_disconnect(
@@ -256,7 +258,8 @@ impl WalletSyncService {
                                     );
                                     // Send reconnected notification if we had previous failures (atomic check)
                                     if manager.should_send_reconnected_notification() {
-                                        let admin_notifications = AdminNotifications::new();
+                                        let admin_notifications =
+                                            AdminNotifications::new(self.config.ntfy_server_url());
                                         if admin_notifications.is_enabled() {
                                             admin_notifications
                                                 .notify_electrum_reconnected(manager.url())
@@ -280,7 +283,8 @@ impl WalletSyncService {
                                     if failures >= ALERT_FAILURE_THRESHOLD
                                         && !manager.has_alert_been_sent()
                                     {
-                                        let admin_notifications = AdminNotifications::new();
+                                        let admin_notifications =
+                                            AdminNotifications::new(self.config.ntfy_server_url());
                                         if admin_notifications.is_enabled() {
                                             admin_notifications
                                                 .notify_electrum_disconnect(

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -339,8 +339,11 @@
       "serverNoteBefore": "Lad stå tomt for at bruge den offentlige ntfy.sh server. Du kan ",
       "selfHostLink": "selv-hoste ntfy",
       "serverNoteAfter": " for fuldstændig privatliv.",
+      "publicServerDescription": "Offentlig eller brugerdefineret server",
+      "localAuthNote": "Lokal ntfy kræver godkendelse. Opret et adgangstoken i ntfy og indsæt det nedenfor.",
       "auth": {
         "title": "Godkendelse",
+        "localTokenHint": "Brug et adgangstoken fra din lokale ntfy-app. Canary læser eller forhåndsudfylder ikke ntfy-legitimationsoplysninger.",
         "configured": {
           "token": "Adgangstoken konfigureret",
           "credentials": "Brugernavn/adgangskode konfigureret ({username})",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -336,9 +336,6 @@
       "description": "Konfigurer din ntfy-server til push-notifikationer",
       "serverLabel": "ntfy Server URL",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "Lad stå tomt for at bruge den offentlige ntfy.sh server. Du kan ",
-      "selfHostLink": "selv-hoste ntfy",
-      "serverNoteAfter": " for fuldstændig privatliv.",
       "localAuthNote": "Lokal ntfy kræver godkendelse. Opret et adgangstoken i ntfy og indsæt det nedenfor.",
       "validation": {
         "urlRequired": "ntfy-server URL er påkrævet",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -339,7 +339,6 @@
       "serverNoteBefore": "Lad stå tomt for at bruge den offentlige ntfy.sh server. Du kan ",
       "selfHostLink": "selv-hoste ntfy",
       "serverNoteAfter": " for fuldstændig privatliv.",
-      "publicServerDescription": "Offentlig eller brugerdefineret server",
       "localAuthNote": "Lokal ntfy kræver godkendelse. Opret et adgangstoken i ntfy og indsæt det nedenfor.",
       "auth": {
         "title": "Godkendelse",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "ntfy-emne",
-        "topicHint": "Abonner på dette emne på {server} for at modtage notifikationer"
+        "topicHint": "Abonner på dette emne på {server} for at modtage notifikationer",
+        "localServer": "lokal ntfy"
       },
       "sms": {
         "phoneHint": "Inkluder landekode"

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -340,6 +340,11 @@
       "selfHostLink": "selv-hoste ntfy",
       "serverNoteAfter": " for fuldstændig privatliv.",
       "localAuthNote": "Lokal ntfy kræver godkendelse. Opret et adgangstoken i ntfy og indsæt det nedenfor.",
+      "validation": {
+        "urlRequired": "ntfy-server URL er påkrævet",
+        "urlProtocol": "ntfy-server URL skal starte med http:// eller https://",
+        "saveFailed": "Kunne ikke gemme"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "Lokal"

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -342,7 +342,7 @@
       "localAuthNote": "Lokal ntfy kræver godkendelse. Opret et adgangstoken i ntfy og indsæt det nedenfor.",
       "platform": {
         "umbrel": "Umbrel",
-        "local": "Local"
+        "local": "Lokal"
       },
       "auth": {
         "title": "Godkendelse",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -340,6 +340,10 @@
       "selfHostLink": "selv-hoste ntfy",
       "serverNoteAfter": " for fuldstændig privatliv.",
       "localAuthNote": "Lokal ntfy kræver godkendelse. Opret et adgangstoken i ntfy og indsæt det nedenfor.",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "Godkendelse",
         "localTokenHint": "Brug et adgangstoken fra din lokale ntfy-app. Canary læser eller forhåndsudfylder ikke ntfy-legitimationsoplysninger.",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -291,8 +291,11 @@
       "serverNoteBefore": "Leer lassen, um den öffentlichen ntfy.sh-Server zu verwenden. Sie können ",
       "selfHostLink": "ntfy selbst hosten",
       "serverNoteAfter": " für vollständige Privatsphäre.",
+      "publicServerDescription": "Öffentlicher oder benutzerdefinierter Server",
+      "localAuthNote": "Lokales ntfy erfordert Authentifizierung. Erstellen Sie ein Zugriffstoken in ntfy und fügen Sie es unten ein.",
       "auth": {
         "title": "Authentifizierung",
+        "localTokenHint": "Verwenden Sie ein Zugriffstoken aus Ihrer lokalen ntfy-App. Canary liest oder füllt keine ntfy-Zugangsdaten aus.",
         "configured": {
           "token": "Zugriffstoken konfiguriert",
           "credentials": "Benutzername/Passwort konfiguriert ({username})",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -294,7 +294,7 @@
       "localAuthNote": "Lokales ntfy erfordert Authentifizierung. Erstellen Sie ein Zugriffstoken in ntfy und fügen Sie es unten ein.",
       "platform": {
         "umbrel": "Umbrel",
-        "local": "Local"
+        "local": "Lokal"
       },
       "auth": {
         "title": "Authentifizierung",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -292,6 +292,11 @@
       "selfHostLink": "ntfy selbst hosten",
       "serverNoteAfter": " für vollständige Privatsphäre.",
       "localAuthNote": "Lokales ntfy erfordert Authentifizierung. Erstellen Sie ein Zugriffstoken in ntfy und fügen Sie es unten ein.",
+      "validation": {
+        "urlRequired": "ntfy-Server-URL ist erforderlich",
+        "urlProtocol": "ntfy-Server-URL muss mit http:// oder https:// beginnen",
+        "saveFailed": "Speichern fehlgeschlagen"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "Lokal"

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -291,7 +291,6 @@
       "serverNoteBefore": "Leer lassen, um den öffentlichen ntfy.sh-Server zu verwenden. Sie können ",
       "selfHostLink": "ntfy selbst hosten",
       "serverNoteAfter": " für vollständige Privatsphäre.",
-      "publicServerDescription": "Öffentlicher oder benutzerdefinierter Server",
       "localAuthNote": "Lokales ntfy erfordert Authentifizierung. Erstellen Sie ein Zugriffstoken in ntfy und fügen Sie es unten ein.",
       "auth": {
         "title": "Authentifizierung",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "ntfy-Thema",
-        "topicHint": "Abonnieren Sie dieses Thema auf {server}, um Benachrichtigungen zu erhalten"
+        "topicHint": "Abonnieren Sie dieses Thema auf {server}, um Benachrichtigungen zu erhalten",
+        "localServer": "lokales ntfy"
       },
       "sms": {
         "phoneHint": "Ländervorwahl angeben"

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -288,9 +288,6 @@
       "description": "Konfigurieren Sie Ihren ntfy-Server für Push-Benachrichtigungen",
       "serverLabel": "ntfy Server-URL",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "Leer lassen, um den öffentlichen ntfy.sh-Server zu verwenden. Sie können ",
-      "selfHostLink": "ntfy selbst hosten",
-      "serverNoteAfter": " für vollständige Privatsphäre.",
       "localAuthNote": "Lokales ntfy erfordert Authentifizierung. Erstellen Sie ein Zugriffstoken in ntfy und fügen Sie es unten ein.",
       "validation": {
         "urlRequired": "ntfy-Server-URL ist erforderlich",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -292,6 +292,10 @@
       "selfHostLink": "ntfy selbst hosten",
       "serverNoteAfter": " für vollständige Privatsphäre.",
       "localAuthNote": "Lokales ntfy erfordert Authentifizierung. Erstellen Sie ein Zugriffstoken in ntfy und fügen Sie es unten ein.",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "Authentifizierung",
         "localTokenHint": "Verwenden Sie ein Zugriffstoken aus Ihrer lokalen ntfy-App. Canary liest oder füllt keine ntfy-Zugangsdaten aus.",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -340,6 +340,10 @@
       "selfHostLink": "self-host ntfy",
       "serverNoteAfter": " for complete privacy.",
       "localAuthNote": "Local ntfy requires authentication. Create an access token in ntfy and paste it below.",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "Authentication",
         "localTokenHint": "Use an access token from your local ntfy app. Canary does not read or prefill ntfy credentials.",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -336,9 +336,6 @@
       "description": "Configure your ntfy server for push notifications",
       "serverLabel": "ntfy Server URL",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "Leave empty to use the public ntfy.sh server. You can ",
-      "selfHostLink": "self-host ntfy",
-      "serverNoteAfter": " for complete privacy.",
       "localAuthNote": "Local ntfy requires authentication. Create an access token in ntfy and paste it below.",
       "validation": {
         "urlRequired": "ntfy server URL is required",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -340,6 +340,11 @@
       "selfHostLink": "self-host ntfy",
       "serverNoteAfter": " for complete privacy.",
       "localAuthNote": "Local ntfy requires authentication. Create an access token in ntfy and paste it below.",
+      "validation": {
+        "urlRequired": "ntfy server URL is required",
+        "urlProtocol": "ntfy server URL must start with http:// or https://",
+        "saveFailed": "Failed to save"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "Local"

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -339,7 +339,6 @@
       "serverNoteBefore": "Leave empty to use the public ntfy.sh server. You can ",
       "selfHostLink": "self-host ntfy",
       "serverNoteAfter": " for complete privacy.",
-      "publicServerDescription": "Public or custom server",
       "localAuthNote": "Local ntfy requires authentication. Create an access token in ntfy and paste it below.",
       "auth": {
         "title": "Authentication",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -339,8 +339,11 @@
       "serverNoteBefore": "Leave empty to use the public ntfy.sh server. You can ",
       "selfHostLink": "self-host ntfy",
       "serverNoteAfter": " for complete privacy.",
+      "publicServerDescription": "Public or custom server",
+      "localAuthNote": "Local ntfy requires authentication. Create an access token in ntfy and paste it below.",
       "auth": {
         "title": "Authentication",
+        "localTokenHint": "Use an access token from your local ntfy app. Canary does not read or prefill ntfy credentials.",
         "configured": {
           "token": "Access token configured",
           "credentials": "Username/password configured ({username})",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "ntfy Topic",
-        "topicHint": "Subscribe to this topic at {server} to receive notifications"
+        "topicHint": "Subscribe to this topic at {server} to receive notifications",
+        "localServer": "local ntfy"
       },
       "sms": {
         "phoneHint": "Include country code"

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "Tema de ntfy",
-        "topicHint": "Suscríbete a este tema en {server} para recibir notificaciones"
+        "topicHint": "Suscríbete a este tema en {server} para recibir notificaciones",
+        "localServer": "ntfy local"
       },
       "sms": {
         "phoneHint": "Incluye código de país"

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -292,6 +292,11 @@
       "selfHostLink": "auto-alojar ntfy",
       "serverNoteAfter": " para completa privacidad.",
       "localAuthNote": "ntfy local requiere autenticación. Crea un token de acceso en ntfy y pégalo abajo.",
+      "validation": {
+        "urlRequired": "La URL del servidor ntfy es obligatoria",
+        "urlProtocol": "La URL del servidor ntfy debe comenzar con http:// o https://",
+        "saveFailed": "No se pudo guardar"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "Local"

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -288,9 +288,6 @@
       "description": "Configura tu servidor ntfy para notificaciones push",
       "serverLabel": "URL del Servidor ntfy",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "Deja vacío para usar el servidor público ntfy.sh. Puedes ",
-      "selfHostLink": "auto-alojar ntfy",
-      "serverNoteAfter": " para completa privacidad.",
       "localAuthNote": "ntfy local requiere autenticación. Crea un token de acceso en ntfy y pégalo abajo.",
       "validation": {
         "urlRequired": "La URL del servidor ntfy es obligatoria",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -292,6 +292,10 @@
       "selfHostLink": "auto-alojar ntfy",
       "serverNoteAfter": " para completa privacidad.",
       "localAuthNote": "ntfy local requiere autenticación. Crea un token de acceso en ntfy y pégalo abajo.",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "Autenticación",
         "localTokenHint": "Usa un token de acceso de tu app ntfy local. Canary no lee ni rellena credenciales de ntfy.",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -291,8 +291,11 @@
       "serverNoteBefore": "Deja vacío para usar el servidor público ntfy.sh. Puedes ",
       "selfHostLink": "auto-alojar ntfy",
       "serverNoteAfter": " para completa privacidad.",
+      "publicServerDescription": "Servidor público o personalizado",
+      "localAuthNote": "ntfy local requiere autenticación. Crea un token de acceso en ntfy y pégalo abajo.",
       "auth": {
         "title": "Autenticación",
+        "localTokenHint": "Usa un token de acceso de tu app ntfy local. Canary no lee ni rellena credenciales de ntfy.",
         "configured": {
           "token": "Token de acceso configurado",
           "credentials": "Usuario/contraseña configurado ({username})",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -291,7 +291,6 @@
       "serverNoteBefore": "Deja vacío para usar el servidor público ntfy.sh. Puedes ",
       "selfHostLink": "auto-alojar ntfy",
       "serverNoteAfter": " para completa privacidad.",
-      "publicServerDescription": "Servidor público o personalizado",
       "localAuthNote": "ntfy local requiere autenticación. Crea un token de acceso en ntfy y pégalo abajo.",
       "auth": {
         "title": "Autenticación",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -291,8 +291,11 @@
       "serverNoteBefore": "Laissez vide pour utiliser le serveur public ntfy.sh. Vous pouvez ",
       "selfHostLink": "auto-héberger ntfy",
       "serverNoteAfter": " pour une confidentialité complète.",
+      "publicServerDescription": "Serveur public ou personnalisé",
+      "localAuthNote": "Le ntfy local nécessite une authentification. Créez un token d'accès dans ntfy et collez-le ci-dessous.",
       "auth": {
         "title": "Authentification",
+        "localTokenHint": "Utilisez un token d'accès de votre app ntfy locale. Canary ne lit pas et ne préremplit pas les identifiants ntfy.",
         "configured": {
           "token": "Token d'accès configuré",
           "credentials": "Nom d'utilisateur/mot de passe configuré ({username})",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -292,6 +292,10 @@
       "selfHostLink": "auto-héberger ntfy",
       "serverNoteAfter": " pour une confidentialité complète.",
       "localAuthNote": "Le ntfy local nécessite une authentification. Créez un token d'accès dans ntfy et collez-le ci-dessous.",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "Authentification",
         "localTokenHint": "Utilisez un token d'accès de votre app ntfy locale. Canary ne lit pas et ne préremplit pas les identifiants ntfy.",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -288,9 +288,6 @@
       "description": "Configurez votre serveur ntfy pour les notifications push",
       "serverLabel": "URL du serveur ntfy",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "Laissez vide pour utiliser le serveur public ntfy.sh. Vous pouvez ",
-      "selfHostLink": "auto-héberger ntfy",
-      "serverNoteAfter": " pour une confidentialité complète.",
       "localAuthNote": "Le ntfy local nécessite une authentification. Créez un token d'accès dans ntfy et collez-le ci-dessous.",
       "validation": {
         "urlRequired": "L'URL du serveur ntfy est requise",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "Sujet ntfy",
-        "topicHint": "Abonnez-vous à ce sujet sur {server} pour recevoir les notifications"
+        "topicHint": "Abonnez-vous à ce sujet sur {server} pour recevoir les notifications",
+        "localServer": "ntfy local"
       },
       "sms": {
         "phoneHint": "Inclure l'indicatif du pays"

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -292,6 +292,11 @@
       "selfHostLink": "auto-héberger ntfy",
       "serverNoteAfter": " pour une confidentialité complète.",
       "localAuthNote": "Le ntfy local nécessite une authentification. Créez un token d'accès dans ntfy et collez-le ci-dessous.",
+      "validation": {
+        "urlRequired": "L'URL du serveur ntfy est requise",
+        "urlProtocol": "L'URL du serveur ntfy doit commencer par http:// ou https://",
+        "saveFailed": "Échec de l'enregistrement"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "Local"

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -291,7 +291,6 @@
       "serverNoteBefore": "Laissez vide pour utiliser le serveur public ntfy.sh. Vous pouvez ",
       "selfHostLink": "auto-héberger ntfy",
       "serverNoteAfter": " pour une confidentialité complète.",
-      "publicServerDescription": "Serveur public ou personnalisé",
       "localAuthNote": "Le ntfy local nécessite une authentification. Créez un token d'accès dans ntfy et collez-le ci-dessous.",
       "auth": {
         "title": "Authentification",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -292,6 +292,11 @@
       "selfHostLink": "ntfyを自己ホスト",
       "serverNoteAfter": "できます。",
       "localAuthNote": "ローカルntfyには認証が必要です。ntfyでアクセストークンを作成し、下に貼り付けてください。",
+      "validation": {
+        "urlRequired": "ntfyサーバーURLは必須です",
+        "urlProtocol": "ntfyサーバーURLはhttp://またはhttps://で始まる必要があります",
+        "saveFailed": "保存に失敗しました"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "ローカル"

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -288,9 +288,6 @@
       "description": "プッシュ通知用のntfyサーバーを設定",
       "serverLabel": "ntfyサーバーURL",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "空のままにすると公開ntfy.shサーバーを使用します。完全なプライバシーのために",
-      "selfHostLink": "ntfyを自己ホスト",
-      "serverNoteAfter": "できます。",
       "localAuthNote": "ローカルntfyには認証が必要です。ntfyでアクセストークンを作成し、下に貼り付けてください。",
       "validation": {
         "urlRequired": "ntfyサーバーURLは必須です",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "ntfyトピック",
-        "topicHint": "通知を受け取るには、{server}でこのトピックを購読してください"
+        "topicHint": "通知を受け取るには、{server}でこのトピックを購読してください",
+        "localServer": "ローカルntfy"
       },
       "sms": {
         "phoneHint": "国番号を含める"

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -291,7 +291,6 @@
       "serverNoteBefore": "空のままにすると公開ntfy.shサーバーを使用します。完全なプライバシーのために",
       "selfHostLink": "ntfyを自己ホスト",
       "serverNoteAfter": "できます。",
-      "publicServerDescription": "公開またはカスタムサーバー",
       "localAuthNote": "ローカルntfyには認証が必要です。ntfyでアクセストークンを作成し、下に貼り付けてください。",
       "auth": {
         "title": "認証",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -291,8 +291,11 @@
       "serverNoteBefore": "空のままにすると公開ntfy.shサーバーを使用します。完全なプライバシーのために",
       "selfHostLink": "ntfyを自己ホスト",
       "serverNoteAfter": "できます。",
+      "publicServerDescription": "公開またはカスタムサーバー",
+      "localAuthNote": "ローカルntfyには認証が必要です。ntfyでアクセストークンを作成し、下に貼り付けてください。",
       "auth": {
         "title": "認証",
+        "localTokenHint": "ローカルntfyアプリのアクセストークンを使用してください。Canaryはntfy認証情報を読み取ったり事前入力したりしません。",
         "configured": {
           "token": "アクセストークン設定済み",
           "credentials": "ユーザー名/パスワード設定済み ({username})",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -294,7 +294,7 @@
       "localAuthNote": "ローカルntfyには認証が必要です。ntfyでアクセストークンを作成し、下に貼り付けてください。",
       "platform": {
         "umbrel": "Umbrel",
-        "local": "Local"
+        "local": "ローカル"
       },
       "auth": {
         "title": "認証",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -292,6 +292,10 @@
       "selfHostLink": "ntfyを自己ホスト",
       "serverNoteAfter": "できます。",
       "localAuthNote": "ローカルntfyには認証が必要です。ntfyでアクセストークンを作成し、下に貼り付けてください。",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "認証",
         "localTokenHint": "ローカルntfyアプリのアクセストークンを使用してください。Canaryはntfy認証情報を読み取ったり事前入力したりしません。",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -342,7 +342,7 @@
       "localAuthNote": "Lokal ntfy krever autentisering. Opprett et tilgangstoken i ntfy og lim det inn nedenfor.",
       "platform": {
         "umbrel": "Umbrel",
-        "local": "Local"
+        "local": "Lokal"
       },
       "auth": {
         "title": "Autentisering",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -339,7 +339,6 @@
       "serverNoteBefore": "La stå tom for å bruke den offentlige ntfy.sh-serveren. Du kan ",
       "selfHostLink": "kjøre ntfy selv",
       "serverNoteAfter": " for fullstendig personvern.",
-      "publicServerDescription": "Offentlig eller egendefinert server",
       "localAuthNote": "Lokal ntfy krever autentisering. Opprett et tilgangstoken i ntfy og lim det inn nedenfor.",
       "auth": {
         "title": "Autentisering",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -336,9 +336,6 @@
       "description": "Konfigurer din ntfy-server for push-varsler",
       "serverLabel": "ntfy-server URL",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "La stå tom for å bruke den offentlige ntfy.sh-serveren. Du kan ",
-      "selfHostLink": "kjøre ntfy selv",
-      "serverNoteAfter": " for fullstendig personvern.",
       "localAuthNote": "Lokal ntfy krever autentisering. Opprett et tilgangstoken i ntfy og lim det inn nedenfor.",
       "validation": {
         "urlRequired": "ntfy-server URL er påkrevd",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -340,6 +340,11 @@
       "selfHostLink": "kjøre ntfy selv",
       "serverNoteAfter": " for fullstendig personvern.",
       "localAuthNote": "Lokal ntfy krever autentisering. Opprett et tilgangstoken i ntfy og lim det inn nedenfor.",
+      "validation": {
+        "urlRequired": "ntfy-server URL er påkrevd",
+        "urlProtocol": "ntfy-server URL må starte med http:// eller https://",
+        "saveFailed": "Kunne ikke lagre"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "Lokal"

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -339,8 +339,11 @@
       "serverNoteBefore": "La stå tom for å bruke den offentlige ntfy.sh-serveren. Du kan ",
       "selfHostLink": "kjøre ntfy selv",
       "serverNoteAfter": " for fullstendig personvern.",
+      "publicServerDescription": "Offentlig eller egendefinert server",
+      "localAuthNote": "Lokal ntfy krever autentisering. Opprett et tilgangstoken i ntfy og lim det inn nedenfor.",
       "auth": {
         "title": "Autentisering",
+        "localTokenHint": "Bruk et tilgangstoken fra din lokale ntfy-app. Canary leser eller forhåndsutfyller ikke ntfy-legitimasjon.",
         "configured": {
           "token": "Tilgangstoken konfigurert",
           "credentials": "Brukernavn/passord konfigurert ({username})",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "ntfy-emne",
-        "topicHint": "Abonner på dette emnet på {server} for å motta varsler"
+        "topicHint": "Abonner på dette emnet på {server} for å motta varsler",
+        "localServer": "lokal ntfy"
       },
       "sms": {
         "phoneHint": "Inkluder landskode"

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -340,6 +340,10 @@
       "selfHostLink": "kjøre ntfy selv",
       "serverNoteAfter": " for fullstendig personvern.",
       "localAuthNote": "Lokal ntfy krever autentisering. Opprett et tilgangstoken i ntfy og lim det inn nedenfor.",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "Autentisering",
         "localTokenHint": "Bruk et tilgangstoken fra din lokale ntfy-app. Canary leser eller forhåndsutfyller ikke ntfy-legitimasjon.",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "Tópico do ntfy",
-        "topicHint": "Inscreva-se neste tópico em {server} para receber notificações"
+        "topicHint": "Inscreva-se neste tópico em {server} para receber notificações",
+        "localServer": "ntfy local"
       },
       "sms": {
         "phoneHint": "Inclua o código do país"

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -291,7 +291,6 @@
       "serverNoteBefore": "Deixe vazio para usar o servidor público ntfy.sh. Você pode ",
       "selfHostLink": "auto-hospedar ntfy",
       "serverNoteAfter": " para privacidade completa.",
-      "publicServerDescription": "Servidor público ou personalizado",
       "localAuthNote": "O ntfy local requer autenticação. Crie um token de acesso no ntfy e cole-o abaixo.",
       "auth": {
         "title": "Autenticação",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -288,9 +288,6 @@
       "description": "Configure seu servidor ntfy para notificações push",
       "serverLabel": "URL do Servidor ntfy",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "Deixe vazio para usar o servidor público ntfy.sh. Você pode ",
-      "selfHostLink": "auto-hospedar ntfy",
-      "serverNoteAfter": " para privacidade completa.",
       "localAuthNote": "O ntfy local requer autenticação. Crie um token de acesso no ntfy e cole-o abaixo.",
       "validation": {
         "urlRequired": "A URL do servidor ntfy é obrigatória",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -292,6 +292,11 @@
       "selfHostLink": "auto-hospedar ntfy",
       "serverNoteAfter": " para privacidade completa.",
       "localAuthNote": "O ntfy local requer autenticação. Crie um token de acesso no ntfy e cole-o abaixo.",
+      "validation": {
+        "urlRequired": "A URL do servidor ntfy é obrigatória",
+        "urlProtocol": "A URL do servidor ntfy deve começar com http:// ou https://",
+        "saveFailed": "Falha ao salvar"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "Local"

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -291,8 +291,11 @@
       "serverNoteBefore": "Deixe vazio para usar o servidor público ntfy.sh. Você pode ",
       "selfHostLink": "auto-hospedar ntfy",
       "serverNoteAfter": " para privacidade completa.",
+      "publicServerDescription": "Servidor público ou personalizado",
+      "localAuthNote": "O ntfy local requer autenticação. Crie um token de acesso no ntfy e cole-o abaixo.",
       "auth": {
         "title": "Autenticação",
+        "localTokenHint": "Use um token de acesso do seu app ntfy local. O Canary não lê nem preenche credenciais do ntfy.",
         "configured": {
           "token": "Token de acesso configurado",
           "credentials": "Usuário/senha configurado ({username})",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -292,6 +292,10 @@
       "selfHostLink": "auto-hospedar ntfy",
       "serverNoteAfter": " para privacidade completa.",
       "localAuthNote": "O ntfy local requer autenticação. Crie um token de acesso no ntfy e cole-o abaixo.",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "Autenticação",
         "localTokenHint": "Use um token de acesso do seu app ntfy local. O Canary não lê nem preenche credenciais do ntfy.",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -664,7 +664,8 @@
       },
       "ntfy": {
         "topicLabel": "ntfy-ämne",
-        "topicHint": "Prenumerera på detta ämne på {server} för att ta emot aviseringar"
+        "topicHint": "Prenumerera på detta ämne på {server} för att ta emot aviseringar",
+        "localServer": "lokal ntfy"
       },
       "sms": {
         "phoneHint": "Inkludera landskod"

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -336,9 +336,6 @@
       "description": "Konfigurera din ntfy-server för push-notiser",
       "serverLabel": "URL för ntfy-server",
       "serverPlaceholder": "https://ntfy.sh",
-      "serverNoteBefore": "Lämna tomt för att använda den publika ntfy.sh-servern. Du kan ",
-      "selfHostLink": "självvärda ntfy",
-      "serverNoteAfter": " för fullständig integritet.",
       "localAuthNote": "Lokal ntfy kräver autentisering. Skapa en åtkomsttoken i ntfy och klistra in den nedan.",
       "validation": {
         "urlRequired": "ntfy-serverns URL krävs",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -339,8 +339,11 @@
       "serverNoteBefore": "Lämna tomt för att använda den publika ntfy.sh-servern. Du kan ",
       "selfHostLink": "självvärda ntfy",
       "serverNoteAfter": " för fullständig integritet.",
+      "publicServerDescription": "Publik eller anpassad server",
+      "localAuthNote": "Lokal ntfy kräver autentisering. Skapa en åtkomsttoken i ntfy och klistra in den nedan.",
       "auth": {
         "title": "Autentisering",
+        "localTokenHint": "Använd en åtkomsttoken från din lokala ntfy-app. Canary läser eller förifyller inte ntfy-uppgifter.",
         "configured": {
           "token": "Åtkomsttoken konfigurerad",
           "credentials": "Användarnamn/lösenord konfigurerat ({username})",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -340,6 +340,10 @@
       "selfHostLink": "självvärda ntfy",
       "serverNoteAfter": " för fullständig integritet.",
       "localAuthNote": "Lokal ntfy kräver autentisering. Skapa en åtkomsttoken i ntfy och klistra in den nedan.",
+      "platform": {
+        "umbrel": "Umbrel",
+        "local": "Local"
+      },
       "auth": {
         "title": "Autentisering",
         "localTokenHint": "Använd en åtkomsttoken från din lokala ntfy-app. Canary läser inte och fyller inte i ntfy-uppgifter på förhand.",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -339,7 +339,6 @@
       "serverNoteBefore": "Lämna tomt för att använda den publika ntfy.sh-servern. Du kan ",
       "selfHostLink": "självvärda ntfy",
       "serverNoteAfter": " för fullständig integritet.",
-      "publicServerDescription": "Publik eller anpassad server",
       "localAuthNote": "Lokal ntfy kräver autentisering. Skapa en åtkomsttoken i ntfy och klistra in den nedan.",
       "auth": {
         "title": "Autentisering",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -342,7 +342,7 @@
       "localAuthNote": "Lokal ntfy kräver autentisering. Skapa en åtkomsttoken i ntfy och klistra in den nedan.",
       "auth": {
         "title": "Autentisering",
-        "localTokenHint": "Använd en åtkomsttoken från din lokala ntfy-app. Canary läser eller förifyller inte ntfy-uppgifter.",
+        "localTokenHint": "Använd en åtkomsttoken från din lokala ntfy-app. Canary läser inte och fyller inte i ntfy-uppgifter på förhand.",
         "configured": {
           "token": "Åtkomsttoken konfigurerad",
           "credentials": "Användarnamn/lösenord konfigurerat ({username})",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -340,6 +340,11 @@
       "selfHostLink": "självvärda ntfy",
       "serverNoteAfter": " för fullständig integritet.",
       "localAuthNote": "Lokal ntfy kräver autentisering. Skapa en åtkomsttoken i ntfy och klistra in den nedan.",
+      "validation": {
+        "urlRequired": "ntfy-serverns URL krävs",
+        "urlProtocol": "ntfy-serverns URL måste börja med http:// eller https://",
+        "saveFailed": "Kunde inte spara"
+      },
       "platform": {
         "umbrel": "Umbrel",
         "local": "Lokal"

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -342,7 +342,7 @@
       "localAuthNote": "Lokal ntfy kräver autentisering. Skapa en åtkomsttoken i ntfy och klistra in den nedan.",
       "platform": {
         "umbrel": "Umbrel",
-        "local": "Local"
+        "local": "Lokal"
       },
       "auth": {
         "title": "Autentisering",

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+# Keep both fields for compatibility across the pnpm versions used locally and in deploy scripts.
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  sharp: true
+  unrs-resolver: true
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@swc/core'

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -74,6 +74,9 @@ export default function SettingsPage() {
           <NtfyServerSettings
             ntfyServerUrl={preferences.ntfyServerUrl}
             onNtfyServerUrlChange={preferences.setNtfyServerUrl}
+            ntfyServers={preferences.availableNtfyServers}
+            selectedNtfyServerId={preferences.selectedNtfyServerId}
+            onNtfyServerChange={preferences.handleNtfyServerChange}
             userPreferences={preferences.userPreferences}
             ntfyAuthType={preferences.ntfyAuthType}
             onNtfyAuthTypeChange={preferences.setNtfyAuthType}

--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -8,6 +8,10 @@ jest.mock('../../hooks/usePhonePlaceholder', () => ({
   usePhonePlaceholder: () => '+1 234 567 8900',
 }))
 
+jest.mock('../../contexts/auth-context', () => ({
+  useAuth: jest.fn(),
+}))
+
 // Mock the api module but keep ApiError from the real module
 jest.mock('../../lib/api', () => {
   const actual = jest.requireActual('../../lib/api')
@@ -27,6 +31,7 @@ jest.mock('../../lib/api', () => {
 })
 
 const mockApi = jest.requireMock('../../lib/api').api
+const mockUseAuth = jest.requireMock('../../contexts/auth-context').useAuth
 const { ApiError } = jest.requireMock('../../lib/api')
 
 const mockProviders = [
@@ -73,6 +78,10 @@ describe('ContactModal', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    })
     mockApi.getProviders.mockResolvedValue({ providers: mockProviders })
     mockApi.sendContactVerification.mockResolvedValue({ message: 'Verification sent' })
     mockApi.verifyContact.mockResolvedValue({ valid: true, message: 'Verified' })

--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -178,7 +178,7 @@ describe('ContactModal', () => {
         tx_explorers: [],
         default_tx_explorer_id: 'mempool-space',
         ntfy_servers: [
-          { id: 'umbrel-ntfy', name: 'ntfy', base_url: 'http://ntfy_app_1' },
+          { id: 'umbrel-ntfy', name: 'ntfy', base_url: 'http://ntfy_app_1', platform: 'umbrel' },
         ],
         default_ntfy_server_id: 'umbrel-ntfy',
       })

--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -21,6 +21,7 @@ jest.mock('../../lib/api', () => {
       updateContact: jest.fn(),
       deleteContact: jest.fn(),
       getUserPreferences: jest.fn(),
+      getConfig: jest.fn(),
     },
   }
 })
@@ -76,6 +77,12 @@ describe('ContactModal', () => {
     mockApi.sendContactVerification.mockResolvedValue({ message: 'Verification sent' })
     mockApi.verifyContact.mockResolvedValue({ valid: true, message: 'Verified' })
     mockApi.createContact.mockResolvedValue({ id: 1 })
+    mockApi.getConfig.mockResolvedValue({
+      tx_explorers: [],
+      default_tx_explorer_id: 'mempool-space',
+      ntfy_servers: [],
+      default_ntfy_server_id: 'ntfy-sh',
+    })
     mockApi.getUserPreferences.mockResolvedValue({
       preferred_fiat_currency: 'USD',
       preferred_tx_explorer_id: null,

--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -172,6 +172,31 @@ describe('ContactModal', () => {
       })
     })
 
+    it('does not show Docker-internal ntfy server URLs in the topic hint', async () => {
+      const user = userEvent.setup()
+      mockApi.getConfig.mockResolvedValue({
+        tx_explorers: [],
+        default_tx_explorer_id: 'mempool-space',
+        ntfy_servers: [
+          { id: 'umbrel-ntfy', name: 'ntfy', base_url: 'http://ntfy_app_1' },
+        ],
+        default_ntfy_server_id: 'umbrel-ntfy',
+      })
+
+      await act(async () => {
+        render(<ContactModal {...defaultProps} />)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('ntfy.sh Notifications')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('checkbox', { name: /ntfy\.sh Notifications/ }))
+
+      expect(screen.getByText(/local ntfy/)).toBeInTheDocument()
+      expect(screen.queryByText(/ntfy_app_1/)).not.toBeInTheDocument()
+    })
+
     it('shows validation error when name is empty', async () => {
       const user = userEvent.setup()
       await act(async () => {

--- a/frontend/src/components/__tests__/wallet-contacts-list.test.tsx
+++ b/frontend/src/components/__tests__/wallet-contacts-list.test.tsx
@@ -340,6 +340,15 @@ describe('WalletContactsList', () => {
     expect(ntfyLink).toHaveAttribute('href', 'https://ntfy.example.com/bob-no-8nt3y08q')
   })
 
+  it('renders ntfy links for browser-safe local servers', () => {
+    mockUseNtfyServerTarget.mockReturnValue({ url: 'http://umbrel', isBrowserSafe: true })
+
+    render(<WalletContactsList {...defaultProps} />)
+
+    const ntfyLink = screen.getByText('bob-no-8nt3y08q').closest('a')
+    expect(ntfyLink).toHaveAttribute('href', 'http://umbrel/bob-no-8nt3y08q')
+  })
+
   it('displays multiple notification methods for a single contact', () => {
     const contactWithMultipleMethods: Contact = {
       id: 'contact-3',

--- a/frontend/src/components/__tests__/wallet-contacts-list.test.tsx
+++ b/frontend/src/components/__tests__/wallet-contacts-list.test.tsx
@@ -349,6 +349,14 @@ describe('WalletContactsList', () => {
     expect(ntfyLink).toHaveAttribute('href', 'http://umbrel/bob-no-8nt3y08q')
   })
 
+  it('renders ntfy targets as plain text when server is not browser-safe', () => {
+    mockUseNtfyServerTarget.mockReturnValue({ url: 'http://ntfy_app_1', isBrowserSafe: false })
+
+    render(<WalletContactsList {...defaultProps} />)
+
+    expect(screen.getByText('bob-no-8nt3y08q').closest('a')).toBeNull()
+  })
+
   it('displays multiple notification methods for a single contact', () => {
     const contactWithMultipleMethods: Contact = {
       id: 'contact-3',

--- a/frontend/src/components/__tests__/wallet-contacts-list.test.tsx
+++ b/frontend/src/components/__tests__/wallet-contacts-list.test.tsx
@@ -16,9 +16,10 @@ jest.mock('../../lib/api', () => ({
 }))
 
 // Mock the useNtfyServerUrl hook
-const mockUseNtfyServerUrl = jest.fn(() => 'https://ntfy.sh')
+const mockUseNtfyServerTarget = jest.fn(() => ({ url: 'https://ntfy.sh', isBrowserSafe: true }))
 jest.mock('../../hooks/useNtfyServerUrl', () => ({
-  useNtfyServerUrl: () => mockUseNtfyServerUrl(),
+  useNtfyServerTarget: () => mockUseNtfyServerTarget(),
+  useNtfyServerUrl: () => mockUseNtfyServerTarget().url,
 }))
 
 // Mock the useAuth hook
@@ -100,7 +101,7 @@ describe('WalletContactsList', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUseNtfyServerUrl.mockReturnValue('https://ntfy.sh')
+    mockUseNtfyServerTarget.mockReturnValue({ url: 'https://ntfy.sh', isBrowserSafe: true })
     mockUseAuth.mockReturnValue(defaultAuthState)
     mockApi.getProviders.mockResolvedValue({ providers: [] })
     mockApi.sendContactVerification.mockResolvedValue({ message: 'Verification sent' })
@@ -331,7 +332,7 @@ describe('WalletContactsList', () => {
   })
 
   it('renders ntfy links with custom server URL when configured', () => {
-    mockUseNtfyServerUrl.mockReturnValue('https://ntfy.example.com')
+    mockUseNtfyServerTarget.mockReturnValue({ url: 'https://ntfy.example.com', isBrowserSafe: true })
 
     render(<WalletContactsList {...defaultProps} />)
 

--- a/frontend/src/components/contact-modal.tsx
+++ b/frontend/src/components/contact-modal.tsx
@@ -26,7 +26,7 @@ import { useSmsVerification } from "@/hooks/useSmsVerification"
 import { useEmailVerification } from "@/hooks/useEmailVerification"
 import { useOriginalContactState } from "@/hooks/useOriginalContactState"
 import { useContactChangeDetection } from "@/hooks/useContactChangeDetection"
-import { useNtfyServerUrl } from "@/hooks/useNtfyServerUrl"
+import { useNtfyServerTarget } from "@/hooks/useNtfyServerUrl"
 import { useIsMobile } from "@/hooks/useIsMobile"
 import { useContactWizard } from "@/hooks/useContactWizard"
 
@@ -68,7 +68,7 @@ export function ContactModal({
   const tCommon = useTranslations('common')
   const tApiErrors = useTranslations('errors.api')
   const phonePlaceholder = usePhonePlaceholder()
-  const ntfyServerUrl = useNtfyServerUrl()
+  const ntfyServerTarget = useNtfyServerTarget()
   const [name, setName] = useState("")
   const [ntfyTopic, setNtfyTopic] = useState("")
   const [userEditedNtfyTopic, setUserEditedNtfyTopic] = useState(false)
@@ -517,7 +517,8 @@ export function ContactModal({
                     }}
                     defaultTopicPlaceholder={generateDefaultNtfyTopic(name || 'contact', walletChecksum)}
                     disabled={isSubmitting}
-                    ntfyServerUrl={ntfyServerUrl}
+                    ntfyServerUrl={ntfyServerTarget.url}
+                    ntfyServerIsBrowserSafe={ntfyServerTarget.isBrowserSafe}
                   />
                 )}
               </div>

--- a/frontend/src/components/contact-modal/ntfy-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/ntfy-provider-fields.tsx
@@ -10,6 +10,7 @@ interface NtfyProviderFieldsProps {
   defaultTopicPlaceholder: string
   disabled?: boolean
   ntfyServerUrl?: string
+  ntfyServerIsBrowserSafe?: boolean
 }
 
 export function NtfyProviderFields({
@@ -18,12 +19,15 @@ export function NtfyProviderFields({
   defaultTopicPlaceholder,
   disabled = false,
   ntfyServerUrl,
+  ntfyServerIsBrowserSafe = true,
 }: NtfyProviderFieldsProps) {
   const t = useTranslations('contacts')
 
   // Extract hostname for display (e.g., "https://ntfy.example.com" → "ntfy.example.com")
   let serverDisplay = 'ntfy.sh'
-  if (ntfyServerUrl) {
+  if (!ntfyServerIsBrowserSafe) {
+    serverDisplay = t('add.ntfy.localServer')
+  } else if (ntfyServerUrl) {
     try {
       serverDisplay = new URL(ntfyServerUrl).hostname
     } catch {

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -9,7 +9,6 @@ describe("NtfyServerSettings", () => {
     name: "ntfy",
     baseUrl: "http://ntfy_app_1",
     isLocal: true,
-    isCustom: false,
   }
 
   const publicNtfy: NtfyServerOption = {
@@ -17,7 +16,6 @@ describe("NtfyServerSettings", () => {
     name: "ntfy",
     baseUrl: "https://ntfy.sh",
     isLocal: false,
-    isCustom: false,
   }
 
   const defaultProps = {

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -123,12 +123,14 @@ describe("NtfyServerSettings", () => {
   it("does not save inline public URL edits when the URL is unchanged", async () => {
     const user = userEvent.setup()
     const onNtfySettingsSave = jest.fn()
+    const onClearNtfySettingsErrors = jest.fn()
     render(
       <NtfyServerSettings
         {...defaultProps}
         selectedNtfyServerId="ntfy-sh"
         ntfyServerUrl="https://ntfy.example.com"
         onNtfySettingsSave={onNtfySettingsSave}
+        onClearNtfySettingsErrors={onClearNtfySettingsErrors}
       />
     )
 
@@ -136,7 +138,39 @@ describe("NtfyServerSettings", () => {
     await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
 
     expect(onNtfySettingsSave).not.toHaveBeenCalled()
+    expect(onClearNtfySettingsErrors).toHaveBeenCalled()
     expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
+  })
+
+  it("keeps the public URL editor open when save validation fails", async () => {
+    const user = userEvent.setup()
+    const onNtfySettingsSave = jest.fn().mockResolvedValue(false)
+
+    function ControlledSettings() {
+      const [serverUrl, setServerUrl] = useState("https://ntfy.example.com")
+
+      return (
+        <NtfyServerSettings
+          {...defaultProps}
+          selectedNtfyServerId="ntfy-sh"
+          ntfyServerUrl={serverUrl}
+          onNtfyServerUrlChange={setServerUrl}
+          onNtfySettingsSave={onNtfySettingsSave}
+          ntfySettingsError="URL must start with http:// or https://"
+        />
+      )
+    }
+
+    render(<ControlledSettings />)
+
+    await user.click(screen.getByRole("button", { name: /edit/i }))
+    await user.clear(screen.getByLabelText("ntfy Server URL"))
+    await user.type(screen.getByLabelText("ntfy Server URL"), "ntfy.example.com")
+    await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
+
+    expect(onNtfySettingsSave).toHaveBeenCalledTimes(1)
+    expect(screen.getByLabelText("ntfy Server URL")).toBeInTheDocument()
+    expect(screen.getByText("URL must start with http:// or https://")).toBeInTheDocument()
   })
 
   it("does not save inline public URL edits when only trailing slashes change", async () => {

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -72,7 +72,8 @@ describe("NtfyServerSettings", () => {
     expect(onNtfyServerChange).toHaveBeenCalledWith("ntfy-sh")
   })
 
-  it("shows editable URL input when public/custom option is selected", () => {
+  it("shows public/custom URL behind an edit button", async () => {
+    const user = userEvent.setup()
     render(
       <NtfyServerSettings
         {...defaultProps}
@@ -80,6 +81,11 @@ describe("NtfyServerSettings", () => {
         ntfyServerUrl="https://ntfy.example.com"
       />
     )
+
+    expect(screen.getByText("https://ntfy.example.com")).toBeInTheDocument()
+    expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /edit/i }))
 
     expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("https://ntfy.example.com")
   })

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { NtfyServerSettings } from "../ntfy-server-settings"
+import type { NtfyServerOption } from "@/lib/ntfy-servers"
+
+describe("NtfyServerSettings", () => {
+  const localNtfy: NtfyServerOption = {
+    id: "umbrel-ntfy",
+    name: "ntfy",
+    baseUrl: "http://ntfy_app_1",
+    isLocal: true,
+    isCustom: false,
+  }
+
+  const publicNtfy: NtfyServerOption = {
+    id: "ntfy-sh",
+    name: "ntfy",
+    baseUrl: "https://ntfy.sh",
+    isLocal: false,
+    isCustom: false,
+  }
+
+  const defaultProps = {
+    ntfyServerUrl: "http://ntfy_app_1",
+    onNtfyServerUrlChange: jest.fn(),
+    ntfyServers: [publicNtfy, localNtfy],
+    selectedNtfyServerId: "umbrel-ntfy",
+    onNtfyServerChange: jest.fn(),
+    userPreferences: {
+      preferred_fiat_currency: "USD",
+      preferred_tx_explorer_id: null,
+      ntfy_server_url: null,
+      ntfy_has_access_token: false,
+      ntfy_has_credentials: false,
+      ntfy_username: null,
+    },
+    ntfyAuthType: "none" as const,
+    onNtfyAuthTypeChange: jest.fn(),
+    ntfyAccessToken: "",
+    onNtfyAccessTokenChange: jest.fn(),
+    ntfyUsername: "",
+    onNtfyUsernameChange: jest.fn(),
+    ntfyPassword: "",
+    onNtfyPasswordChange: jest.fn(),
+    hasAnyNtfyChanges: false,
+    isUpdatingNtfySettings: false,
+    ntfySettingsError: null,
+    ntfySettingsSuccess: false,
+    onNtfySettingsSave: jest.fn(),
+    onClearNtfySettingsErrors: jest.fn(),
+  }
+
+  it("renders an editable URL option and local Umbrel when detected", () => {
+    render(<NtfyServerSettings {...defaultProps} />)
+
+    expect(screen.getByText("Push Notifications")).toBeInTheDocument()
+    expect(screen.getAllByText("ntfy")).toHaveLength(2)
+    expect(screen.getByText("Public or custom server")).toBeInTheDocument()
+    expect(screen.getByText("Umbrel")).toBeInTheDocument()
+    expect(screen.queryByText("http://ntfy_app_1")).not.toBeInTheDocument()
+    expect(screen.getByText(/Create an access token in ntfy/)).toBeInTheDocument()
+  })
+
+  it("calls the server change handler when choosing an option", async () => {
+    const user = userEvent.setup()
+    const onNtfyServerChange = jest.fn()
+
+    render(<NtfyServerSettings {...defaultProps} onNtfyServerChange={onNtfyServerChange} />)
+
+    await user.click(screen.getAllByRole("radio", { name: "ntfy" })[0])
+
+    expect(onNtfyServerChange).toHaveBeenCalledWith("ntfy-sh")
+  })
+
+  it("shows editable URL input when public/custom option is selected", () => {
+    render(
+      <NtfyServerSettings
+        {...defaultProps}
+        selectedNtfyServerId="ntfy-sh"
+        ntfyServerUrl="https://ntfy.example.com"
+      />
+    )
+
+    expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("https://ntfy.example.com")
+  })
+
+  it("shows auth controls for public ntfy", () => {
+    render(
+      <NtfyServerSettings
+        {...defaultProps}
+        selectedNtfyServerId="ntfy-sh"
+        ntfyServerUrl="https://ntfy.sh"
+      />
+    )
+
+    expect(screen.getByText("Authentication")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -72,13 +72,17 @@ describe("NtfyServerSettings", () => {
     expect(onNtfyServerChange).toHaveBeenCalledWith("ntfy-sh")
   })
 
-  it("shows public/custom URL behind an edit button", async () => {
+  it("edits the public/custom URL inline", async () => {
     const user = userEvent.setup()
+    const onNtfyServerUrlChange = jest.fn()
+    const onNtfySettingsSave = jest.fn()
     render(
       <NtfyServerSettings
         {...defaultProps}
         selectedNtfyServerId="ntfy-sh"
         ntfyServerUrl="https://ntfy.example.com"
+        onNtfyServerUrlChange={onNtfyServerUrlChange}
+        onNtfySettingsSave={onNtfySettingsSave}
       />
     )
 
@@ -88,6 +92,28 @@ describe("NtfyServerSettings", () => {
     await user.click(screen.getByRole("button", { name: /edit/i }))
 
     expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("https://ntfy.example.com")
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
+    await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
+
+    expect(onNtfySettingsSave).toHaveBeenCalledTimes(1)
+  })
+
+  it("restores the public/custom URL when cancelling inline edit", async () => {
+    const user = userEvent.setup()
+    const onNtfyServerUrlChange = jest.fn()
+    render(
+      <NtfyServerSettings
+        {...defaultProps}
+        selectedNtfyServerId="ntfy-sh"
+        ntfyServerUrl="https://ntfy.example.com"
+        onNtfyServerUrlChange={onNtfyServerUrlChange}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /edit/i }))
+    await user.click(screen.getByRole("button", { name: /cancel/i }))
+
+    expect(onNtfyServerUrlChange).toHaveBeenCalledWith("https://ntfy.example.com")
   })
 
   it("shows auth controls for public ntfy", () => {

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -10,6 +10,7 @@ describe("NtfyServerSettings", () => {
     name: "ntfy",
     baseUrl: "http://ntfy_app_1",
     isLocal: true,
+    platform: "umbrel",
   }
 
   const publicNtfy: NtfyServerOption = {

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -139,6 +139,33 @@ describe("NtfyServerSettings", () => {
     expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
   })
 
+  it("does not save inline public URL edits when only trailing slashes change", async () => {
+    const user = userEvent.setup()
+    const onNtfySettingsSave = jest.fn()
+
+    function ControlledSettings() {
+      const [serverUrl, setServerUrl] = useState("https://ntfy.example.com")
+
+      return (
+        <NtfyServerSettings
+          {...defaultProps}
+          selectedNtfyServerId="ntfy-sh"
+          ntfyServerUrl={serverUrl}
+          onNtfyServerUrlChange={setServerUrl}
+          onNtfySettingsSave={onNtfySettingsSave}
+        />
+      )
+    }
+
+    render(<ControlledSettings />)
+
+    await user.click(screen.getByRole("button", { name: /edit/i }))
+    await user.type(screen.getByLabelText("ntfy Server URL"), "/")
+    await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
+
+    expect(onNtfySettingsSave).not.toHaveBeenCalled()
+  })
+
   it("restores the public/custom URL when cancelling inline edit", async () => {
     const user = userEvent.setup()
     const onNtfyServerUrlChange = jest.fn()

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -141,4 +141,10 @@ describe("NtfyServerSettings", () => {
 
     expect(screen.getByText("Authentication")).toBeInTheDocument()
   })
+
+  it("disables test notifications while ntfy settings are unsaved", () => {
+    render(<NtfyServerSettings {...defaultProps} hasAnyNtfyChanges={true} />)
+
+    expect(screen.getByRole("button", { name: "Send Test" })).toBeDisabled()
+  })
 })

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -88,17 +88,23 @@ describe("NtfyServerSettings", () => {
 
   it("edits the public/custom URL inline", async () => {
     const user = userEvent.setup()
-    const onNtfyServerUrlChange = jest.fn()
     const onNtfySettingsSave = jest.fn()
-    render(
-      <NtfyServerSettings
-        {...defaultProps}
-        selectedNtfyServerId="ntfy-sh"
-        ntfyServerUrl="https://ntfy.example.com"
-        onNtfyServerUrlChange={onNtfyServerUrlChange}
-        onNtfySettingsSave={onNtfySettingsSave}
-      />
-    )
+
+    function ControlledSettings() {
+      const [serverUrl, setServerUrl] = useState("https://ntfy.example.com")
+
+      return (
+        <NtfyServerSettings
+          {...defaultProps}
+          selectedNtfyServerId="ntfy-sh"
+          ntfyServerUrl={serverUrl}
+          onNtfyServerUrlChange={setServerUrl}
+          onNtfySettingsSave={onNtfySettingsSave}
+        />
+      )
+    }
+
+    render(<ControlledSettings />)
 
     expect(screen.getByText("https://ntfy.example.com")).toBeInTheDocument()
     expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
@@ -107,9 +113,30 @@ describe("NtfyServerSettings", () => {
 
     expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("https://ntfy.example.com")
     expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
+    await user.clear(screen.getByLabelText("ntfy Server URL"))
+    await user.type(screen.getByLabelText("ntfy Server URL"), "https://ntfy.changed.example.com")
     await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
 
     expect(onNtfySettingsSave).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not save inline public URL edits when the URL is unchanged", async () => {
+    const user = userEvent.setup()
+    const onNtfySettingsSave = jest.fn()
+    render(
+      <NtfyServerSettings
+        {...defaultProps}
+        selectedNtfyServerId="ntfy-sh"
+        ntfyServerUrl="https://ntfy.example.com"
+        onNtfySettingsSave={onNtfySettingsSave}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /edit/i }))
+    await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
+
+    expect(onNtfySettingsSave).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
   })
 
   it("restores the public/custom URL when cancelling inline edit", async () => {

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { useState } from "react"
 import { NtfyServerSettings } from "../ntfy-server-settings"
 import type { NtfyServerOption } from "@/lib/ntfy-servers"
 
@@ -126,6 +127,40 @@ describe("NtfyServerSettings", () => {
     await user.click(screen.getByRole("button", { name: /cancel/i }))
 
     expect(onNtfyServerUrlChange).toHaveBeenCalledWith("https://ntfy.example.com")
+  })
+
+  it("closes the public URL editor when switching servers", async () => {
+    const user = userEvent.setup()
+
+    function ControlledSettings() {
+      const [selectedServerId, setSelectedServerId] = useState("ntfy-sh")
+      const [serverUrl, setServerUrl] = useState("https://ntfy.example.com")
+
+      return (
+        <NtfyServerSettings
+          {...defaultProps}
+          selectedNtfyServerId={selectedServerId}
+          ntfyServerUrl={serverUrl}
+          onNtfyServerUrlChange={setServerUrl}
+          onNtfyServerChange={(serverId) => {
+            setSelectedServerId(serverId)
+            setServerUrl(serverId === "umbrel-ntfy" ? "http://ntfy_app_1" : "https://ntfy.example.com")
+          }}
+        />
+      )
+    }
+
+    render(<ControlledSettings />)
+
+    await user.click(screen.getByRole("button", { name: /edit/i }))
+    expect(screen.getByLabelText("ntfy Server URL")).toBeInTheDocument()
+
+    await user.click(screen.getAllByRole("radio", { name: "ntfy" })[1])
+    expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
+
+    await user.click(screen.getAllByRole("radio", { name: "ntfy" })[0])
+    expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
+    expect(screen.getByText("https://ntfy.example.com")).toBeInTheDocument()
   })
 
   it("shows auth controls for public ntfy", () => {

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -72,6 +72,20 @@ describe("NtfyServerSettings", () => {
     expect(onNtfyServerChange).toHaveBeenCalledWith("ntfy-sh")
   })
 
+  it("does not show a radio button when only public ntfy is available", () => {
+    render(
+      <NtfyServerSettings
+        {...defaultProps}
+        ntfyServers={[publicNtfy]}
+        selectedNtfyServerId="ntfy-sh"
+        ntfyServerUrl="https://ntfy.sh"
+      />
+    )
+
+    expect(screen.getByText("ntfy")).toBeInTheDocument()
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument()
+  })
+
   it("edits the public/custom URL inline", async () => {
     const user = userEvent.setup()
     const onNtfyServerUrlChange = jest.fn()

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -55,7 +55,7 @@ describe("NtfyServerSettings", () => {
 
     expect(screen.getByText("Push Notifications")).toBeInTheDocument()
     expect(screen.getAllByText("ntfy")).toHaveLength(2)
-    expect(screen.getByText("Public or custom server")).toBeInTheDocument()
+    expect(screen.getByText("https://ntfy.sh")).toBeInTheDocument()
     expect(screen.getByText("Umbrel")).toBeInTheDocument()
     expect(screen.queryByText("http://ntfy_app_1")).not.toBeInTheDocument()
     expect(screen.getByText(/Create an access token in ntfy/)).toBeInTheDocument()

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -68,7 +68,7 @@ export function NtfyServerSettings({
   const [isEditingPublicUrl, setIsEditingPublicUrl] = useState(false)
   const [publicUrlBeforeEdit, setPublicUrlBeforeEdit] = useState("")
 
-  const publicServers = ntfyServers.filter((server) => !server.isLocal && !server.isCustom)
+  const publicServers = ntfyServers.filter((server) => !server.isLocal)
   const localServers = ntfyServers.filter((server) => server.isLocal)
   const publicServer = publicServers[0]
   const showAuthSection = Boolean(ntfyServerUrl)

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ErrorDisplay, SuccessDisplay } from "@/components/ui/error-display"
-import { Bell } from "lucide-react"
+import { Bell, Pencil } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { api } from "@/lib/api"
 import type { UserPreferences, NtfyAuthType } from "@/hooks/useUserPreferences"
@@ -65,6 +65,7 @@ export function NtfyServerSettings({
 }: NtfyServerSettingsProps) {
   const t = useTranslations("settings")
   const tCommon = useTranslations("common")
+  const [isEditingPublicUrl, setIsEditingPublicUrl] = useState(false)
 
   const publicServers = ntfyServers.filter((server) => !server.isLocal && !server.isCustom)
   const localServers = ntfyServers.filter((server) => server.isLocal)
@@ -94,19 +95,40 @@ export function NtfyServerSettings({
                 <NtfyServerOptionRow server={publicServer} subtitle={t("ntfy.publicServerDescription")} />
                 {selectedNtfyServerId === publicServer.id && (
                   <div>
-                    <Label htmlFor="ntfy-server">{t("ntfy.serverLabel")}</Label>
-                    <Input
-                      id="ntfy-server"
-                      type="url"
-                      placeholder={t("ntfy.serverPlaceholder")}
-                      value={ntfyServerUrl}
-                      onChange={(e) => {
-                        onNtfyServerUrlChange(e.target.value)
-                        onClearNtfySettingsErrors()
-                      }}
-                      disabled={isUpdatingNtfySettings}
-                      className="mt-1"
-                    />
+                    {isEditingPublicUrl ? (
+                      <>
+                        <Label htmlFor="ntfy-server">{t("ntfy.serverLabel")}</Label>
+                        <Input
+                          id="ntfy-server"
+                          type="url"
+                          placeholder={t("ntfy.serverPlaceholder")}
+                          value={ntfyServerUrl}
+                          onChange={(e) => {
+                            onNtfyServerUrlChange(e.target.value)
+                            onClearNtfySettingsErrors()
+                          }}
+                          disabled={isUpdatingNtfySettings}
+                          className="mt-1"
+                        />
+                      </>
+                    ) : (
+                      <div className="flex items-center justify-between gap-3 rounded-md bg-muted/50 px-3 py-2">
+                        <span className="min-w-0 break-all text-sm text-muted-foreground">
+                          {ntfyServerUrl}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setIsEditingPublicUrl(true)}
+                          disabled={isUpdatingNtfySettings}
+                          className="shrink-0"
+                        >
+                          <Pencil className="h-4 w-4" />
+                          {tCommon("edit")}
+                        </Button>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, type ReactNode } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
@@ -72,6 +72,7 @@ export function NtfyServerSettings({
   const publicServer = publicServers[0]
   const showAuthSection = Boolean(ntfyServerUrl)
   const isLocalSelection = localServers.some((server) => server.id === selectedNtfyServerId)
+  const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl : ntfyServerUrl
 
   return (
     <Card>
@@ -92,45 +93,43 @@ export function NtfyServerSettings({
           >
             {publicServer && (
               <div className="space-y-2">
-                <NtfyServerOptionRow server={publicServer} subtitle={t("ntfy.publicServerDescription")} />
-                {selectedNtfyServerId === publicServer.id && (
-                  <div>
-                    {isEditingPublicUrl ? (
-                      <>
-                        <Label htmlFor="ntfy-server">{t("ntfy.serverLabel")}</Label>
-                        <Input
-                          id="ntfy-server"
-                          type="url"
-                          placeholder={t("ntfy.serverPlaceholder")}
-                          value={ntfyServerUrl}
-                          onChange={(e) => {
-                            onNtfyServerUrlChange(e.target.value)
-                            onClearNtfySettingsErrors()
-                          }}
-                          disabled={isUpdatingNtfySettings}
-                          className="mt-1"
-                        />
-                      </>
-                    ) : (
-                      <div className="flex items-center justify-between gap-3 rounded-md bg-muted/50 px-3 py-2">
-                        <span className="min-w-0 break-all text-sm text-muted-foreground">
-                          {ntfyServerUrl}
-                        </span>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => setIsEditingPublicUrl(true)}
-                          disabled={isUpdatingNtfySettings}
-                          className="shrink-0"
-                        >
-                          <Pencil className="h-4 w-4" />
-                          {tCommon("edit")}
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                )}
+                <NtfyServerOptionRow
+                  server={publicServer}
+                  subtitle={publicServerDisplayUrl ?? publicServer.baseUrl}
+                  action={
+                    selectedNtfyServerId === publicServer.id && !isEditingPublicUrl ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setIsEditingPublicUrl(true)}
+                        disabled={isUpdatingNtfySettings}
+                        className="shrink-0"
+                      >
+                        <Pencil className="h-4 w-4" />
+                        {tCommon("edit")}
+                      </Button>
+                    ) : null
+                  }
+                >
+                  {selectedNtfyServerId === publicServer.id && isEditingPublicUrl && (
+                    <div className="pt-2">
+                      <Label htmlFor="ntfy-server">{t("ntfy.serverLabel")}</Label>
+                      <Input
+                        id="ntfy-server"
+                        type="url"
+                        placeholder={t("ntfy.serverPlaceholder")}
+                        value={ntfyServerUrl}
+                        onChange={(e) => {
+                          onNtfyServerUrlChange(e.target.value)
+                          onClearNtfySettingsErrors()
+                        }}
+                        disabled={isUpdatingNtfySettings}
+                        className="mt-1"
+                      />
+                    </div>
+                  )}
+                </NtfyServerOptionRow>
               </div>
             )}
 
@@ -258,15 +257,31 @@ export function NtfyServerSettings({
   )
 }
 
-function NtfyServerOptionRow({ server, subtitle }: { server: NtfyServerOption; subtitle: string }) {
+function NtfyServerOptionRow({
+  server,
+  subtitle,
+  action,
+  children,
+}: {
+  server: NtfyServerOption
+  subtitle: string
+  action?: ReactNode
+  children?: ReactNode
+}) {
   return (
     <div className="flex items-start gap-3 rounded-md border p-3">
       <RadioGroupItem value={server.id} id={`ntfy-server-${server.id}`} className="mt-1" />
-      <div className="min-w-0 space-y-1">
-        <Label htmlFor={`ntfy-server-${server.id}`} className="cursor-pointer">
-          {server.name}
-        </Label>
-        <p className="break-all text-sm text-muted-foreground">{subtitle}</p>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <Label htmlFor={`ntfy-server-${server.id}`} className="cursor-pointer">
+              {server.name}
+            </Label>
+            <p className="break-all text-sm text-muted-foreground">{subtitle}</p>
+          </div>
+          {action}
+        </div>
+        {children}
       </div>
     </div>
   )

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -131,7 +131,7 @@ export function NtfyServerSettings({
                   action={
                     selectedNtfyServerId === publicServer.id ? (
                       isEditingPublicUrl ? (
-                        <div className="flex shrink-0 items-center gap-2">
+                        <div className="mt-6 flex shrink-0 items-center gap-2">
                           <Button
                             type="button"
                             variant="outline"

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -72,6 +72,7 @@ export function NtfyServerSettings({
   const localServers = ntfyServers.filter((server) => server.isLocal)
   const publicServer = publicServers[0]
   const isLocalSelection = localServers.some((server) => server.id === selectedNtfyServerId)
+  // ntfy.sh supports accounts/private topics, so auth stays available for both public and local servers.
   const showAuthSection = Boolean(ntfyServerUrl || isLocalSelection)
   const hasLocalServers = localServers.length > 0
   const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl ?? "" : ntfyServerUrl
@@ -86,7 +87,7 @@ export function NtfyServerSettings({
   }
   const saveEditingPublicUrl = () => {
     setIsEditingPublicUrl(false)
-    if (ntfyServerUrl !== publicUrlBeforeEdit) {
+    if (normalizeEditablePublicUrl(ntfyServerUrl) !== normalizeEditablePublicUrl(publicUrlBeforeEdit)) {
       onNtfySettingsSave()
     }
   }
@@ -318,6 +319,10 @@ export function NtfyServerSettings({
       </CardContent>
     </Card>
   )
+}
+
+function normalizeEditablePublicUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "")
 }
 
 function NtfyServerOptionRow({

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -169,7 +169,10 @@ export function NtfyServerSettings({
           {hasLocalServers ? (
             <RadioGroup
               value={selectedNtfyServerId}
-              onValueChange={onNtfyServerChange}
+              onValueChange={(serverId) => {
+                setIsEditingPublicUrl(false)
+                onNtfyServerChange(serverId)
+              }}
               disabled={isUpdatingNtfySettings}
               className="space-y-4"
             >

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -37,7 +37,7 @@ interface NtfyServerSettingsProps {
   isUpdatingNtfySettings: boolean
   ntfySettingsError: string | null
   ntfySettingsSuccess: boolean
-  onNtfySettingsSave: () => void
+  onNtfySettingsSave: () => boolean | Promise<boolean> | void | Promise<void>
   onClearNtfySettingsErrors: () => void
 }
 
@@ -85,11 +85,15 @@ export function NtfyServerSettings({
     onClearNtfySettingsErrors()
     setIsEditingPublicUrl(false)
   }
-  const saveEditingPublicUrl = () => {
-    setIsEditingPublicUrl(false)
+  const saveEditingPublicUrl = async () => {
+    onClearNtfySettingsErrors()
     if (normalizeEditablePublicUrl(ntfyServerUrl) !== normalizeEditablePublicUrl(publicUrlBeforeEdit)) {
-      onNtfySettingsSave()
+      const didSave = await onNtfySettingsSave()
+      if (didSave === false) {
+        return
+      }
     }
+    setIsEditingPublicUrl(false)
   }
   const localServerSubtitle = (server: NtfyServerOption) =>
     server.platform === "umbrel" ? t("ntfy.platform.umbrel") : t("ntfy.platform.local")

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -76,7 +76,7 @@ export function NtfyServerSettings({
   const hasLocalServers = localServers.length > 0
   const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl : ntfyServerUrl
   const startEditingPublicUrl = () => {
-    setPublicUrlBeforeEdit(ntfyServerUrl)
+    setPublicUrlBeforeEdit(publicServerDisplayUrl ?? publicServer?.baseUrl ?? "")
     setIsEditingPublicUrl(true)
   }
   const cancelEditingPublicUrl = () => {
@@ -88,6 +88,72 @@ export function NtfyServerSettings({
     setIsEditingPublicUrl(false)
     onNtfySettingsSave()
   }
+  const localServerSubtitle = (server: NtfyServerOption) =>
+    server.id === "umbrel-ntfy" ? t("ntfy.platform.umbrel") : t("ntfy.platform.local")
+  const publicServerRow = publicServer ? (
+    <div className="space-y-2">
+      <NtfyServerOptionRow
+        server={publicServer}
+        showRadio={hasLocalServers}
+        subtitle={
+          selectedNtfyServerId === publicServer.id && isEditingPublicUrl ? (
+            <Input
+              id="ntfy-server"
+              aria-label={t("ntfy.serverLabel")}
+              type="url"
+              placeholder={t("ntfy.serverPlaceholder")}
+              value={ntfyServerUrl}
+              onChange={(e) => {
+                onNtfyServerUrlChange(e.target.value)
+                onClearNtfySettingsErrors()
+              }}
+              disabled={isUpdatingNtfySettings}
+              className="h-8"
+            />
+          ) : (
+            publicServerDisplayUrl ?? publicServer.baseUrl
+          )
+        }
+        subtitleAction={
+          selectedNtfyServerId === publicServer.id ? (
+            isEditingPublicUrl ? (
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={cancelEditingPublicUrl}
+                  disabled={isUpdatingNtfySettings}
+                >
+                  {tCommon("cancel")}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={saveEditingPublicUrl}
+                  disabled={isUpdatingNtfySettings}
+                >
+                  {isUpdatingNtfySettings ? tCommon("saving") : tCommon("save")}
+                </Button>
+              </div>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={startEditingPublicUrl}
+                disabled={isUpdatingNtfySettings}
+                className="shrink-0"
+              >
+                <Pencil className="h-4 w-4" />
+                {tCommon("edit")}
+              </Button>
+            )
+          ) : null
+        }
+      />
+    </div>
+  ) : null
 
   return (
     <Card>
@@ -100,88 +166,26 @@ export function NtfyServerSettings({
       </CardHeader>
       <CardContent>
         <div className="space-y-6">
-          <RadioGroup
-            value={selectedNtfyServerId}
-            onValueChange={onNtfyServerChange}
-            disabled={isUpdatingNtfySettings}
-            className="space-y-4"
-          >
-            {publicServer && (
-              <div className="space-y-2">
-                <NtfyServerOptionRow
-                  server={publicServer}
-                  showRadio={hasLocalServers}
-                  subtitle={
-                    selectedNtfyServerId === publicServer.id && isEditingPublicUrl ? (
-                      <Input
-                        id="ntfy-server"
-                        aria-label={t("ntfy.serverLabel")}
-                        type="url"
-                        placeholder={t("ntfy.serverPlaceholder")}
-                        value={ntfyServerUrl}
-                        onChange={(e) => {
-                          onNtfyServerUrlChange(e.target.value)
-                          onClearNtfySettingsErrors()
-                        }}
-                        disabled={isUpdatingNtfySettings}
-                        className="h-8"
-                      />
-                    ) : (
-                      publicServerDisplayUrl ?? publicServer.baseUrl
-                    )
-                  }
-                  subtitleAction={
-                    selectedNtfyServerId === publicServer.id ? (
-                      isEditingPublicUrl ? (
-                        <div className="flex shrink-0 items-center gap-2">
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={cancelEditingPublicUrl}
-                            disabled={isUpdatingNtfySettings}
-                          >
-                            {tCommon("cancel")}
-                          </Button>
-                          <Button
-                            type="button"
-                            size="sm"
-                            onClick={saveEditingPublicUrl}
-                            disabled={isUpdatingNtfySettings}
-                          >
-                            {isUpdatingNtfySettings ? tCommon("saving") : tCommon("save")}
-                          </Button>
-                        </div>
-                      ) : (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={startEditingPublicUrl}
-                          disabled={isUpdatingNtfySettings}
-                          className="shrink-0"
-                        >
-                          <Pencil className="h-4 w-4" />
-                          {tCommon("edit")}
-                        </Button>
-                      )
-                    ) : null
-                  }
-                />
-              </div>
-            )}
-
-            {hasLocalServers && (
+          {hasLocalServers ? (
+            <RadioGroup
+              value={selectedNtfyServerId}
+              onValueChange={onNtfyServerChange}
+              disabled={isUpdatingNtfySettings}
+              className="space-y-4"
+            >
+              {publicServerRow}
               <div className="space-y-2">
                 <div className="space-y-3">
                   {localServers.map((server) => (
-                    <NtfyServerOptionRow key={server.id} server={server} subtitle="Umbrel" />
+                    <NtfyServerOptionRow key={server.id} server={server} subtitle={localServerSubtitle(server)} />
                   ))}
                 </div>
                 <p className="text-sm text-muted-foreground">{t("ntfy.localAuthNote")}</p>
               </div>
-            )}
-          </RadioGroup>
+            </RadioGroup>
+          ) : (
+            publicServerRow
+          )}
 
           {showAuthSection && (
             <div className="border-t pt-4">

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -71,10 +71,10 @@ export function NtfyServerSettings({
   const publicServers = ntfyServers.filter((server) => !server.isLocal)
   const localServers = ntfyServers.filter((server) => server.isLocal)
   const publicServer = publicServers[0]
-  const showAuthSection = Boolean(ntfyServerUrl)
   const isLocalSelection = localServers.some((server) => server.id === selectedNtfyServerId)
+  const showAuthSection = Boolean(ntfyServerUrl || isLocalSelection)
   const hasLocalServers = localServers.length > 0
-  const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl : ntfyServerUrl
+  const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl ?? "" : ntfyServerUrl
   const startEditingPublicUrl = () => {
     setPublicUrlBeforeEdit(publicServerDisplayUrl ?? publicServer?.baseUrl ?? "")
     setIsEditingPublicUrl(true)
@@ -89,7 +89,7 @@ export function NtfyServerSettings({
     onNtfySettingsSave()
   }
   const localServerSubtitle = (server: NtfyServerOption) =>
-    server.id === "umbrel-ntfy" ? t("ntfy.platform.umbrel") : t("ntfy.platform.local")
+    server.platform === "umbrel" ? t("ntfy.platform.umbrel") : t("ntfy.platform.local")
   const publicServerRow = publicServer ? (
     <div className="space-y-2">
       <NtfyServerOptionRow

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -73,6 +73,7 @@ export function NtfyServerSettings({
   const publicServer = publicServers[0]
   const showAuthSection = Boolean(ntfyServerUrl)
   const isLocalSelection = localServers.some((server) => server.id === selectedNtfyServerId)
+  const hasLocalServers = localServers.length > 0
   const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl : ntfyServerUrl
   const startEditingPublicUrl = () => {
     setPublicUrlBeforeEdit(ntfyServerUrl)
@@ -109,6 +110,7 @@ export function NtfyServerSettings({
               <div className="space-y-2">
                 <NtfyServerOptionRow
                   server={publicServer}
+                  showRadio={hasLocalServers}
                   subtitle={
                     selectedNtfyServerId === publicServer.id && isEditingPublicUrl ? (
                       <Input
@@ -128,10 +130,10 @@ export function NtfyServerSettings({
                       publicServerDisplayUrl ?? publicServer.baseUrl
                     )
                   }
-                  action={
+                  subtitleAction={
                     selectedNtfyServerId === publicServer.id ? (
                       isEditingPublicUrl ? (
-                        <div className="mt-6 flex shrink-0 items-center gap-2">
+                        <div className="flex shrink-0 items-center gap-2">
                           <Button
                             type="button"
                             variant="outline"
@@ -169,7 +171,7 @@ export function NtfyServerSettings({
               </div>
             )}
 
-            {localServers.length > 0 && (
+            {hasLocalServers && (
               <div className="space-y-2">
                 <div className="space-y-3">
                   {localServers.map((server) => (
@@ -296,26 +298,35 @@ export function NtfyServerSettings({
 function NtfyServerOptionRow({
   server,
   subtitle,
-  action,
+  subtitleAction,
   children,
+  showRadio = true,
 }: {
   server: NtfyServerOption
   subtitle: ReactNode
-  action?: ReactNode
+  subtitleAction?: ReactNode
   children?: ReactNode
+  showRadio?: boolean
 }) {
   return (
     <div className="flex items-start gap-3 rounded-md border p-3">
-      <RadioGroupItem value={server.id} id={`ntfy-server-${server.id}`} className="mt-1" />
+      {showRadio && (
+        <RadioGroupItem value={server.id} id={`ntfy-server-${server.id}`} className="mt-1" />
+      )}
       <div className="min-w-0 flex-1 space-y-1">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1 space-y-1">
-            <Label htmlFor={`ntfy-server-${server.id}`} className="cursor-pointer">
+        <div className="space-y-1">
+          <div className="min-w-0">
+            <Label
+              htmlFor={showRadio ? `ntfy-server-${server.id}` : undefined}
+              className={showRadio ? "cursor-pointer" : undefined}
+            >
               {server.name}
             </Label>
-            <div className="break-all text-sm text-muted-foreground">{subtitle}</div>
           </div>
-          {action}
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0 flex-1 break-all text-sm text-muted-foreground">{subtitle}</div>
+            {subtitleAction}
+          </div>
         </div>
         {children}
       </div>

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -66,6 +66,7 @@ export function NtfyServerSettings({
   const t = useTranslations("settings")
   const tCommon = useTranslations("common")
   const [isEditingPublicUrl, setIsEditingPublicUrl] = useState(false)
+  const [publicUrlBeforeEdit, setPublicUrlBeforeEdit] = useState("")
 
   const publicServers = ntfyServers.filter((server) => !server.isLocal && !server.isCustom)
   const localServers = ntfyServers.filter((server) => server.isLocal)
@@ -73,6 +74,19 @@ export function NtfyServerSettings({
   const showAuthSection = Boolean(ntfyServerUrl)
   const isLocalSelection = localServers.some((server) => server.id === selectedNtfyServerId)
   const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl : ntfyServerUrl
+  const startEditingPublicUrl = () => {
+    setPublicUrlBeforeEdit(ntfyServerUrl)
+    setIsEditingPublicUrl(true)
+  }
+  const cancelEditingPublicUrl = () => {
+    onNtfyServerUrlChange(publicUrlBeforeEdit)
+    onClearNtfySettingsErrors()
+    setIsEditingPublicUrl(false)
+  }
+  const saveEditingPublicUrl = () => {
+    setIsEditingPublicUrl(false)
+    onNtfySettingsSave()
+  }
 
   return (
     <Card>
@@ -95,28 +109,11 @@ export function NtfyServerSettings({
               <div className="space-y-2">
                 <NtfyServerOptionRow
                   server={publicServer}
-                  subtitle={publicServerDisplayUrl ?? publicServer.baseUrl}
-                  action={
-                    selectedNtfyServerId === publicServer.id && !isEditingPublicUrl ? (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setIsEditingPublicUrl(true)}
-                        disabled={isUpdatingNtfySettings}
-                        className="shrink-0"
-                      >
-                        <Pencil className="h-4 w-4" />
-                        {tCommon("edit")}
-                      </Button>
-                    ) : null
-                  }
-                >
-                  {selectedNtfyServerId === publicServer.id && isEditingPublicUrl && (
-                    <div className="pt-2">
-                      <Label htmlFor="ntfy-server">{t("ntfy.serverLabel")}</Label>
+                  subtitle={
+                    selectedNtfyServerId === publicServer.id && isEditingPublicUrl ? (
                       <Input
                         id="ntfy-server"
+                        aria-label={t("ntfy.serverLabel")}
                         type="url"
                         placeholder={t("ntfy.serverPlaceholder")}
                         value={ntfyServerUrl}
@@ -125,11 +122,50 @@ export function NtfyServerSettings({
                           onClearNtfySettingsErrors()
                         }}
                         disabled={isUpdatingNtfySettings}
-                        className="mt-1"
+                        className="h-8"
                       />
-                    </div>
-                  )}
-                </NtfyServerOptionRow>
+                    ) : (
+                      publicServerDisplayUrl ?? publicServer.baseUrl
+                    )
+                  }
+                  action={
+                    selectedNtfyServerId === publicServer.id ? (
+                      isEditingPublicUrl ? (
+                        <div className="flex shrink-0 items-center gap-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={cancelEditingPublicUrl}
+                            disabled={isUpdatingNtfySettings}
+                          >
+                            {tCommon("cancel")}
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            onClick={saveEditingPublicUrl}
+                            disabled={isUpdatingNtfySettings}
+                          >
+                            {isUpdatingNtfySettings ? tCommon("saving") : tCommon("save")}
+                          </Button>
+                        </div>
+                      ) : (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={startEditingPublicUrl}
+                          disabled={isUpdatingNtfySettings}
+                          className="shrink-0"
+                        >
+                          <Pencil className="h-4 w-4" />
+                          {tCommon("edit")}
+                        </Button>
+                      )
+                    ) : null
+                  }
+                />
               </div>
             )}
 
@@ -264,7 +300,7 @@ function NtfyServerOptionRow({
   children,
 }: {
   server: NtfyServerOption
-  subtitle: string
+  subtitle: ReactNode
   action?: ReactNode
   children?: ReactNode
 }) {
@@ -273,11 +309,11 @@ function NtfyServerOptionRow({
       <RadioGroupItem value={server.id} id={`ntfy-server-${server.id}`} className="mt-1" />
       <div className="min-w-0 flex-1 space-y-1">
         <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1">
+          <div className="min-w-0 flex-1 space-y-1">
             <Label htmlFor={`ntfy-server-${server.id}`} className="cursor-pointer">
               {server.name}
             </Label>
-            <p className="break-all text-sm text-muted-foreground">{subtitle}</p>
+            <div className="break-all text-sm text-muted-foreground">{subtitle}</div>
           </div>
           {action}
         </div>

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -5,16 +5,21 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ErrorDisplay, SuccessDisplay } from "@/components/ui/error-display"
 import { Bell } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { api } from "@/lib/api"
 import type { UserPreferences, NtfyAuthType } from "@/hooks/useUserPreferences"
+import { isBrowserSafeNtfyUrl, type NtfyServerOption } from "@/lib/ntfy-servers"
 
 interface NtfyServerSettingsProps {
   ntfyServerUrl: string
   onNtfyServerUrlChange: (url: string) => void
+  ntfyServers: NtfyServerOption[]
+  selectedNtfyServerId: string
+  onNtfyServerChange: (serverId: string) => void
 
   // Auth section
   userPreferences: UserPreferences | null
@@ -39,6 +44,9 @@ interface NtfyServerSettingsProps {
 export function NtfyServerSettings({
   ntfyServerUrl,
   onNtfyServerUrlChange,
+  ntfyServers,
+  selectedNtfyServerId,
+  onNtfyServerChange,
   userPreferences,
   ntfyAuthType,
   onNtfyAuthTypeChange,
@@ -58,7 +66,11 @@ export function NtfyServerSettings({
   const t = useTranslations("settings")
   const tCommon = useTranslations("common")
 
-  const showAuthSection = ntfyServerUrl && ntfyServerUrl !== "https://ntfy.sh"
+  const publicServers = ntfyServers.filter((server) => !server.isLocal && !server.isCustom)
+  const localServers = ntfyServers.filter((server) => server.isLocal)
+  const publicServer = publicServers[0]
+  const showAuthSection = Boolean(ntfyServerUrl)
+  const isLocalSelection = localServers.some((server) => server.id === selectedNtfyServerId)
 
   return (
     <Card>
@@ -71,39 +83,53 @@ export function NtfyServerSettings({
       </CardHeader>
       <CardContent>
         <div className="space-y-6">
-          {/* Server URL */}
-          <div>
-            <Label htmlFor="ntfy-server">{t("ntfy.serverLabel")}</Label>
-            <Input
-              id="ntfy-server"
-              type="url"
-              placeholder={t("ntfy.serverPlaceholder")}
-              value={ntfyServerUrl}
-              onChange={(e) => {
-                onNtfyServerUrlChange(e.target.value)
-                onClearNtfySettingsErrors()
-              }}
-              disabled={isUpdatingNtfySettings}
-              className="mt-1"
-            />
-            <p className="text-sm text-muted-foreground mt-2">
-              {t("ntfy.serverNoteBefore")}
-              <a
-                href="https://ntfy.sh/docs/install/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                {t("ntfy.selfHostLink")}
-              </a>
-              {t("ntfy.serverNoteAfter")}
-            </p>
-          </div>
+          <RadioGroup
+            value={selectedNtfyServerId}
+            onValueChange={onNtfyServerChange}
+            disabled={isUpdatingNtfySettings}
+            className="space-y-4"
+          >
+            {publicServer && (
+              <div className="space-y-2">
+                <NtfyServerOptionRow server={publicServer} subtitle={t("ntfy.publicServerDescription")} />
+                {selectedNtfyServerId === publicServer.id && (
+                  <div>
+                    <Label htmlFor="ntfy-server">{t("ntfy.serverLabel")}</Label>
+                    <Input
+                      id="ntfy-server"
+                      type="url"
+                      placeholder={t("ntfy.serverPlaceholder")}
+                      value={ntfyServerUrl}
+                      onChange={(e) => {
+                        onNtfyServerUrlChange(e.target.value)
+                        onClearNtfySettingsErrors()
+                      }}
+                      disabled={isUpdatingNtfySettings}
+                      className="mt-1"
+                    />
+                  </div>
+                )}
+              </div>
+            )}
 
-          {/* Authentication - only show if custom server URL is set */}
+            {localServers.length > 0 && (
+              <div className="space-y-2">
+                <div className="space-y-3">
+                  {localServers.map((server) => (
+                    <NtfyServerOptionRow key={server.id} server={server} subtitle="Umbrel" />
+                  ))}
+                </div>
+                <p className="text-sm text-muted-foreground">{t("ntfy.localAuthNote")}</p>
+              </div>
+            )}
+          </RadioGroup>
+
           {showAuthSection && (
             <div className="border-t pt-4">
               <Label>{t("ntfy.auth.title")}</Label>
+              {isLocalSelection && (
+                <p className="text-sm text-muted-foreground mb-3">{t("ntfy.auth.localTokenHint")}</p>
+              )}
               <p className="text-sm text-muted-foreground mb-3">
                 {userPreferences?.ntfy_has_access_token
                   ? t("ntfy.auth.configured.token")
@@ -203,10 +229,24 @@ export function NtfyServerSettings({
           </Button>
 
           {/* Test Notification */}
-          <TestNotificationSection savedServerUrl={userPreferences?.ntfy_server_url || null} />
+          <TestNotificationSection savedServerUrl={ntfyServerUrl || userPreferences?.ntfy_server_url || null} />
         </div>
       </CardContent>
     </Card>
+  )
+}
+
+function NtfyServerOptionRow({ server, subtitle }: { server: NtfyServerOption; subtitle: string }) {
+  return (
+    <div className="flex items-start gap-3 rounded-md border p-3">
+      <RadioGroupItem value={server.id} id={`ntfy-server-${server.id}`} className="mt-1" />
+      <div className="min-w-0 space-y-1">
+        <Label htmlFor={`ntfy-server-${server.id}`} className="cursor-pointer">
+          {server.name}
+        </Label>
+        <p className="break-all text-sm text-muted-foreground">{subtitle}</p>
+      </div>
+    </div>
   )
 }
 
@@ -222,7 +262,9 @@ function TestNotificationSection({ savedServerUrl }: { savedServerUrl: string | 
     try {
       const response = await api.sendTestNtfyNotification(topic)
       const serverBase = savedServerUrl || "https://ntfy.sh"
-      const topicUrl = `${serverBase.replace(/\/+$/, "")}/${topic.trim()}`
+      const topicUrl = isBrowserSafeNtfyUrl(serverBase)
+        ? `${serverBase.replace(/\/+$/, "")}/${topic.trim()}`
+        : undefined
       if (response.success) {
         setResult({ success: true, message: t("ntfy.test.success"), topicUrl })
       } else if (response.error) {

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -288,7 +288,10 @@ export function NtfyServerSettings({
           </Button>
 
           {/* Test Notification */}
-          <TestNotificationSection savedServerUrl={ntfyServerUrl || userPreferences?.ntfy_server_url || null} />
+          <TestNotificationSection
+            savedServerUrl={ntfyServerUrl || userPreferences?.ntfy_server_url || null}
+            hasUnsavedSettings={hasAnyNtfyChanges}
+          />
         </div>
       </CardContent>
     </Card>
@@ -299,13 +302,11 @@ function NtfyServerOptionRow({
   server,
   subtitle,
   subtitleAction,
-  children,
   showRadio = true,
 }: {
   server: NtfyServerOption
   subtitle: ReactNode
   subtitleAction?: ReactNode
-  children?: ReactNode
   showRadio?: boolean
 }) {
   return (
@@ -328,13 +329,18 @@ function NtfyServerOptionRow({
             {subtitleAction}
           </div>
         </div>
-        {children}
       </div>
     </div>
   )
 }
 
-function TestNotificationSection({ savedServerUrl }: { savedServerUrl: string | null }) {
+function TestNotificationSection({
+  savedServerUrl,
+  hasUnsavedSettings,
+}: {
+  savedServerUrl: string | null
+  hasUnsavedSettings: boolean
+}) {
   const t = useTranslations("settings")
   const [topic, setTopic] = useState("canary-test")
   const [isSending, setIsSending] = useState(false)
@@ -380,7 +386,7 @@ function TestNotificationSection({ savedServerUrl }: { savedServerUrl: string | 
         />
         <Button
           onClick={handleSendTest}
-          disabled={!topic.trim() || isSending}
+          disabled={!topic.trim() || isSending || hasUnsavedSettings}
           variant="outline"
           className="shrink-0"
         >

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -76,7 +76,7 @@ export function NtfyServerSettings({
   const hasLocalServers = localServers.length > 0
   const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl ?? "" : ntfyServerUrl
   const startEditingPublicUrl = () => {
-    setPublicUrlBeforeEdit(publicServerDisplayUrl ?? publicServer?.baseUrl ?? "")
+    setPublicUrlBeforeEdit(publicServerDisplayUrl)
     setIsEditingPublicUrl(true)
   }
   const cancelEditingPublicUrl = () => {
@@ -86,7 +86,9 @@ export function NtfyServerSettings({
   }
   const saveEditingPublicUrl = () => {
     setIsEditingPublicUrl(false)
-    onNtfySettingsSave()
+    if (ntfyServerUrl !== publicUrlBeforeEdit) {
+      onNtfySettingsSave()
+    }
   }
   const localServerSubtitle = (server: NtfyServerOption) =>
     server.platform === "umbrel" ? t("ntfy.platform.umbrel") : t("ntfy.platform.local")
@@ -350,6 +352,7 @@ function NtfyServerOptionRow({
   )
 }
 
+// Separate row components keep non-selectable public-only settings outside RadioGroup semantics.
 function NtfyServerStaticRow({
   server,
   subtitle,

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -92,68 +92,81 @@ export function NtfyServerSettings({
     server.platform === "umbrel" ? t("ntfy.platform.umbrel") : t("ntfy.platform.local")
   const publicServerRow = publicServer ? (
     <div className="space-y-2">
-      <NtfyServerOptionRow
-        server={publicServer}
-        showRadio={hasLocalServers}
-        subtitle={
-          selectedNtfyServerId === publicServer.id && isEditingPublicUrl ? (
-            <Input
-              id="ntfy-server"
-              aria-label={t("ntfy.serverLabel")}
-              type="url"
-              placeholder={t("ntfy.serverPlaceholder")}
-              value={ntfyServerUrl}
-              onChange={(e) => {
-                onNtfyServerUrlChange(e.target.value)
-                onClearNtfySettingsErrors()
-              }}
-              disabled={isUpdatingNtfySettings}
-              className="h-8"
-            />
-          ) : (
-            publicServerDisplayUrl ?? publicServer.baseUrl
-          )
-        }
-        subtitleAction={
-          selectedNtfyServerId === publicServer.id ? (
-            isEditingPublicUrl ? (
-              <div className="flex shrink-0 items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={cancelEditingPublicUrl}
-                  disabled={isUpdatingNtfySettings}
-                >
-                  {tCommon("cancel")}
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={saveEditingPublicUrl}
-                  disabled={isUpdatingNtfySettings}
-                >
-                  {isUpdatingNtfySettings ? tCommon("saving") : tCommon("save")}
-                </Button>
-              </div>
-            ) : (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={startEditingPublicUrl}
-                disabled={isUpdatingNtfySettings}
-                className="shrink-0"
-              >
-                <Pencil className="h-4 w-4" />
-                {tCommon("edit")}
-              </Button>
-            )
-          ) : null
-        }
-      />
+      {hasLocalServers ? (
+        <NtfyServerOptionRow
+          server={publicServer}
+          subtitle={renderPublicServerSubtitle()}
+          subtitleAction={renderPublicServerAction()}
+        />
+      ) : (
+        <NtfyServerStaticRow
+          server={publicServer}
+          subtitle={renderPublicServerSubtitle()}
+          subtitleAction={renderPublicServerAction()}
+        />
+      )}
     </div>
   ) : null
+
+  function renderPublicServerSubtitle() {
+    return selectedNtfyServerId === publicServer?.id && isEditingPublicUrl ? (
+      <Input
+        id="ntfy-server"
+        aria-label={t("ntfy.serverLabel")}
+        type="url"
+        placeholder={t("ntfy.serverPlaceholder")}
+        value={ntfyServerUrl}
+        onChange={(e) => {
+          onNtfyServerUrlChange(e.target.value)
+          onClearNtfySettingsErrors()
+        }}
+        disabled={isUpdatingNtfySettings}
+        className="h-8"
+      />
+    ) : (
+      publicServerDisplayUrl || publicServer?.baseUrl || ""
+    )
+  }
+
+  function renderPublicServerAction() {
+    if (selectedNtfyServerId !== publicServer?.id) {
+      return null
+    }
+
+    return isEditingPublicUrl ? (
+      <div className="flex shrink-0 items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={cancelEditingPublicUrl}
+          disabled={isUpdatingNtfySettings}
+        >
+          {tCommon("cancel")}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={saveEditingPublicUrl}
+          disabled={isUpdatingNtfySettings}
+        >
+          {isUpdatingNtfySettings ? tCommon("saving") : tCommon("save")}
+        </Button>
+      </div>
+    ) : (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={startEditingPublicUrl}
+        disabled={isUpdatingNtfySettings}
+        className="shrink-0"
+      >
+        <Pencil className="h-4 w-4" />
+        {tCommon("edit")}
+      </Button>
+    )
+  }
 
   return (
     <Card>
@@ -309,27 +322,49 @@ function NtfyServerOptionRow({
   server,
   subtitle,
   subtitleAction,
-  showRadio = true,
 }: {
   server: NtfyServerOption
   subtitle: ReactNode
   subtitleAction?: ReactNode
-  showRadio?: boolean
 }) {
   return (
     <div className="flex items-start gap-3 rounded-md border p-3">
-      {showRadio && (
-        <RadioGroupItem value={server.id} id={`ntfy-server-${server.id}`} className="mt-1" />
-      )}
+      <RadioGroupItem value={server.id} id={`ntfy-server-${server.id}`} className="mt-1" />
       <div className="min-w-0 flex-1 space-y-1">
         <div className="space-y-1">
           <div className="min-w-0">
             <Label
-              htmlFor={showRadio ? `ntfy-server-${server.id}` : undefined}
-              className={showRadio ? "cursor-pointer" : undefined}
+              htmlFor={`ntfy-server-${server.id}`}
+              className="cursor-pointer"
             >
               {server.name}
             </Label>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0 flex-1 break-all text-sm text-muted-foreground">{subtitle}</div>
+            {subtitleAction}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function NtfyServerStaticRow({
+  server,
+  subtitle,
+  subtitleAction,
+}: {
+  server: NtfyServerOption
+  subtitle: ReactNode
+  subtitleAction?: ReactNode
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-md border p-3">
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="space-y-1">
+          <div className="min-w-0">
+            <Label>{server.name}</Label>
           </div>
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0 flex-1 break-all text-sm text-muted-foreground">{subtitle}</div>
@@ -359,6 +394,7 @@ function TestNotificationSection({
     try {
       const response = await api.sendTestNtfyNotification(topic)
       const serverBase = savedServerUrl || "https://ntfy.sh"
+      // Local integrations can resolve server-side while remaining unreachable from the browser.
       const topicUrl = isBrowserSafeNtfyUrl(serverBase)
         ? `${serverBase.replace(/\/+$/, "")}/${topic.trim()}`
         : undefined

--- a/frontend/src/components/wallet-contacts-list.tsx
+++ b/frontend/src/components/wallet-contacts-list.tsx
@@ -7,7 +7,7 @@ import { Contact } from "../types"
 import { ContactModal } from "./contact-modal"
 import { useAuth } from "@/contexts/auth-context"
 import { useTranslations } from "next-intl"
-import { useNtfyServerUrl } from "@/hooks/useNtfyServerUrl"
+import { useNtfyServerTarget } from "@/hooks/useNtfyServerUrl"
 
 interface WalletContactsListProps {
   walletChecksum: string
@@ -19,7 +19,7 @@ interface WalletContactsListProps {
 export function WalletContactsList({ walletChecksum, contacts, onContactsUpdated, isWalletActive = true }: WalletContactsListProps) {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [editingContact, setEditingContact] = useState<Contact | null>(null)
-  const ntfyServerUrl = useNtfyServerUrl()
+  const ntfyServerTarget = useNtfyServerTarget()
   const { user, isCloudMode, billingStatus } = useAuth()
   const t = useTranslations('contacts')
 
@@ -125,15 +125,19 @@ export function WalletContactsList({ walletChecksum, contacts, onContactsUpdated
                           >
                             {method.display_target || method.notification_target}
                           </a>
-                        ) : method.provider_type === 'ntfy' ? (
+                        ) : method.provider_type === 'ntfy' && ntfyServerTarget.isBrowserSafe ? (
                           <a
-                            href={`${ntfyServerUrl}/${method.notification_target}`}
+                            href={`${ntfyServerTarget.url}/${method.notification_target}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="truncate text-blue-600 hover:text-blue-800 underline"
                           >
                             {method.display_target || method.notification_target}
                           </a>
+                        ) : method.provider_type === 'ntfy' ? (
+                          <span className="truncate">
+                            {method.display_target || method.notification_target}
+                          </span>
                         ) : (
                           <span className="truncate">
                             {method.display_target || method.notification_target}

--- a/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
+++ b/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
@@ -25,6 +25,10 @@ describe('normalizeNtfyUrl', () => {
     expect(normalizeNtfyUrl('http://ntfy.local:8080')).toBe('http://ntfy.local:8080')
   })
 
+  it("accepts Docker-internal http hostnames", () => {
+    expect(normalizeNtfyUrl("http://ntfy_app_1")).toBe("http://ntfy_app_1")
+  })
+
   it('strips trailing slashes', () => {
     expect(normalizeNtfyUrl('https://ntfy.example.com/')).toBe('https://ntfy.example.com')
     expect(normalizeNtfyUrl('https://ntfy.example.com///')).toBe('https://ntfy.example.com')

--- a/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
+++ b/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
@@ -9,7 +9,12 @@ jest.mock("@/lib/api", () => ({
   },
 }))
 
+jest.mock("@/contexts/auth-context", () => ({
+  useAuth: jest.fn(),
+}))
+
 const mockApi = jest.requireMock("@/lib/api").api
+const mockUseAuth = jest.requireMock("@/contexts/auth-context").useAuth
 
 describe('normalizeNtfyUrl', () => {
   it('returns null for empty string', () => {
@@ -62,6 +67,10 @@ describe('normalizeNtfyUrl', () => {
 describe("useNtfyServerTarget", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    })
     mockApi.getUserPreferences.mockResolvedValue({
       ntfy_server_url: null,
     })
@@ -109,5 +118,44 @@ describe("useNtfyServerTarget", () => {
     await waitFor(() => {
       expect(result.current).toEqual({ url: "http://ntfy_app_1", isBrowserSafe: false })
     })
+  })
+
+  it("does not fetch preferences before authentication is available", async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    })
+    mockApi.getConfig.mockResolvedValue({
+      tx_explorers: [],
+      default_tx_explorer_id: "mempool-space",
+      ntfy_servers: [],
+      default_ntfy_server_id: "ntfy-sh",
+    })
+
+    renderHook(() => useNtfyServerTarget())
+
+    await waitFor(() => {
+      expect(mockApi.getConfig).toHaveBeenCalled()
+    })
+    expect(mockApi.getUserPreferences).not.toHaveBeenCalled()
+  })
+
+  it("shares the in-flight ntfy target request across simultaneous hook mounts", async () => {
+    mockApi.getConfig.mockResolvedValue({
+      tx_explorers: [],
+      default_tx_explorer_id: "mempool-space",
+      ntfy_servers: [],
+      default_ntfy_server_id: "ntfy-sh",
+    })
+
+    const first = renderHook(() => useNtfyServerTarget())
+    const second = renderHook(() => useNtfyServerTarget())
+
+    await waitFor(() => {
+      expect(first.result.current).toEqual({ url: "https://ntfy.sh", isBrowserSafe: true })
+      expect(second.result.current).toEqual({ url: "https://ntfy.sh", isBrowserSafe: true })
+    })
+    expect(mockApi.getConfig).toHaveBeenCalledTimes(1)
+    expect(mockApi.getUserPreferences).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
+++ b/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
@@ -1,4 +1,15 @@
-import { normalizeNtfyUrl } from '../useNtfyServerUrl'
+import { renderHook, waitFor } from "@testing-library/react"
+import { normalizeNtfyUrl, useNtfyServerTarget } from "../useNtfyServerUrl"
+import { UMBREL_NTFY_SERVER_ID } from "@/lib/ntfy-servers"
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    getUserPreferences: jest.fn(),
+    getConfig: jest.fn(),
+  },
+}))
+
+const mockApi = jest.requireMock("@/lib/api").api
 
 describe('normalizeNtfyUrl', () => {
   it('returns null for empty string', () => {
@@ -41,5 +52,58 @@ describe('normalizeNtfyUrl', () => {
 
   it('preserves port numbers', () => {
     expect(normalizeNtfyUrl('https://ntfy.local:8443')).toBe('https://ntfy.local:8443')
+  })
+})
+
+describe("useNtfyServerTarget", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApi.getUserPreferences.mockResolvedValue({
+      ntfy_server_url: null,
+    })
+  })
+
+  it("marks browser-reachable local ntfy servers as safe", async () => {
+    mockApi.getConfig.mockResolvedValue({
+      tx_explorers: [],
+      default_tx_explorer_id: "mempool-space",
+      ntfy_servers: [
+        {
+          id: UMBREL_NTFY_SERVER_ID,
+          name: "ntfy",
+          base_url: "http://umbrel",
+          platform: "umbrel",
+        },
+      ],
+      default_ntfy_server_id: UMBREL_NTFY_SERVER_ID,
+    })
+
+    const { result } = renderHook(() => useNtfyServerTarget())
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ url: "http://umbrel", isBrowserSafe: true })
+    })
+  })
+
+  it("marks Docker-internal local ntfy servers as unsafe for browser links", async () => {
+    mockApi.getConfig.mockResolvedValue({
+      tx_explorers: [],
+      default_tx_explorer_id: "mempool-space",
+      ntfy_servers: [
+        {
+          id: UMBREL_NTFY_SERVER_ID,
+          name: "ntfy",
+          base_url: "http://ntfy_app_1",
+          platform: "umbrel",
+        },
+      ],
+      default_ntfy_server_id: UMBREL_NTFY_SERVER_ID,
+    })
+
+    const { result } = renderHook(() => useNtfyServerTarget())
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ url: "http://ntfy_app_1", isBrowserSafe: false })
+    })
   })
 })

--- a/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
+++ b/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
@@ -1,5 +1,9 @@
 import { renderHook, waitFor } from "@testing-library/react"
-import { normalizeNtfyUrl, useNtfyServerTarget } from "../useNtfyServerUrl"
+import {
+  normalizeNtfyUrl,
+  resetNtfyServerTargetCacheForTests,
+  useNtfyServerTarget,
+} from "../useNtfyServerUrl"
 import { UMBREL_NTFY_SERVER_ID } from "@/lib/ntfy-servers"
 
 jest.mock("@/lib/api", () => ({
@@ -67,6 +71,7 @@ describe('normalizeNtfyUrl', () => {
 describe("useNtfyServerTarget", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    resetNtfyServerTargetCacheForTests()
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,

--- a/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
@@ -151,4 +151,30 @@ describe("useUserPreferences", () => {
     })
     expect(screen.getByTestId("ntfy-settings-error")).toHaveTextContent("")
   })
+
+  it("saves an empty ntfy URL when the detected local server is selected", async () => {
+    const user = userEvent.setup()
+    mockApi.updateUserPreferences.mockResolvedValue({
+      preferred_fiat_currency: "USD",
+      preferred_tx_explorer_id: null,
+      ntfy_server_url: "",
+      ntfy_has_access_token: false,
+      ntfy_has_credentials: false,
+      ntfy_username: null,
+    })
+
+    render(<PreferencesProbe />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-ntfy-server")).toHaveTextContent(UMBREL_NTFY_SERVER_ID)
+    })
+
+    await user.click(screen.getByRole("button", { name: "Save ntfy" }))
+
+    await waitFor(() => {
+      expect(mockApi.updateUserPreferences).toHaveBeenCalledWith({
+        ntfy_server_url: "",
+      })
+    })
+  })
 })

--- a/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
@@ -68,4 +68,22 @@ describe("useUserPreferences", () => {
     expect(screen.getByTestId("selected-ntfy-server")).toHaveTextContent("ntfy-sh")
     expect(screen.getByTestId("has-ntfy-changes")).toHaveTextContent("true")
   })
+
+  it("resolves a saved local ntfy URL to the detected local server", async () => {
+    mockApi.getUserPreferences.mockResolvedValue({
+      preferred_fiat_currency: "USD",
+      preferred_tx_explorer_id: null,
+      ntfy_server_url: "http://ntfy_app_1",
+      ntfy_has_access_token: false,
+      ntfy_has_credentials: false,
+      ntfy_username: null,
+    })
+
+    render(<PreferencesProbe />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-ntfy-server")).toHaveTextContent("umbrel-ntfy")
+      expect(screen.getByTestId("has-ntfy-changes")).toHaveTextContent("false")
+    })
+  })
 })

--- a/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
@@ -177,4 +177,16 @@ describe("useUserPreferences", () => {
       })
     })
   })
+
+  it("does not save ntfy settings before config options are loaded", async () => {
+    const user = userEvent.setup()
+    mockApi.getConfig.mockReturnValue(new Promise(() => {}))
+
+    render(<PreferencesProbe />)
+
+    await user.click(screen.getByRole("button", { name: "Save ntfy" }))
+
+    expect(mockApi.updateUserPreferences).not.toHaveBeenCalled()
+    expect(screen.getByTestId("ntfy-settings-error")).toHaveTextContent("Failed to save")
+  })
 })

--- a/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useUserPreferences } from "../useUserPreferences"
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+}))
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    getUserPreferences: jest.fn(),
+    getConfig: jest.fn(),
+    updateUserPreferences: jest.fn(),
+  },
+}))
+
+const mockApi = jest.requireMock("@/lib/api").api
+
+function PreferencesProbe() {
+  const preferences = useUserPreferences({ isAuthenticated: true })
+
+  return (
+    <div>
+      <div data-testid="selected-ntfy-server">{preferences.selectedNtfyServerId}</div>
+      <div data-testid="has-ntfy-changes">{String(preferences.hasAnyNtfyChanges)}</div>
+      <button type="button" onClick={() => preferences.handleNtfyServerChange("ntfy-sh")}>
+        Select public
+      </button>
+      <button type="button" onClick={() => preferences.handleNtfyServerChange("umbrel-ntfy")}>
+        Select local
+      </button>
+    </div>
+  )
+}
+
+describe("useUserPreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApi.getUserPreferences.mockResolvedValue({
+      preferred_fiat_currency: "USD",
+      preferred_tx_explorer_id: null,
+      ntfy_server_url: null,
+      ntfy_has_access_token: false,
+      ntfy_has_credentials: false,
+      ntfy_username: null,
+    })
+    mockApi.getConfig.mockResolvedValue({
+      tx_explorers: [],
+      default_tx_explorer_id: "mempool-space",
+      ntfy_servers: [
+        { id: "umbrel-ntfy", name: "ntfy", base_url: "http://ntfy_app_1", platform: "umbrel" },
+      ],
+      default_ntfy_server_id: "umbrel-ntfy",
+    })
+  })
+
+  it("marks ntfy settings dirty when only the selected server changes", async () => {
+    const user = userEvent.setup()
+    render(<PreferencesProbe />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-ntfy-server")).toHaveTextContent("umbrel-ntfy")
+      expect(screen.getByTestId("has-ntfy-changes")).toHaveTextContent("false")
+    })
+
+    await user.click(screen.getByRole("button", { name: "Select public" }))
+
+    expect(screen.getByTestId("selected-ntfy-server")).toHaveTextContent("ntfy-sh")
+    expect(screen.getByTestId("has-ntfy-changes")).toHaveTextContent("true")
+  })
+})

--- a/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useUserPreferences } from "../useUserPreferences"
+import { PUBLIC_NTFY_SERVER_ID, UMBREL_NTFY_SERVER_ID } from "@/lib/ntfy-servers"
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: jest.fn() }),
@@ -16,19 +17,34 @@ jest.mock("@/lib/api", () => ({
 
 const mockApi = jest.requireMock("@/lib/api").api
 
-function PreferencesProbe() {
-  const preferences = useUserPreferences({ isAuthenticated: true })
+function PreferencesProbe({ isAuthenticated = true }: { isAuthenticated?: boolean }) {
+  const preferences = useUserPreferences({ isAuthenticated })
 
   return (
     <div>
       <div data-testid="selected-ntfy-server">{preferences.selectedNtfyServerId}</div>
       <div data-testid="has-ntfy-changes">{String(preferences.hasAnyNtfyChanges)}</div>
-      <button type="button" onClick={() => preferences.handleNtfyServerChange("ntfy-sh")}>
+      <input
+        aria-label="ntfy server url"
+        value={preferences.ntfyServerUrl}
+        onChange={(event) => preferences.setNtfyServerUrl(event.target.value)}
+      />
+      <button
+        type="button"
+        onClick={() => preferences.handleNtfyServerChange(PUBLIC_NTFY_SERVER_ID)}
+      >
         Select public
       </button>
-      <button type="button" onClick={() => preferences.handleNtfyServerChange("umbrel-ntfy")}>
+      <button
+        type="button"
+        onClick={() => preferences.handleNtfyServerChange(UMBREL_NTFY_SERVER_ID)}
+      >
         Select local
       </button>
+      <button type="button" onClick={() => preferences.handleNtfySettingsSave()}>
+        Save ntfy
+      </button>
+      <div data-testid="ntfy-settings-error">{preferences.ntfySettingsError ?? ""}</div>
     </div>
   )
 }
@@ -48,9 +64,14 @@ describe("useUserPreferences", () => {
       tx_explorers: [],
       default_tx_explorer_id: "mempool-space",
       ntfy_servers: [
-        { id: "umbrel-ntfy", name: "ntfy", base_url: "http://ntfy_app_1", platform: "umbrel" },
+        {
+          id: UMBREL_NTFY_SERVER_ID,
+          name: "ntfy",
+          base_url: "http://ntfy_app_1",
+          platform: "umbrel",
+        },
       ],
-      default_ntfy_server_id: "umbrel-ntfy",
+      default_ntfy_server_id: UMBREL_NTFY_SERVER_ID,
     })
   })
 
@@ -85,5 +106,49 @@ describe("useUserPreferences", () => {
       expect(screen.getByTestId("selected-ntfy-server")).toHaveTextContent("umbrel-ntfy")
       expect(screen.getByTestId("has-ntfy-changes")).toHaveTextContent("false")
     })
+  })
+
+  it("selects a detected local ntfy server in unauthenticated self-hosted mode", async () => {
+    render(<PreferencesProbe isAuthenticated={false} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-ntfy-server")).toHaveTextContent(UMBREL_NTFY_SERVER_ID)
+      expect(screen.getByTestId("has-ntfy-changes")).toHaveTextContent("false")
+    })
+
+    expect(mockApi.getUserPreferences).not.toHaveBeenCalled()
+  })
+
+  it("trims custom ntfy URLs before validation and storage", async () => {
+    const user = userEvent.setup()
+    mockApi.updateUserPreferences.mockResolvedValue({
+      preferred_fiat_currency: "USD",
+      preferred_tx_explorer_id: null,
+      ntfy_server_url: "https://ntfy.example.com",
+      ntfy_has_access_token: false,
+      ntfy_has_credentials: false,
+      ntfy_username: null,
+    })
+
+    render(<PreferencesProbe />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-ntfy-server")).toHaveTextContent(UMBREL_NTFY_SERVER_ID)
+    })
+
+    await user.click(screen.getByRole("button", { name: "Select public" }))
+    await user.clear(screen.getByRole("textbox", { name: "ntfy server url" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "ntfy server url" }),
+      "  https://ntfy.example.com/  "
+    )
+    await user.click(screen.getByRole("button", { name: "Save ntfy" }))
+
+    await waitFor(() => {
+      expect(mockApi.updateUserPreferences).toHaveBeenCalledWith({
+        ntfy_server_url: "https://ntfy.example.com",
+      })
+    })
+    expect(screen.getByTestId("ntfy-settings-error")).toHaveTextContent("")
   })
 })

--- a/frontend/src/hooks/useNtfyServerUrl.ts
+++ b/frontend/src/hooks/useNtfyServerUrl.ts
@@ -12,6 +12,11 @@ const DEFAULT_NTFY_URL = PUBLIC_NTFY_SERVER_URL
 let inFlightNtfyTargetRequest: Promise<{ url: string; isBrowserSafe: boolean }> | null = null
 let inFlightNtfyTargetRequestAuthState: boolean | null = null
 
+export function resetNtfyServerTargetCacheForTests() {
+  inFlightNtfyTargetRequest = null
+  inFlightNtfyTargetRequestAuthState = null
+}
+
 /**
  * Validates and normalizes an ntfy server URL.
  * - Rejects non-http/https schemes (e.g. javascript:)

--- a/frontend/src/hooks/useNtfyServerUrl.ts
+++ b/frontend/src/hooks/useNtfyServerUrl.ts
@@ -46,6 +46,7 @@ export function normalizeNtfyUrl(url: string): string | null {
  */
 export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
   const [ntfyServerUrl, setNtfyServerUrl] = useState(DEFAULT_NTFY_URL)
+  const [isBrowserSafe, setIsBrowserSafe] = useState(true)
 
   useEffect(() => {
     let cancelled = false
@@ -61,6 +62,7 @@ export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
         const normalized = normalizeNtfyUrl(selectedServer.baseUrl)
         if (normalized) {
           setNtfyServerUrl(normalized)
+          setIsBrowserSafe(!selectedServer.isLocal && isBrowserSafeNtfyUrl(normalized))
         }
       })
       .catch(() => {
@@ -72,7 +74,7 @@ export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
 
   return {
     url: ntfyServerUrl,
-    isBrowserSafe: isBrowserSafeNtfyUrl(ntfyServerUrl),
+    isBrowserSafe,
   }
 }
 

--- a/frontend/src/hooks/useNtfyServerUrl.ts
+++ b/frontend/src/hooks/useNtfyServerUrl.ts
@@ -92,6 +92,7 @@ function getNtfyServerTargetRequest(
 ): Promise<{ url: string; isBrowserSafe: boolean }> {
   if (!inFlightNtfyTargetRequest || inFlightNtfyTargetRequestAuthState !== isAuthenticated) {
     inFlightNtfyTargetRequestAuthState = isAuthenticated
+    // Deduplicate concurrent mounts only; sequential mounts should refetch current preferences.
     inFlightNtfyTargetRequest = resolveNtfyServerTarget(isAuthenticated).finally(() => {
       inFlightNtfyTargetRequest = null
       inFlightNtfyTargetRequestAuthState = null

--- a/frontend/src/hooks/useNtfyServerUrl.ts
+++ b/frontend/src/hooks/useNtfyServerUrl.ts
@@ -1,7 +1,13 @@
 import { useState, useEffect } from "react"
 import { api } from "@/lib/api"
+import {
+  PUBLIC_NTFY_SERVER_URL,
+  buildNtfyServerOptions,
+  isBrowserSafeNtfyUrl,
+  resolveSelectedNtfyServer,
+} from "@/lib/ntfy-servers"
 
-const DEFAULT_NTFY_URL = "https://ntfy.sh"
+const DEFAULT_NTFY_URL = PUBLIC_NTFY_SERVER_URL
 
 /**
  * Validates and normalizes an ntfy server URL.
@@ -38,20 +44,23 @@ export function normalizeNtfyUrl(url: string): string | null {
  * Returns a validated, normalized URL that is safe to use in href attributes.
  * Falls back to https://ntfy.sh if no custom server is configured or on error.
  */
-export function useNtfyServerUrl(): string {
+export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
   const [ntfyServerUrl, setNtfyServerUrl] = useState(DEFAULT_NTFY_URL)
 
   useEffect(() => {
     let cancelled = false
 
-    api.getUserPreferences()
-      .then((prefs) => {
+    Promise.all([api.getUserPreferences(), api.getConfig()])
+      .then(([prefs, config]) => {
         if (cancelled) return
-        if (prefs.ntfy_server_url) {
-          const normalized = normalizeNtfyUrl(prefs.ntfy_server_url)
-          if (normalized) {
-            setNtfyServerUrl(normalized)
-          }
+        const selectedServer = resolveSelectedNtfyServer(
+          buildNtfyServerOptions(config),
+          prefs.ntfy_server_url,
+          config.default_ntfy_server_id
+        )
+        const normalized = normalizeNtfyUrl(selectedServer.baseUrl)
+        if (normalized) {
+          setNtfyServerUrl(normalized)
         }
       })
       .catch(() => {
@@ -61,5 +70,12 @@ export function useNtfyServerUrl(): string {
     return () => { cancelled = true }
   }, [])
 
-  return ntfyServerUrl
+  return {
+    url: ntfyServerUrl,
+    isBrowserSafe: isBrowserSafeNtfyUrl(ntfyServerUrl),
+  }
+}
+
+export function useNtfyServerUrl(): string {
+  return useNtfyServerTarget().url
 }

--- a/frontend/src/hooks/useNtfyServerUrl.ts
+++ b/frontend/src/hooks/useNtfyServerUrl.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react"
 import { api } from "@/lib/api"
+import { useAuth } from "@/contexts/auth-context"
 import {
   PUBLIC_NTFY_SERVER_URL,
   buildNtfyServerOptions,
@@ -8,6 +9,8 @@ import {
 } from "@/lib/ntfy-servers"
 
 const DEFAULT_NTFY_URL = PUBLIC_NTFY_SERVER_URL
+let inFlightNtfyTargetRequest: Promise<{ url: string; isBrowserSafe: boolean }> | null = null
+let inFlightNtfyTargetRequestAuthState: boolean | null = null
 
 /**
  * Validates and normalizes an ntfy server URL.
@@ -45,32 +48,29 @@ export function normalizeNtfyUrl(url: string): string | null {
  * Falls back to https://ntfy.sh if no custom server is configured or on error.
  */
 export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
+  const { isAuthenticated, isLoading } = useAuth()
   const [ntfyServerUrl, setNtfyServerUrl] = useState(DEFAULT_NTFY_URL)
   const [isBrowserSafe, setIsBrowserSafe] = useState(true)
 
   useEffect(() => {
+    if (isLoading) return
+
     let cancelled = false
 
-    Promise.all([api.getUserPreferences(), api.getConfig()])
-      .then(([prefs, config]) => {
+    getNtfyServerTargetRequest(isAuthenticated)
+      .then((target) => {
         if (cancelled) return
-        const selectedServer = resolveSelectedNtfyServer(
-          buildNtfyServerOptions(config),
-          prefs.ntfy_server_url,
-          config.default_ntfy_server_id
-        )
-        const normalized = normalizeNtfyUrl(selectedServer.baseUrl)
-        if (normalized) {
-          setNtfyServerUrl(normalized)
-          setIsBrowserSafe(isBrowserSafeNtfyUrl(normalized))
-        }
+        setNtfyServerUrl(target.url)
+        setIsBrowserSafe(target.isBrowserSafe)
       })
       .catch(() => {
         // Fall back to default ntfy.sh
       })
 
-    return () => { cancelled = true }
-  }, [])
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated, isLoading])
 
   return {
     url: ntfyServerUrl,
@@ -80,4 +80,43 @@ export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
 
 export function useNtfyServerUrl(): string {
   return useNtfyServerTarget().url
+}
+
+function getNtfyServerTargetRequest(
+  isAuthenticated: boolean
+): Promise<{ url: string; isBrowserSafe: boolean }> {
+  if (!inFlightNtfyTargetRequest || inFlightNtfyTargetRequestAuthState !== isAuthenticated) {
+    inFlightNtfyTargetRequestAuthState = isAuthenticated
+    inFlightNtfyTargetRequest = resolveNtfyServerTarget(isAuthenticated).finally(() => {
+      inFlightNtfyTargetRequest = null
+      inFlightNtfyTargetRequestAuthState = null
+    })
+  }
+
+  return inFlightNtfyTargetRequest
+}
+
+async function resolveNtfyServerTarget(
+  isAuthenticated: boolean
+): Promise<{ url: string; isBrowserSafe: boolean }> {
+  const [config, prefs] = await Promise.all([
+    api.getConfig(),
+    isAuthenticated ? api.getUserPreferences().catch(() => null) : Promise.resolve(null),
+  ])
+
+  const selectedServer = resolveSelectedNtfyServer(
+    buildNtfyServerOptions(config),
+    prefs?.ntfy_server_url,
+    config.default_ntfy_server_id
+  )
+  const normalized = normalizeNtfyUrl(selectedServer.baseUrl)
+
+  if (!normalized) {
+    return { url: DEFAULT_NTFY_URL, isBrowserSafe: true }
+  }
+
+  return {
+    url: normalized,
+    isBrowserSafe: isBrowserSafeNtfyUrl(normalized),
+  }
 }

--- a/frontend/src/hooks/useNtfyServerUrl.ts
+++ b/frontend/src/hooks/useNtfyServerUrl.ts
@@ -62,7 +62,7 @@ export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
         const normalized = normalizeNtfyUrl(selectedServer.baseUrl)
         if (normalized) {
           setNtfyServerUrl(normalized)
-          setIsBrowserSafe(!selectedServer.isLocal && isBrowserSafeNtfyUrl(normalized))
+          setIsBrowserSafe(isBrowserSafeNtfyUrl(normalized))
         }
       })
       .catch(() => {

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { api } from "@/lib/api"
 import { getStoredLocale, setStoredLocale } from "@/lib/locale"
@@ -48,6 +48,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   const [availableNtfyServers, setAvailableNtfyServers] = useState<NtfyServerOption[]>([])
   const [defaultNtfyServerId, setDefaultNtfyServerId] = useState<string>("ntfy-sh")
   const [selectedNtfyServerId, setSelectedNtfyServerId] = useState<string>("ntfy-sh")
+  const hasInitializedNtfySelection = useRef(false)
 
   // ntfy authentication state
   const [ntfyAuthType, setNtfyAuthType] = useState<NtfyAuthType>("none")
@@ -145,6 +146,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
 
   useEffect(() => {
     if (availableNtfyServers.length === 0) return
+    if (isAuthenticated && userPreferences === null) return
 
     const selectedServer = resolveSelectedNtfyServer(
       availableNtfyServers,
@@ -156,14 +158,16 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     if (userPreferences?.ntfy_server_url) {
       setNtfyServerUrl(selectedServer.baseUrl)
       setSavedNtfyUrl(selectedServer.baseUrl)
+      hasInitializedNtfySelection.current = true
       return
     }
 
-    if (!ntfyServerUrl && !savedNtfyUrl) {
+    if (!hasInitializedNtfySelection.current) {
       setNtfyServerUrl(selectedServer.baseUrl)
       setSavedNtfyUrl(selectedServer.baseUrl)
+      hasInitializedNtfySelection.current = true
     }
-  }, [availableNtfyServers, userPreferences?.ntfy_server_url, defaultNtfyServerId, ntfyServerUrl, savedNtfyUrl])
+  }, [availableNtfyServers, userPreferences, userPreferences?.ntfy_server_url, defaultNtfyServerId, isAuthenticated])
 
   // Initialize locale from cookie
   useEffect(() => {

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react"
 import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
 import { api } from "@/lib/api"
 import { getStoredLocale, setStoredLocale } from "@/lib/locale"
 import type { Locale } from "@/i18n/config"
@@ -29,6 +30,7 @@ interface UseUserPreferencesOptions {
 
 export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOptions) {
   const router = useRouter()
+  const t = useTranslations("settings")
 
   // Regional settings state
   const [selectedCurrency, setSelectedCurrency] = useState<string>("USD")
@@ -238,7 +240,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       const ntfyUrlToStore = selectedNtfyServer?.isLocal ? "" : ntfyServerUrl
 
       if (!selectedNtfyServer?.isLocal && !ntfyServerUrl.trim()) {
-        setNtfySettingsError("ntfy server URL is required")
+        setNtfySettingsError(t("ntfy.validation.urlRequired"))
         return
       }
 
@@ -247,7 +249,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
         !ntfyServerUrl.startsWith("http://") &&
         !ntfyServerUrl.startsWith("https://")
       ) {
-        setNtfySettingsError("ntfy server URL must start with http:// or https://")
+        setNtfySettingsError(t("ntfy.validation.urlProtocol"))
         return
       }
 
@@ -270,13 +272,13 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
           }
         } else if (ntfyAuthType === "token") {
           if (!ntfyAccessToken.trim()) {
-            setNtfySettingsError("Access token is required")
+            setNtfySettingsError(t("ntfy.auth.tokenRequired"))
             return
           }
           updateData = { ...updateData, ntfy_access_token: ntfyAccessToken.trim() }
         } else if (ntfyAuthType === "basic") {
           if (!ntfyUsername.trim() || !ntfyPassword.trim()) {
-            setNtfySettingsError("Both username and password are required")
+            setNtfySettingsError(t("ntfy.auth.credentialsRequired"))
             return
           }
           updateData = {
@@ -307,7 +309,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       setNtfySettingsSuccess(true)
     } catch (error) {
       console.error("Failed to update ntfy settings:", error)
-      setNtfySettingsError(error instanceof Error ? error.message : "Failed to save")
+      setNtfySettingsError(error instanceof Error ? error.message : t("ntfy.validation.saveFailed"))
       // Revert all fields to saved state
       setNtfyServerUrl(savedNtfyUrl)
       setNtfyAuthType(savedNtfyAuthType)
@@ -317,7 +319,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     } finally {
       setIsUpdatingNtfySettings(false)
     }
-  }, [ntfyServerUrl, savedNtfyUrl, ntfyAuthType, savedNtfyAuthType, ntfyAccessToken, ntfyUsername, savedNtfyUsername, ntfyPassword, availableNtfyServers, selectedNtfyServerId])
+  }, [ntfyServerUrl, savedNtfyUrl, ntfyAuthType, savedNtfyAuthType, ntfyAccessToken, ntfyUsername, savedNtfyUsername, ntfyPassword, availableNtfyServers, selectedNtfyServerId, t])
 
   const clearNtfySettingsErrors = useCallback(() => {
     setNtfySettingsError(null)

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -225,6 +225,8 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     try {
       const selectedNtfyServer = availableNtfyServers.find((server) => server.id === selectedNtfyServerId)
       const normalizedNtfyServerUrl = ntfyServerUrl.trim().replace(/\/+$/, "")
+      // Local integrations are detected from config on each load. Persist an empty preference so we
+      // do not store Docker-internal URLs, while still letting the resolver reselect the local server.
       const ntfyUrlToStore = selectedNtfyServer?.isLocal ? "" : normalizedNtfyServerUrl
 
       if (!selectedNtfyServer?.isLocal && !normalizedNtfyServerUrl) {

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -5,6 +5,12 @@ import { getStoredLocale, setStoredLocale } from "@/lib/locale"
 import type { Locale } from "@/i18n/config"
 import { invalidateTxExplorerCache } from "@/hooks/useTxExplorer"
 import { buildTxExplorerOptions, resolveSelectedTxExplorer, type TxExplorerOption } from "@/lib/tx-explorers"
+import {
+  PUBLIC_NTFY_SERVER_URL,
+  buildNtfyServerOptions,
+  resolveSelectedNtfyServer,
+  type NtfyServerOption,
+} from "@/lib/ntfy-servers"
 
 export interface UserPreferences {
   preferred_fiat_currency: string
@@ -39,6 +45,9 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   // ntfy server state
   const [ntfyServerUrl, setNtfyServerUrl] = useState<string>("")
   const [savedNtfyUrl, setSavedNtfyUrl] = useState<string>("")
+  const [availableNtfyServers, setAvailableNtfyServers] = useState<NtfyServerOption[]>([])
+  const [defaultNtfyServerId, setDefaultNtfyServerId] = useState<string>("ntfy-sh")
+  const [selectedNtfyServerId, setSelectedNtfyServerId] = useState<string>("ntfy-sh")
 
   // ntfy authentication state
   const [ntfyAuthType, setNtfyAuthType] = useState<NtfyAuthType>("none")
@@ -104,21 +113,23 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   }, [isAuthenticated])
 
   useEffect(() => {
-    const fetchTxExplorers = async () => {
+    const fetchConfig = async () => {
       try {
         const config = await api.getConfig()
         const location = typeof window === "undefined"
           ? null
           : { protocol: window.location.protocol, hostname: window.location.hostname }
-        const options = buildTxExplorerOptions(config, location)
-        setAvailableTxExplorers(options)
+        const txOptions = buildTxExplorerOptions(config, location)
+        setAvailableTxExplorers(txOptions)
         setDefaultTxExplorerId(config.default_tx_explorer_id)
+        setAvailableNtfyServers(buildNtfyServerOptions(config))
+        setDefaultNtfyServerId(config.default_ntfy_server_id)
       } catch (error) {
-        console.error("Failed to fetch tx explorer config:", error)
+        console.error("Failed to fetch app config:", error)
       }
     }
 
-    fetchTxExplorers()
+    fetchConfig()
   }, [])
 
   useEffect(() => {
@@ -131,6 +142,28 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     )
     setSelectedTxExplorerId(selectedExplorer.id)
   }, [availableTxExplorers, userPreferences?.preferred_tx_explorer_id, defaultTxExplorerId])
+
+  useEffect(() => {
+    if (availableNtfyServers.length === 0) return
+
+    const selectedServer = resolveSelectedNtfyServer(
+      availableNtfyServers,
+      userPreferences?.ntfy_server_url ?? null,
+      defaultNtfyServerId
+    )
+    setSelectedNtfyServerId(selectedServer.id)
+
+    if (userPreferences?.ntfy_server_url) {
+      setNtfyServerUrl(selectedServer.baseUrl)
+      setSavedNtfyUrl(selectedServer.baseUrl)
+      return
+    }
+
+    if (!ntfyServerUrl && !savedNtfyUrl) {
+      setNtfyServerUrl(selectedServer.baseUrl)
+      setSavedNtfyUrl(selectedServer.baseUrl)
+    }
+  }, [availableNtfyServers, userPreferences?.ntfy_server_url, defaultNtfyServerId, ntfyServerUrl, savedNtfyUrl])
 
   // Initialize locale from cookie
   useEffect(() => {
@@ -190,6 +223,16 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       (ntfyAuthType === "basic" && (ntfyPassword.trim() !== "" || ntfyUsername !== savedNtfyUsername))
 
     try {
+      if (!ntfyServerUrl.trim()) {
+        setNtfySettingsError("ntfy server URL is required")
+        return
+      }
+
+      if (!ntfyServerUrl.startsWith("http://") && !ntfyServerUrl.startsWith("https://")) {
+        setNtfySettingsError("ntfy server URL must start with http:// or https://")
+        return
+      }
+
       let updateData: {
         ntfy_server_url?: string
         ntfy_access_token?: string
@@ -228,7 +271,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
 
       const result = await api.updateUserPreferences(updateData)
       setUserPreferences(result)
-      setSavedNtfyUrl(result.ntfy_server_url || "")
+      setSavedNtfyUrl(result.ntfy_server_url || ntfyServerUrl)
       if (authChanged) {
         setSavedNtfyAuthType(ntfyAuthType)
         if (ntfyAuthType === "basic") {
@@ -259,6 +302,19 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     setNtfySettingsError(null)
     setNtfySettingsSuccess(false)
   }, [])
+
+  const handleNtfyServerChange = useCallback((serverId: string) => {
+    const selectedServer = availableNtfyServers.find((server) => server.id === serverId)
+    if (!selectedServer) return
+
+    setSelectedNtfyServerId(serverId)
+    if (selectedServer.isLocal) {
+      setNtfyServerUrl(selectedServer.baseUrl)
+    } else if (selectedNtfyServerId !== selectedServer.id) {
+      setNtfyServerUrl(PUBLIC_NTFY_SERVER_URL)
+    }
+    clearNtfySettingsErrors()
+  }, [availableNtfyServers, clearNtfySettingsErrors, selectedNtfyServerId])
 
   const handleTxExplorerChange = useCallback(async (explorerId: string) => {
     const previousExplorerId = selectedTxExplorerId
@@ -296,6 +352,9 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     // ntfy settings (consolidated)
     ntfyServerUrl,
     setNtfyServerUrl,
+    availableNtfyServers,
+    selectedNtfyServerId,
+    handleNtfyServerChange,
     hasAnyNtfyChanges,
     isUpdatingNtfySettings,
     ntfySettingsError,

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -48,6 +48,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   const [availableNtfyServers, setAvailableNtfyServers] = useState<NtfyServerOption[]>([])
   const [defaultNtfyServerId, setDefaultNtfyServerId] = useState<string>("ntfy-sh")
   const [selectedNtfyServerId, setSelectedNtfyServerId] = useState<string>("ntfy-sh")
+  const [lastPublicNtfyUrl, setLastPublicNtfyUrl] = useState<string>(PUBLIC_NTFY_SERVER_URL)
   const hasInitializedNtfySelection = useRef(false)
 
   // ntfy authentication state
@@ -158,6 +159,9 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     if (userPreferences?.ntfy_server_url) {
       setNtfyServerUrl(selectedServer.baseUrl)
       setSavedNtfyUrl(selectedServer.baseUrl)
+      if (!selectedServer.isLocal) {
+        setLastPublicNtfyUrl(selectedServer.baseUrl)
+      }
       hasInitializedNtfySelection.current = true
       return
     }
@@ -165,6 +169,9 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     if (!hasInitializedNtfySelection.current) {
       setNtfyServerUrl(selectedServer.baseUrl)
       setSavedNtfyUrl(selectedServer.baseUrl)
+      if (!selectedServer.isLocal) {
+        setLastPublicNtfyUrl(selectedServer.baseUrl)
+      }
       hasInitializedNtfySelection.current = true
     }
   }, [availableNtfyServers, userPreferences, userPreferences?.ntfy_server_url, defaultNtfyServerId, isAuthenticated])
@@ -237,13 +244,16 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
         return
       }
 
+      const selectedNtfyServer = availableNtfyServers.find((server) => server.id === selectedNtfyServerId)
+      const ntfyUrlToStore = selectedNtfyServer?.isLocal ? "" : ntfyServerUrl
+
       let updateData: {
         ntfy_server_url?: string
         ntfy_access_token?: string
         ntfy_username?: string
         ntfy_password?: string
       } = {
-        ntfy_server_url: ntfyServerUrl || "",
+        ntfy_server_url: ntfyUrlToStore,
       }
 
       if (authChanged) {
@@ -276,6 +286,9 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       const result = await api.updateUserPreferences(updateData)
       setUserPreferences(result)
       setSavedNtfyUrl(result.ntfy_server_url || ntfyServerUrl)
+      if (!selectedNtfyServer?.isLocal) {
+        setLastPublicNtfyUrl(result.ntfy_server_url || ntfyServerUrl || PUBLIC_NTFY_SERVER_URL)
+      }
       if (authChanged) {
         setSavedNtfyAuthType(ntfyAuthType)
         if (ntfyAuthType === "basic") {
@@ -300,7 +313,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     } finally {
       setIsUpdatingNtfySettings(false)
     }
-  }, [ntfyServerUrl, savedNtfyUrl, ntfyAuthType, savedNtfyAuthType, ntfyAccessToken, ntfyUsername, savedNtfyUsername, ntfyPassword])
+  }, [ntfyServerUrl, savedNtfyUrl, ntfyAuthType, savedNtfyAuthType, ntfyAccessToken, ntfyUsername, savedNtfyUsername, ntfyPassword, availableNtfyServers, selectedNtfyServerId])
 
   const clearNtfySettingsErrors = useCallback(() => {
     setNtfySettingsError(null)
@@ -313,12 +326,16 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
 
     setSelectedNtfyServerId(serverId)
     if (selectedServer.isLocal) {
+      const currentServer = availableNtfyServers.find((server) => server.id === selectedNtfyServerId)
+      if (currentServer && !currentServer.isLocal && ntfyServerUrl.trim()) {
+        setLastPublicNtfyUrl(ntfyServerUrl)
+      }
       setNtfyServerUrl(selectedServer.baseUrl)
     } else if (selectedNtfyServerId !== selectedServer.id) {
-      setNtfyServerUrl(PUBLIC_NTFY_SERVER_URL)
+      setNtfyServerUrl(lastPublicNtfyUrl)
     }
     clearNtfySettingsErrors()
-  }, [availableNtfyServers, clearNtfySettingsErrors, selectedNtfyServerId])
+  }, [availableNtfyServers, clearNtfySettingsErrors, lastPublicNtfyUrl, ntfyServerUrl, selectedNtfyServerId])
 
   const handleTxExplorerChange = useCallback(async (explorerId: string) => {
     const previousExplorerId = selectedTxExplorerId

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -174,7 +174,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       }
       hasInitializedNtfySelection.current = true
     }
-  }, [availableNtfyServers, userPreferences, userPreferences?.ntfy_server_url, defaultNtfyServerId, isAuthenticated])
+  }, [availableNtfyServers, userPreferences, defaultNtfyServerId, isAuthenticated])
 
   // Initialize locale from cookie
   useEffect(() => {
@@ -234,18 +234,22 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       (ntfyAuthType === "basic" && (ntfyPassword.trim() !== "" || ntfyUsername !== savedNtfyUsername))
 
     try {
-      if (!ntfyServerUrl.trim()) {
+      const selectedNtfyServer = availableNtfyServers.find((server) => server.id === selectedNtfyServerId)
+      const ntfyUrlToStore = selectedNtfyServer?.isLocal ? "" : ntfyServerUrl
+
+      if (!selectedNtfyServer?.isLocal && !ntfyServerUrl.trim()) {
         setNtfySettingsError("ntfy server URL is required")
         return
       }
 
-      if (!ntfyServerUrl.startsWith("http://") && !ntfyServerUrl.startsWith("https://")) {
+      if (
+        !selectedNtfyServer?.isLocal &&
+        !ntfyServerUrl.startsWith("http://") &&
+        !ntfyServerUrl.startsWith("https://")
+      ) {
         setNtfySettingsError("ntfy server URL must start with http:// or https://")
         return
       }
-
-      const selectedNtfyServer = availableNtfyServers.find((server) => server.id === selectedNtfyServerId)
-      const ntfyUrlToStore = selectedNtfyServer?.isLocal ? "" : ntfyServerUrl
 
       let updateData: {
         ntfy_server_url?: string

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -223,6 +223,11 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       (ntfyAuthType === "basic" && (ntfyPassword.trim() !== "" || ntfyUsername !== savedNtfyUsername))
 
     try {
+      if (availableNtfyServers.length === 0) {
+        setNtfySettingsError(t("ntfy.validation.saveFailed"))
+        return
+      }
+
       const selectedNtfyServer = availableNtfyServers.find((server) => server.id === selectedNtfyServerId)
       const normalizedNtfyServerUrl = ntfyServerUrl.trim().replace(/\/+$/, "")
       // Local integrations are detected from config on each load. Persist an empty preference so we

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -50,6 +50,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   const [availableNtfyServers, setAvailableNtfyServers] = useState<NtfyServerOption[]>([])
   const [defaultNtfyServerId, setDefaultNtfyServerId] = useState<string>("ntfy-sh")
   const [selectedNtfyServerId, setSelectedNtfyServerId] = useState<string>("ntfy-sh")
+  const [savedNtfyServerId, setSavedNtfyServerId] = useState<string>("ntfy-sh")
   const [lastPublicNtfyUrl, setLastPublicNtfyUrl] = useState<string>(PUBLIC_NTFY_SERVER_URL)
   const hasInitializedNtfySelection = useRef(false)
 
@@ -68,6 +69,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
 
   // Derived state - any ntfy field has changed
   const hasAnyNtfyChanges =
+    selectedNtfyServerId !== savedNtfyServerId ||
     ntfyServerUrl !== savedNtfyUrl ||
     ntfyAuthType !== savedNtfyAuthType ||
     (ntfyAuthType === "token" && ntfyAccessToken.trim() !== "") ||
@@ -159,6 +161,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     setSelectedNtfyServerId(selectedServer.id)
 
     if (userPreferences?.ntfy_server_url) {
+      setSavedNtfyServerId(selectedServer.id)
       setNtfyServerUrl(selectedServer.baseUrl)
       setSavedNtfyUrl(selectedServer.baseUrl)
       if (!selectedServer.isLocal) {
@@ -169,6 +172,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     }
 
     if (!hasInitializedNtfySelection.current) {
+      setSavedNtfyServerId(selectedServer.id)
       setNtfyServerUrl(selectedServer.baseUrl)
       setSavedNtfyUrl(selectedServer.baseUrl)
       if (!selectedServer.isLocal) {
@@ -291,6 +295,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
 
       const result = await api.updateUserPreferences(updateData)
       setUserPreferences(result)
+      setSavedNtfyServerId(selectedNtfyServer?.id ?? selectedNtfyServerId)
       setSavedNtfyUrl(result.ntfy_server_url || ntfyServerUrl)
       if (!selectedNtfyServer?.isLocal) {
         setLastPublicNtfyUrl(result.ntfy_server_url || ntfyServerUrl || PUBLIC_NTFY_SERVER_URL)
@@ -311,6 +316,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       console.error("Failed to update ntfy settings:", error)
       setNtfySettingsError(error instanceof Error ? error.message : t("ntfy.validation.saveFailed"))
       // Revert all fields to saved state
+      setSelectedNtfyServerId(savedNtfyServerId)
       setNtfyServerUrl(savedNtfyUrl)
       setNtfyAuthType(savedNtfyAuthType)
       if (savedNtfyAuthType === "basic") {
@@ -319,7 +325,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     } finally {
       setIsUpdatingNtfySettings(false)
     }
-  }, [ntfyServerUrl, savedNtfyUrl, ntfyAuthType, savedNtfyAuthType, ntfyAccessToken, ntfyUsername, savedNtfyUsername, ntfyPassword, availableNtfyServers, selectedNtfyServerId, t])
+  }, [ntfyServerUrl, savedNtfyUrl, ntfyAuthType, savedNtfyAuthType, ntfyAccessToken, ntfyUsername, savedNtfyUsername, ntfyPassword, availableNtfyServers, selectedNtfyServerId, savedNtfyServerId, t])
 
   const clearNtfySettingsErrors = useCallback(() => {
     setNtfySettingsError(null)

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -278,11 +278,9 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       }
 
       const result = await api.updateUserPreferences(updateData)
-      const savedUrlAfterSave =
-        result.ntfy_server_url ||
-        selectedNtfyServer?.baseUrl ||
-        normalizedNtfyServerUrl ||
-        PUBLIC_NTFY_SERVER_URL
+      const savedUrlAfterSave = selectedNtfyServer?.isLocal
+        ? selectedNtfyServer.baseUrl
+        : result.ntfy_server_url || normalizedNtfyServerUrl || PUBLIC_NTFY_SERVER_URL
       setUserPreferences(result)
       setSavedNtfyServerId(selectedNtfyServer?.id ?? selectedNtfyServerId)
       setSavedNtfyUrl(savedUrlAfterSave)

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -225,7 +225,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     try {
       if (availableNtfyServers.length === 0) {
         setNtfySettingsError(t("ntfy.validation.saveFailed"))
-        return
+        return false
       }
 
       const selectedNtfyServer = availableNtfyServers.find((server) => server.id === selectedNtfyServerId)
@@ -236,7 +236,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
 
       if (!selectedNtfyServer?.isLocal && !normalizedNtfyServerUrl) {
         setNtfySettingsError(t("ntfy.validation.urlRequired"))
-        return
+        return false
       }
 
       if (
@@ -245,7 +245,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
         !normalizedNtfyServerUrl.startsWith("https://")
       ) {
         setNtfySettingsError(t("ntfy.validation.urlProtocol"))
-        return
+        return false
       }
 
       let updateData: {
@@ -268,13 +268,13 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
         } else if (ntfyAuthType === "token") {
           if (!ntfyAccessToken.trim()) {
             setNtfySettingsError(t("ntfy.auth.tokenRequired"))
-            return
+            return false
           }
           updateData = { ...updateData, ntfy_access_token: ntfyAccessToken.trim() }
         } else if (ntfyAuthType === "basic") {
           if (!ntfyUsername.trim() || !ntfyPassword.trim()) {
             setNtfySettingsError(t("ntfy.auth.credentialsRequired"))
-            return
+            return false
           }
           updateData = {
             ...updateData,
@@ -307,6 +307,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       setNtfyPassword("")
 
       setNtfySettingsSuccess(true)
+      return true
     } catch (error) {
       console.error("Failed to update ntfy settings:", error)
       setNtfySettingsError(error instanceof Error ? error.message : t("ntfy.validation.saveFailed"))
@@ -317,6 +318,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       if (savedNtfyAuthType === "basic") {
         setNtfyUsername(savedNtfyUsername)
       }
+      return false
     } finally {
       setIsUpdatingNtfySettings(false)
     }

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { api } from "@/lib/api"
@@ -8,6 +8,7 @@ import { invalidateTxExplorerCache } from "@/hooks/useTxExplorer"
 import { buildTxExplorerOptions, resolveSelectedTxExplorer, type TxExplorerOption } from "@/lib/tx-explorers"
 import {
   PUBLIC_NTFY_SERVER_URL,
+  PUBLIC_NTFY_SERVER_ID,
   buildNtfyServerOptions,
   resolveSelectedNtfyServer,
   type NtfyServerOption,
@@ -45,14 +46,13 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   const [isUpdatingTxExplorer, setIsUpdatingTxExplorer] = useState(false)
 
   // ntfy server state
-  const [ntfyServerUrl, setNtfyServerUrl] = useState<string>("")
-  const [savedNtfyUrl, setSavedNtfyUrl] = useState<string>("")
+  const [ntfyServerUrl, setNtfyServerUrl] = useState<string>(PUBLIC_NTFY_SERVER_URL)
+  const [savedNtfyUrl, setSavedNtfyUrl] = useState<string>(PUBLIC_NTFY_SERVER_URL)
   const [availableNtfyServers, setAvailableNtfyServers] = useState<NtfyServerOption[]>([])
-  const [defaultNtfyServerId, setDefaultNtfyServerId] = useState<string>("ntfy-sh")
-  const [selectedNtfyServerId, setSelectedNtfyServerId] = useState<string>("ntfy-sh")
-  const [savedNtfyServerId, setSavedNtfyServerId] = useState<string>("ntfy-sh")
+  const [defaultNtfyServerId, setDefaultNtfyServerId] = useState<string>(PUBLIC_NTFY_SERVER_ID)
+  const [selectedNtfyServerId, setSelectedNtfyServerId] = useState<string>(PUBLIC_NTFY_SERVER_ID)
+  const [savedNtfyServerId, setSavedNtfyServerId] = useState<string>(PUBLIC_NTFY_SERVER_ID)
   const [lastPublicNtfyUrl, setLastPublicNtfyUrl] = useState<string>(PUBLIC_NTFY_SERVER_URL)
-  const hasInitializedNtfySelection = useRef(false)
 
   // ntfy authentication state
   const [ntfyAuthType, setNtfyAuthType] = useState<NtfyAuthType>("none")
@@ -91,8 +91,6 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
         const prefs = await api.getUserPreferences()
         setUserPreferences(prefs)
         setSelectedCurrency(prefs.preferred_fiat_currency)
-        setNtfyServerUrl(prefs.ntfy_server_url || "")
-        setSavedNtfyUrl(prefs.ntfy_server_url || "")
 
         // Set auth type based on what's configured
         if (prefs.ntfy_has_access_token) {
@@ -150,8 +148,8 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   }, [availableTxExplorers, userPreferences?.preferred_tx_explorer_id, defaultTxExplorerId])
 
   useEffect(() => {
-    if (availableNtfyServers.length === 0) return
-    if (isAuthenticated && userPreferences === null) return
+    const hasLoadedPreferences = !isAuthenticated || userPreferences !== null
+    if (availableNtfyServers.length === 0 || !hasLoadedPreferences) return
 
     const selectedServer = resolveSelectedNtfyServer(
       availableNtfyServers,
@@ -159,26 +157,11 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       defaultNtfyServerId
     )
     setSelectedNtfyServerId(selectedServer.id)
-
-    if (userPreferences?.ntfy_server_url) {
-      setSavedNtfyServerId(selectedServer.id)
-      setNtfyServerUrl(selectedServer.baseUrl)
-      setSavedNtfyUrl(selectedServer.baseUrl)
-      if (!selectedServer.isLocal) {
-        setLastPublicNtfyUrl(selectedServer.baseUrl)
-      }
-      hasInitializedNtfySelection.current = true
-      return
-    }
-
-    if (!hasInitializedNtfySelection.current) {
-      setSavedNtfyServerId(selectedServer.id)
-      setNtfyServerUrl(selectedServer.baseUrl)
-      setSavedNtfyUrl(selectedServer.baseUrl)
-      if (!selectedServer.isLocal) {
-        setLastPublicNtfyUrl(selectedServer.baseUrl)
-      }
-      hasInitializedNtfySelection.current = true
+    setSavedNtfyServerId(selectedServer.id)
+    setNtfyServerUrl(selectedServer.baseUrl)
+    setSavedNtfyUrl(selectedServer.baseUrl)
+    if (!selectedServer.isLocal) {
+      setLastPublicNtfyUrl(selectedServer.baseUrl)
     }
   }, [availableNtfyServers, userPreferences, defaultNtfyServerId, isAuthenticated])
 
@@ -241,17 +224,18 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
 
     try {
       const selectedNtfyServer = availableNtfyServers.find((server) => server.id === selectedNtfyServerId)
-      const ntfyUrlToStore = selectedNtfyServer?.isLocal ? "" : ntfyServerUrl
+      const normalizedNtfyServerUrl = ntfyServerUrl.trim().replace(/\/+$/, "")
+      const ntfyUrlToStore = selectedNtfyServer?.isLocal ? "" : normalizedNtfyServerUrl
 
-      if (!selectedNtfyServer?.isLocal && !ntfyServerUrl.trim()) {
+      if (!selectedNtfyServer?.isLocal && !normalizedNtfyServerUrl) {
         setNtfySettingsError(t("ntfy.validation.urlRequired"))
         return
       }
 
       if (
         !selectedNtfyServer?.isLocal &&
-        !ntfyServerUrl.startsWith("http://") &&
-        !ntfyServerUrl.startsWith("https://")
+        !normalizedNtfyServerUrl.startsWith("http://") &&
+        !normalizedNtfyServerUrl.startsWith("https://")
       ) {
         setNtfySettingsError(t("ntfy.validation.urlProtocol"))
         return
@@ -294,11 +278,17 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       }
 
       const result = await api.updateUserPreferences(updateData)
+      const savedUrlAfterSave =
+        result.ntfy_server_url ||
+        selectedNtfyServer?.baseUrl ||
+        normalizedNtfyServerUrl ||
+        PUBLIC_NTFY_SERVER_URL
       setUserPreferences(result)
       setSavedNtfyServerId(selectedNtfyServer?.id ?? selectedNtfyServerId)
-      setSavedNtfyUrl(result.ntfy_server_url || ntfyServerUrl)
+      setSavedNtfyUrl(savedUrlAfterSave)
       if (!selectedNtfyServer?.isLocal) {
-        setLastPublicNtfyUrl(result.ntfy_server_url || ntfyServerUrl || PUBLIC_NTFY_SERVER_URL)
+        setNtfyServerUrl(savedUrlAfterSave)
+        setLastPublicNtfyUrl(savedUrlAfterSave)
       }
       if (authChanged) {
         setSavedNtfyAuthType(ntfyAuthType)

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -335,7 +335,7 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
         setLastPublicNtfyUrl(ntfyServerUrl)
       }
       setNtfyServerUrl(selectedServer.baseUrl)
-    } else if (selectedNtfyServerId !== selectedServer.id) {
+    } else {
       setNtfyServerUrl(lastPublicNtfyUrl)
     }
     clearNtfySettingsErrors()

--- a/frontend/src/lib/__tests__/ntfy-servers.test.ts
+++ b/frontend/src/lib/__tests__/ntfy-servers.test.ts
@@ -53,6 +53,12 @@ describe("ntfy server helpers", () => {
     expect(selected.id).toBe("umbrel-ntfy")
   })
 
+  it("selects a single detected local ntfy when the saved preference is empty", () => {
+    const selected = resolveSelectedNtfyServer(buildNtfyServerOptions(config), "", "umbrel-ntfy")
+
+    expect(selected.id).toBe("umbrel-ntfy")
+  })
+
   it("selects a single detected local ntfy before the public config default", () => {
     const selected = resolveSelectedNtfyServer(buildNtfyServerOptions(config), null, "ntfy-sh")
 
@@ -93,5 +99,7 @@ describe("ntfy server helpers", () => {
     expect(isBrowserSafeNtfyUrl("http://ntfy")).toBe(true)
     expect(isBrowserSafeNtfyUrl("https://ntfy.sh")).toBe(true)
     expect(isBrowserSafeNtfyUrl("http://localhost:8080")).toBe(true)
+    expect(isBrowserSafeNtfyUrl("http://192.168.1.10:8080")).toBe(true)
+    expect(isBrowserSafeNtfyUrl("http://valid-host/path_with_underscore")).toBe(true)
   })
 })

--- a/frontend/src/lib/__tests__/ntfy-servers.test.ts
+++ b/frontend/src/lib/__tests__/ntfy-servers.test.ts
@@ -23,7 +23,6 @@ describe("ntfy server helpers", () => {
         name: "ntfy",
         baseUrl: "http://ntfy_app_1",
         isLocal: true,
-        isCustom: false,
       },
     ])
   })
@@ -79,7 +78,6 @@ describe("ntfy server helpers", () => {
     expect(selected).toMatchObject({
       id: "ntfy-sh",
       baseUrl: "https://ntfy.example.com",
-      isCustom: false,
     })
   })
 

--- a/frontend/src/lib/__tests__/ntfy-servers.test.ts
+++ b/frontend/src/lib/__tests__/ntfy-servers.test.ts
@@ -1,0 +1,91 @@
+import {
+  PUBLIC_NTFY_SERVER,
+  buildNtfyServerOptions,
+  isBrowserSafeNtfyUrl,
+  resolveSelectedNtfyServer,
+} from "../ntfy-servers"
+
+describe("ntfy server helpers", () => {
+  const config = {
+    tx_explorers: [],
+    default_tx_explorer_id: "mempool-space",
+    ntfy_servers: [
+      { id: "umbrel-ntfy", name: "ntfy", base_url: "http://ntfy_app_1/" },
+    ],
+    default_ntfy_server_id: "umbrel-ntfy",
+  }
+
+  it("builds public/custom and local options", () => {
+    expect(buildNtfyServerOptions(config)).toEqual([
+      PUBLIC_NTFY_SERVER,
+      {
+        id: "umbrel-ntfy",
+        name: "ntfy",
+        baseUrl: "http://ntfy_app_1",
+        isLocal: true,
+        isCustom: false,
+      },
+    ])
+  })
+
+  it("uses saved public ntfy over detected local ntfy", () => {
+    const selected = resolveSelectedNtfyServer(
+      buildNtfyServerOptions(config),
+      "https://ntfy.sh",
+      "umbrel-ntfy"
+    )
+
+    expect(selected.id).toBe("ntfy-sh")
+  })
+
+  it("uses saved local ntfy when detected", () => {
+    const selected = resolveSelectedNtfyServer(
+      buildNtfyServerOptions(config),
+      "http://ntfy_app_1",
+      "umbrel-ntfy"
+    )
+
+    expect(selected.id).toBe("umbrel-ntfy")
+  })
+
+  it("selects a single detected local ntfy when there is no saved preference", () => {
+    const selected = resolveSelectedNtfyServer(buildNtfyServerOptions(config), null, "umbrel-ntfy")
+
+    expect(selected.id).toBe("umbrel-ntfy")
+  })
+
+  it("falls back to public ntfy when no local server is available", () => {
+    const selected = resolveSelectedNtfyServer(
+      buildNtfyServerOptions({
+        tx_explorers: [],
+        default_tx_explorer_id: "mempool-space",
+        ntfy_servers: [],
+        default_ntfy_server_id: "ntfy-sh",
+      }),
+      null,
+      "ntfy-sh"
+    )
+
+    expect(selected.id).toBe("ntfy-sh")
+  })
+
+  it("uses the editable public option for unknown saved URLs", () => {
+    const selected = resolveSelectedNtfyServer(
+      buildNtfyServerOptions(config),
+      "https://ntfy.example.com",
+      "umbrel-ntfy"
+    )
+
+    expect(selected).toMatchObject({
+      id: "ntfy-sh",
+      baseUrl: "https://ntfy.example.com",
+      isCustom: false,
+    })
+  })
+
+  it("does not treat Docker-internal URLs as browser-safe", () => {
+    expect(isBrowserSafeNtfyUrl("http://ntfy_app_1")).toBe(false)
+    expect(isBrowserSafeNtfyUrl("https://ntfy.sh")).toBe(true)
+    expect(isBrowserSafeNtfyUrl("http://localhost:8080")).toBe(true)
+  })
+})

--- a/frontend/src/lib/__tests__/ntfy-servers.test.ts
+++ b/frontend/src/lib/__tests__/ntfy-servers.test.ts
@@ -53,6 +53,12 @@ describe("ntfy server helpers", () => {
     expect(selected.id).toBe("umbrel-ntfy")
   })
 
+  it("selects a single detected local ntfy before the public config default", () => {
+    const selected = resolveSelectedNtfyServer(buildNtfyServerOptions(config), null, "ntfy-sh")
+
+    expect(selected.id).toBe("umbrel-ntfy")
+  })
+
   it("falls back to public ntfy when no local server is available", () => {
     const selected = resolveSelectedNtfyServer(
       buildNtfyServerOptions({

--- a/frontend/src/lib/__tests__/ntfy-servers.test.ts
+++ b/frontend/src/lib/__tests__/ntfy-servers.test.ts
@@ -10,7 +10,7 @@ describe("ntfy server helpers", () => {
     tx_explorers: [],
     default_tx_explorer_id: "mempool-space",
     ntfy_servers: [
-      { id: "umbrel-ntfy", name: "ntfy", base_url: "http://ntfy_app_1/" },
+      { id: "umbrel-ntfy", name: "ntfy", base_url: "http://ntfy_app_1/", platform: "umbrel" },
     ],
     default_ntfy_server_id: "umbrel-ntfy",
   }
@@ -23,6 +23,7 @@ describe("ntfy server helpers", () => {
         name: "ntfy",
         baseUrl: "http://ntfy_app_1",
         isLocal: true,
+        platform: "umbrel",
       },
     ])
   })
@@ -101,5 +102,18 @@ describe("ntfy server helpers", () => {
     expect(isBrowserSafeNtfyUrl("http://localhost:8080")).toBe(true)
     expect(isBrowserSafeNtfyUrl("http://192.168.1.10:8080")).toBe(true)
     expect(isBrowserSafeNtfyUrl("http://valid-host/path_with_underscore")).toBe(true)
+  })
+
+  it("filters blank detected ntfy server URLs", () => {
+    const options = buildNtfyServerOptions({
+      tx_explorers: [],
+      default_tx_explorer_id: "mempool-space",
+      ntfy_servers: [
+        { id: "blank-ntfy", name: "ntfy", base_url: "   ", platform: "umbrel" },
+      ],
+      default_ntfy_server_id: "blank-ntfy",
+    })
+
+    expect(options).toEqual([PUBLIC_NTFY_SERVER])
   })
 })

--- a/frontend/src/lib/__tests__/ntfy-servers.test.ts
+++ b/frontend/src/lib/__tests__/ntfy-servers.test.ts
@@ -83,8 +83,10 @@ describe("ntfy server helpers", () => {
     })
   })
 
-  it("does not treat Docker-internal URLs as browser-safe", () => {
+  it("rejects Docker-internal URLs but allows browser-reachable single-label hosts", () => {
     expect(isBrowserSafeNtfyUrl("http://ntfy_app_1")).toBe(false)
+    expect(isBrowserSafeNtfyUrl("http://umbrel")).toBe(true)
+    expect(isBrowserSafeNtfyUrl("http://ntfy")).toBe(true)
     expect(isBrowserSafeNtfyUrl("https://ntfy.sh")).toBe(true)
     expect(isBrowserSafeNtfyUrl("http://localhost:8080")).toBe(true)
   })

--- a/frontend/src/lib/__tests__/tx-explorers.test.ts
+++ b/frontend/src/lib/__tests__/tx-explorers.test.ts
@@ -20,6 +20,8 @@ describe("tx explorer helpers", () => {
           { id: "bitfeed", name: "Bitfeed", base_url: null, port: 8314 },
         ],
         default_tx_explorer_id: "mempool-space",
+        ntfy_servers: [],
+        default_ntfy_server_id: "ntfy-sh",
       },
       location
     )
@@ -36,6 +38,8 @@ describe("tx explorer helpers", () => {
       {
         tx_explorers: [],
         default_tx_explorer_id: "mempool-space",
+        ntfy_servers: [],
+        default_ntfy_server_id: "ntfy-sh",
       },
       location
     )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,9 +24,17 @@ export interface TxExplorerConfig {
   port: number | null
 }
 
+export interface NtfyServerConfig {
+  id: string
+  name: string
+  base_url: string
+}
+
 export interface AppConfigResponse {
   tx_explorers: TxExplorerConfig[]
   default_tx_explorer_id: string
+  ntfy_servers: NtfyServerConfig[]
+  default_ntfy_server_id: string
 }
 
 export interface UserPreferencesResponse {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,6 +28,7 @@ export interface NtfyServerConfig {
   id: string
   name: string
   base_url: string
+  platform: string | null
 }
 
 export interface AppConfigResponse {

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -69,7 +69,10 @@ export function resolveSelectedNtfyServer(
 export function isBrowserSafeNtfyUrl(baseUrl: string): boolean {
   try {
     const parsed = new URL(baseUrl)
-    return parsed.hostname.includes(".") || parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1"
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false
+    }
+    return !parsed.hostname.includes("_")
   } catch {
     return false
   }

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -1,6 +1,8 @@
 import type { AppConfigResponse } from "@/lib/api"
 
 export const PUBLIC_NTFY_SERVER_URL = "https://ntfy.sh"
+export const PUBLIC_NTFY_SERVER_ID = "ntfy-sh"
+export const UMBREL_NTFY_SERVER_ID = "umbrel-ntfy"
 
 export interface NtfyServerOption {
   id: string
@@ -11,7 +13,7 @@ export interface NtfyServerOption {
 }
 
 export const PUBLIC_NTFY_SERVER: NtfyServerOption = {
-  id: "ntfy-sh",
+  id: PUBLIC_NTFY_SERVER_ID,
   name: "ntfy",
   baseUrl: PUBLIC_NTFY_SERVER_URL,
   isLocal: false,
@@ -73,8 +75,8 @@ export function isBrowserSafeNtfyUrl(baseUrl: string): boolean {
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return false
     }
-    // Single-label names like umbrel are treated as browser-safe; Docker-internal
-    // names with underscores, like ntfy_app_1, are invalid under RFC 1123 and hidden.
+    // Only the hostname is checked. Path underscores are valid; Docker-internal
+    // hostnames with underscores, like ntfy_app_1, are not browser-safe.
     return !parsed.hostname.includes("_")
   } catch {
     return false

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -55,6 +55,7 @@ export function resolveSelectedNtfyServer(
   const localServers = options.filter((option) => option.isLocal)
   if (localServers.length === 1) {
     // First-run self-hosted UX: a single detected local server wins until the user saves a public/custom URL.
+    // If multiple local integrations are added later, choose an explicit default instead of guessing.
     return localServers[0]
   }
 
@@ -73,7 +74,8 @@ export function isBrowserSafeNtfyUrl(baseUrl: string): boolean {
       return false
     }
     // Underscores make hostnames invalid under RFC 1123; Docker-internal names like ntfy_app_1 commonly use them.
-    // Operators with browser-reachable local ntfy should use DNS-valid hostnames instead.
+    // This is a reachability heuristic: DNS-valid single-label hosts may still be unreachable from a user's browser.
+    // Operators with browser-reachable local ntfy should use DNS-valid hostnames.
     return !parsed.hostname.includes("_")
   } catch {
     return false

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -1,0 +1,76 @@
+import type { AppConfigResponse } from "@/lib/api"
+
+export const PUBLIC_NTFY_SERVER_URL = "https://ntfy.sh"
+
+export interface NtfyServerOption {
+  id: string
+  name: string
+  baseUrl: string
+  isLocal: boolean
+  isCustom: boolean
+}
+
+export const PUBLIC_NTFY_SERVER: NtfyServerOption = {
+  id: "ntfy-sh",
+  name: "ntfy",
+  baseUrl: PUBLIC_NTFY_SERVER_URL,
+  isLocal: false,
+  isCustom: false,
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "")
+}
+
+export function buildNtfyServerOptions(config: AppConfigResponse): NtfyServerOption[] {
+  const localServers = config.ntfy_servers
+    .map((server) => ({
+      id: server.id,
+      name: server.name,
+      baseUrl: normalizeBaseUrl(server.base_url),
+      isLocal: true,
+      isCustom: false,
+    }))
+    .filter((server) => server.baseUrl)
+
+  return [PUBLIC_NTFY_SERVER, ...localServers]
+}
+
+export function resolveSelectedNtfyServer(
+  options: NtfyServerOption[],
+  savedServerUrl: string | null | undefined,
+  defaultServerId: string | null | undefined
+): NtfyServerOption {
+  const normalizedSavedUrl = savedServerUrl ? normalizeBaseUrl(savedServerUrl) : null
+
+  if (normalizedSavedUrl) {
+    const matchingOption = options.find(
+      (option) => !option.isCustom && normalizeBaseUrl(option.baseUrl) === normalizedSavedUrl
+    )
+    if (matchingOption) {
+      return matchingOption
+    }
+    return { ...PUBLIC_NTFY_SERVER, baseUrl: normalizedSavedUrl }
+  }
+
+  const localServers = options.filter((option) => option.isLocal)
+  if (localServers.length === 1) {
+    return localServers[0]
+  }
+
+  const configDefaultServer = options.find((option) => option.id === defaultServerId)
+  if (configDefaultServer && !configDefaultServer.isCustom) {
+    return configDefaultServer
+  }
+
+  return PUBLIC_NTFY_SERVER
+}
+
+export function isBrowserSafeNtfyUrl(baseUrl: string): boolean {
+  try {
+    const parsed = new URL(baseUrl)
+    return parsed.hostname.includes(".") || parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1"
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -57,6 +57,8 @@ export function resolveSelectedNtfyServer(
   const localServers = options.filter((option) => option.isLocal)
   if (localServers.length === 1) {
     // First-run self-hosted UX: a single detected local server wins until the user saves a public/custom URL.
+    // The settings save path stores local selections as an empty preference so this resolver can reselect
+    // the current detected integration without persisting Docker-internal hostnames.
     // If multiple local integrations are added later, choose an explicit default instead of guessing.
     return localServers[0]
   }

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -73,9 +73,8 @@ export function isBrowserSafeNtfyUrl(baseUrl: string): boolean {
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return false
     }
-    // Underscores make hostnames invalid under RFC 1123; Docker-internal names like ntfy_app_1 commonly use them.
-    // This is a reachability heuristic: DNS-valid single-label hosts may still be unreachable from a user's browser.
-    // Operators with browser-reachable local ntfy should use DNS-valid hostnames.
+    // Single-label names like umbrel are treated as browser-safe; Docker-internal
+    // names with underscores, like ntfy_app_1, are invalid under RFC 1123 and hidden.
     return !parsed.hostname.includes("_")
   } catch {
     return false

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -7,7 +7,6 @@ export interface NtfyServerOption {
   name: string
   baseUrl: string
   isLocal: boolean
-  isCustom: boolean
 }
 
 export const PUBLIC_NTFY_SERVER: NtfyServerOption = {
@@ -15,7 +14,6 @@ export const PUBLIC_NTFY_SERVER: NtfyServerOption = {
   name: "ntfy",
   baseUrl: PUBLIC_NTFY_SERVER_URL,
   isLocal: false,
-  isCustom: false,
 }
 
 function normalizeBaseUrl(baseUrl: string): string {
@@ -29,7 +27,6 @@ export function buildNtfyServerOptions(config: AppConfigResponse): NtfyServerOpt
       name: server.name,
       baseUrl: normalizeBaseUrl(server.base_url),
       isLocal: true,
-      isCustom: false,
     }))
     .filter((server) => server.baseUrl)
 
@@ -45,7 +42,7 @@ export function resolveSelectedNtfyServer(
 
   if (normalizedSavedUrl) {
     const matchingOption = options.find(
-      (option) => !option.isCustom && normalizeBaseUrl(option.baseUrl) === normalizedSavedUrl
+      (option) => normalizeBaseUrl(option.baseUrl) === normalizedSavedUrl
     )
     if (matchingOption) {
       return matchingOption
@@ -59,7 +56,7 @@ export function resolveSelectedNtfyServer(
   }
 
   const configDefaultServer = options.find((option) => option.id === defaultServerId)
-  if (configDefaultServer && !configDefaultServer.isCustom) {
+  if (configDefaultServer) {
     return configDefaultServer
   }
 
@@ -73,6 +70,7 @@ export function isBrowserSafeNtfyUrl(baseUrl: string): boolean {
       return false
     }
     // Docker-internal hostnames commonly contain underscores and are not browser-reachable.
+    // Operators with browser-reachable local ntfy should use DNS-valid hostnames instead.
     return !parsed.hostname.includes("_")
   } catch {
     return false

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -72,6 +72,7 @@ export function isBrowserSafeNtfyUrl(baseUrl: string): boolean {
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return false
     }
+    // Docker-internal hostnames commonly contain underscores and are not browser-reachable.
     return !parsed.hostname.includes("_")
   } catch {
     return false

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -7,6 +7,7 @@ export interface NtfyServerOption {
   name: string
   baseUrl: string
   isLocal: boolean
+  platform?: string
 }
 
 export const PUBLIC_NTFY_SERVER: NtfyServerOption = {
@@ -27,8 +28,9 @@ export function buildNtfyServerOptions(config: AppConfigResponse): NtfyServerOpt
       name: server.name,
       baseUrl: normalizeBaseUrl(server.base_url),
       isLocal: true,
+      platform: server.platform ?? undefined,
     }))
-    .filter((server) => server.baseUrl)
+    .filter((server) => server.baseUrl.length > 0)
 
   return [PUBLIC_NTFY_SERVER, ...localServers]
 }

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -52,6 +52,7 @@ export function resolveSelectedNtfyServer(
 
   const localServers = options.filter((option) => option.isLocal)
   if (localServers.length === 1) {
+    // First-run self-hosted UX: a single detected local server wins until the user saves a public/custom URL.
     return localServers[0]
   }
 
@@ -69,7 +70,7 @@ export function isBrowserSafeNtfyUrl(baseUrl: string): boolean {
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return false
     }
-    // Docker-internal hostnames commonly contain underscores and are not browser-reachable.
+    // Underscores make hostnames invalid under RFC 1123; Docker-internal names like ntfy_app_1 commonly use them.
     // Operators with browser-reachable local ntfy should use DNS-valid hostnames instead.
     return !parsed.hostname.includes("_")
   } catch {


### PR DESCRIPTION
## Summary
- add detected ntfy server config to /api/config for self-hosted installs
- add Settings UI for public/custom ntfy and detected Umbrel ntfy
- keep official ntfy editable inline, with auth available for public/custom and local targets
- avoid exposing Docker-internal ntfy URLs as browser links

## Umbrel packaging
- companion Umbrel branch pushed: schjonhaug/umbrel-apps:canary-version-1.5.0
- Umbrel PR intentionally not open yet; we will test on device first

## Testing
- pnpm test
- pnpm lint
- pnpm build
- cargo fmt --check
- cargo test --lib