### PR TITLE
Support StartOS local transaction explorer URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 ## Node distro packaging work
 
 Keep Umbrel, StartOS, myNode, and similar node distro packaging changes batched
-on the shared unpublished-work branch `canary-1.x.x` until the full feature set
-for the next Canary release is ready.
+on the shared unpublished-work branch `canary-next-version` until the full
+feature set for the next Canary release is ready.
 
 Do not open node distro packaging PRs early. Commit and push related packaging
 changes to the relevant branch first, then create the upstream PRs when the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,12 @@
 # Canary Agent Notes
 
-## StartOS packaging work
+## Node distro packaging work
 
-Keep StartOS packaging changes batched on the shared StartOS feature/release
-branch until the full feature set for the next Canary release is ready.
+Keep Umbrel, StartOS, myNode, and similar node distro packaging changes batched
+on their shared feature/release branches until the full feature set for the next
+Canary release is ready.
 
-Do not open a non-draft StartOS packaging PR early. If a PR is useful for
-visibility while work is still ongoing, create it as a draft and continue
-pushing related StartOS changes to the same branch/PR.
+Do not open node distro packaging PRs early. Commit and push related packaging
+changes to the relevant branch first, then create the upstream PRs when the
+release is ready. If a PR is useful for visibility while work is still ongoing,
+create it as a draft and continue pushing related changes to the same branch/PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Canary Agent Notes
+
+## StartOS packaging work
+
+Keep StartOS packaging changes batched on the shared StartOS feature/release
+branch until the full feature set for the next Canary release is ready.
+
+Do not open a non-draft StartOS packaging PR early. If a PR is useful for
+visibility while work is still ongoing, create it as a draft and continue
+pushing related StartOS changes to the same branch/PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,13 @@
 ## Node distro packaging work
 
 Keep Umbrel, StartOS, myNode, and similar node distro packaging changes batched
-on their shared feature/release branches until the full feature set for the next
-Canary release is ready.
+on the shared unpublished-work branch `canary-1.x.x` until the full feature set
+for the next Canary release is ready.
 
 Do not open node distro packaging PRs early. Commit and push related packaging
 changes to the relevant branch first, then create the upstream PRs when the
 release is ready. If a PR is useful for visibility while work is still ongoing,
 create it as a draft and continue pushing related changes to the same branch/PR.
+
+Do not keep using already released version branches like `canary-version-1.5.0`
+for new unpublished packaging work.

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -83,7 +83,10 @@ CANARY_SELF_HOSTED_ADMIN_PASSWORD=replace-with-a-strong-password
 #
 # Packaging layers can also provide multiple browser-facing URLs for one explorer.
 # Canary will choose the URL matching the hostname used to open Canary when possible.
+# If both the singular URL and URLS list are set for an explorer, the singular
+# URL is kept as the primary fallback and deduplicated into the candidate list.
 # CANARY_MEMPOOL_URLS=https://example-node.local:52127,https://203.0.113.10:52127
+# CANARY_BITFEED_URLS=https://example-node.local:8314,https://203.0.113.10:8314
 # CANARY_BTC_RPC_EXPLORER_URLS=https://example-node.local:49389,https://203.0.113.10:49389
 
 # On Umbrel, explorers can be auto-detected via ports set by exports.sh:

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -80,6 +80,11 @@ CANARY_SELF_HOSTED_ADMIN_PASSWORD=replace-with-a-strong-password
 # CANARY_MEMPOOL_URL=http://umbrel.local:3006
 # CANARY_BITFEED_URL=http://umbrel.local:8314
 # CANARY_BTC_RPC_EXPLORER_URL=http://umbrel.local:3002
+#
+# Packaging layers can also provide multiple browser-facing URLs for one explorer.
+# Canary will choose the URL matching the hostname used to open Canary when possible.
+# CANARY_MEMPOOL_URLS=https://example-node.local:52127,https://203.0.113.10:52127
+# CANARY_BTC_RPC_EXPLORER_URLS=https://example-node.local:49389,https://203.0.113.10:49389
 
 # On Umbrel, explorers can be auto-detected via ports set by exports.sh:
 # CANARY_MEMPOOL_PORT=3006

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1345,6 +1345,10 @@ mod tests {
         assert_eq!(config.tx_explorers().len(), 2);
         assert_eq!(config.tx_explorers()[0].id, "mempool");
         assert_eq!(
+            config.tx_explorers()[0].base_url,
+            Some("https://example-node.local:52127".to_string())
+        );
+        assert_eq!(
             config.tx_explorers()[0].base_urls,
             vec![
                 "https://example-node.local:52127".to_string(),

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -11,6 +11,8 @@ pub struct TxExplorerConfig {
     pub id: String,
     pub name: String,
     pub base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub base_urls: Vec<String>,
     pub port: Option<u16>,
 }
 
@@ -38,10 +40,24 @@ impl NtfyServerConfig {
 }
 
 impl TxExplorerConfig {
-    fn new(id: &str, name: &str, base_url: Option<String>, port: Option<u16>) -> Option<Self> {
+    fn new(
+        id: &str,
+        name: &str,
+        base_url: Option<String>,
+        base_urls: Vec<String>,
+        port: Option<u16>,
+    ) -> Option<Self> {
         let normalized_base_url = base_url.map(|url| url.trim_end_matches('/').to_string());
+        let mut normalized_base_urls = Vec::new();
 
-        if normalized_base_url.is_none() && port.is_none() {
+        for url in normalized_base_url.iter().chain(base_urls.iter()) {
+            let normalized_url = url.trim().trim_end_matches('/').to_string();
+            if !normalized_url.is_empty() && !normalized_base_urls.contains(&normalized_url) {
+                normalized_base_urls.push(normalized_url);
+            }
+        }
+
+        if normalized_base_url.is_none() && normalized_base_urls.is_empty() && port.is_none() {
             return None;
         }
 
@@ -49,6 +65,7 @@ impl TxExplorerConfig {
             id: id.to_string(),
             name: name.to_string(),
             base_url: normalized_base_url,
+            base_urls: normalized_base_urls,
             port,
         })
     }
@@ -186,23 +203,43 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
+    fn normalize_url_env_value(var_name: &str, url: &str) -> Option<String> {
+        let trimmed_url = url.trim();
+        if trimmed_url.is_empty() {
+            tracing::warn!("{} contains a blank URL and it will be ignored", var_name);
+            None
+        } else if trimmed_url.starts_with("http://") || trimmed_url.starts_with("https://") {
+            Some(trimmed_url.trim_end_matches('/').to_string())
+        } else {
+            tracing::warn!(
+                "{} must contain URLs that start with http:// or https://: '{}' - ignoring",
+                var_name,
+                url
+            );
+            None
+        }
+    }
+
     fn parse_url_env(var_name: &str) -> Option<String> {
-        std::env::var(var_name).ok().and_then(|url| {
-            let trimmed_url = url.trim();
-            if trimmed_url.is_empty() {
-                tracing::warn!("{} is blank and will be ignored", var_name);
-                None
-            } else if trimmed_url.starts_with("http://") || trimmed_url.starts_with("https://") {
-                Some(trimmed_url.trim_end_matches('/').to_string())
-            } else {
-                tracing::warn!(
-                    "{} must start with http:// or https://: '{}' - ignoring",
-                    var_name,
-                    url
-                );
-                None
+        std::env::var(var_name)
+            .ok()
+            .and_then(|url| Self::normalize_url_env_value(var_name, &url))
+    }
+
+    fn parse_url_list_env(var_name: &str) -> Vec<String> {
+        let mut urls = Vec::new();
+
+        if let Ok(raw_urls) = std::env::var(var_name) {
+            for raw_url in raw_urls.split(',') {
+                if let Some(url) = Self::normalize_url_env_value(var_name, raw_url) {
+                    if !urls.contains(&url) {
+                        urls.push(url);
+                    }
+                }
             }
-        })
+        }
+
+        urls
     }
 
     fn require_non_empty_config<'a>(
@@ -288,24 +325,40 @@ impl AppConfig {
 
         // Load self-hosted tx explorer configuration (optional)
         let mempool_url = Self::parse_url_env("CANARY_MEMPOOL_URL");
+        let mempool_urls = Self::parse_url_list_env("CANARY_MEMPOOL_URLS");
         let mempool_port = std::env::var("CANARY_MEMPOOL_PORT")
             .ok()
             .and_then(|s| s.parse().ok());
         let bitfeed_url = Self::parse_url_env("CANARY_BITFEED_URL");
+        let bitfeed_urls = Self::parse_url_list_env("CANARY_BITFEED_URLS");
         let bitfeed_port = std::env::var("CANARY_BITFEED_PORT")
             .ok()
             .and_then(|s| s.parse().ok());
         let btc_rpc_explorer_url = Self::parse_url_env("CANARY_BTC_RPC_EXPLORER_URL");
+        let btc_rpc_explorer_urls = Self::parse_url_list_env("CANARY_BTC_RPC_EXPLORER_URLS");
         let btc_rpc_explorer_port = std::env::var("CANARY_BTC_RPC_EXPLORER_PORT")
             .ok()
             .and_then(|s| s.parse().ok());
         let tx_explorers = [
-            TxExplorerConfig::new("mempool", "Mempool", mempool_url, mempool_port),
-            TxExplorerConfig::new("bitfeed", "Bitfeed", bitfeed_url, bitfeed_port),
+            TxExplorerConfig::new(
+                "mempool",
+                "Mempool",
+                mempool_url,
+                mempool_urls,
+                mempool_port,
+            ),
+            TxExplorerConfig::new(
+                "bitfeed",
+                "Bitfeed",
+                bitfeed_url,
+                bitfeed_urls,
+                bitfeed_port,
+            ),
             TxExplorerConfig::new(
                 "btc-rpc-explorer",
                 "BTC RPC Explorer",
                 btc_rpc_explorer_url,
+                btc_rpc_explorer_urls,
                 btc_rpc_explorer_port,
             ),
         ]
@@ -1235,6 +1288,87 @@ mod tests {
         restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
         restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
         restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
+    }
+
+    #[test]
+    fn test_tx_explorer_url_list_env_validates_and_deduplicates_urls() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mempool_urls = std::env::var("CANARY_MEMPOOL_URLS").ok();
+
+        std::env::set_var(
+            "CANARY_MEMPOOL_URLS",
+            " https://example-node.local:52127/ , not-a-url, https://example-node.local:52127, https://203.0.113.10:52127 ",
+        );
+
+        assert_eq!(
+            AppConfig::parse_url_list_env("CANARY_MEMPOOL_URLS"),
+            vec![
+                "https://example-node.local:52127".to_string(),
+                "https://203.0.113.10:52127".to_string()
+            ]
+        );
+
+        restore_env_var("CANARY_MEMPOOL_URLS", previous_mempool_urls);
+    }
+
+    #[test]
+    fn test_load_detects_tx_explorer_url_lists_in_self_hosted_mode() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_jwt = std::env::var("JWT_SECRET").ok();
+        let previous_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
+        let previous_mempool_url = std::env::var("CANARY_MEMPOOL_URL").ok();
+        let previous_mempool_urls = std::env::var("CANARY_MEMPOOL_URLS").ok();
+        let previous_btc_rpc_explorer_urls = std::env::var("CANARY_BTC_RPC_EXPLORER_URLS").ok();
+
+        std::env::set_var("CANARY_MODE", "self-hosted");
+        std::env::set_var("JWT_SECRET", "test-jwt-secret");
+        std::env::set_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", "test-admin-password");
+        std::env::set_var("CANARY_MEMPOOL_URL", "https://example-node.local:52127");
+        std::env::set_var(
+            "CANARY_MEMPOOL_URLS",
+            "https://example-node.local:52127,https://203.0.113.10:52127",
+        );
+        std::env::set_var(
+            "CANARY_BTC_RPC_EXPLORER_URLS",
+            "https://example-node.local:49389,https://203.0.113.10:49389",
+        );
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Mainnet),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .expect("self-hosted config should load");
+
+        assert_eq!(config.tx_explorers().len(), 2);
+        assert_eq!(config.tx_explorers()[0].id, "mempool");
+        assert_eq!(
+            config.tx_explorers()[0].base_urls,
+            vec![
+                "https://example-node.local:52127".to_string(),
+                "https://203.0.113.10:52127".to_string(),
+            ]
+        );
+        assert_eq!(config.tx_explorers()[1].id, "btc-rpc-explorer");
+        assert_eq!(
+            config.tx_explorers()[1].base_urls,
+            vec![
+                "https://example-node.local:49389".to_string(),
+                "https://203.0.113.10:49389".to_string(),
+            ]
+        );
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("JWT_SECRET", previous_jwt);
+        restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
+        restore_env_var("CANARY_MEMPOOL_URL", previous_mempool_url);
+        restore_env_var("CANARY_MEMPOOL_URLS", previous_mempool_urls);
+        restore_env_var(
+            "CANARY_BTC_RPC_EXPLORER_URLS",
+            previous_btc_rpc_explorer_urls,
+        );
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -47,7 +47,9 @@ impl TxExplorerConfig {
         base_urls: Vec<String>,
         port: Option<u16>,
     ) -> Option<Self> {
-        let normalized_base_url = base_url.map(|url| url.trim().trim_end_matches('/').to_string());
+        let normalized_base_url = base_url
+            .map(|url| url.trim().trim_end_matches('/').to_string())
+            .filter(|url| !url.is_empty());
         let mut normalized_base_urls = Vec::new();
 
         for url in normalized_base_url.iter().chain(base_urls.iter()) {
@@ -1372,6 +1374,14 @@ mod tests {
         restore_env_var(
             "CANARY_BTC_RPC_EXPLORER_URLS",
             previous_btc_rpc_explorer_urls,
+        );
+    }
+
+    #[test]
+    fn test_tx_explorer_config_rejects_blank_base_url() {
+        assert!(
+            TxExplorerConfig::new("mempool", "Mempool", Some("   ".to_string()), vec![], None,)
+                .is_none()
         );
     }
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -47,7 +47,7 @@ impl TxExplorerConfig {
         base_urls: Vec<String>,
         port: Option<u16>,
     ) -> Option<Self> {
-        let normalized_base_url = base_url.map(|url| url.trim_end_matches('/').to_string());
+        let normalized_base_url = base_url.map(|url| url.trim().trim_end_matches('/').to_string());
         let mut normalized_base_urls = Vec::new();
 
         for url in normalized_base_url.iter().chain(base_urls.iter()) {

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -212,7 +212,7 @@ impl AppConfig {
             Some(trimmed_url.trim_end_matches('/').to_string())
         } else {
             tracing::warn!(
-                "{} must contain URLs that start with http:// or https://: '{}' - ignoring",
+                "{} contains a URL that does not start with http:// or https://: '{}' - ignoring",
                 var_name,
                 url
             );

--- a/backend/src/email_provider.rs
+++ b/backend/src/email_provider.rs
@@ -149,8 +149,7 @@ impl NotificationProvider for EmailProvider {
         let batch_results = email_service.send_batch_emails(batch_requests).await;
 
         // Process results and return
-        for ((method, message, _), result) in batch_data.into_iter().zip(batch_results.into_iter())
-        {
+        for ((method, message, _), result) in batch_data.into_iter().zip(batch_results) {
             match result {
                 Ok(_) => {
                     // Email queued successfully

--- a/backend/tests/config_endpoint_tests.rs
+++ b/backend/tests/config_endpoint_tests.rs
@@ -155,6 +155,7 @@ async fn test_config_endpoint_self_hosted_with_single_tx_explorer() {
         id: "mempool".to_string(),
         name: "Mempool".to_string(),
         base_url: Some("http://umbrel.local:3006".to_string()),
+        base_urls: Vec::new(),
         port: None,
     }]);
 
@@ -194,12 +195,14 @@ async fn test_config_endpoint_self_hosted_with_multiple_tx_explorers() {
             id: "mempool".to_string(),
             name: "Mempool".to_string(),
             base_url: None,
+            base_urls: Vec::new(),
             port: Some(3006),
         },
         TxExplorerConfig {
             id: "bitfeed".to_string(),
             name: "Bitfeed".to_string(),
             base_url: None,
+            base_urls: Vec::new(),
             port: Some(8314),
         },
     ]);
@@ -263,6 +266,7 @@ async fn test_config_endpoint_cloud_mode_ignores_self_hosted_tx_explorers() {
         id: "mempool".to_string(),
         name: "Mempool".to_string(),
         base_url: Some("http://umbrel.local:3006".to_string()),
+        base_urls: Vec::new(),
         port: None,
     }]);
 
@@ -296,6 +300,7 @@ async fn test_user_preferences_accepts_supported_tx_explorer_ids() {
         id: "bitfeed".to_string(),
         name: "Bitfeed".to_string(),
         base_url: None,
+        base_urls: Vec::new(),
         port: Some(8314),
     }]);
     let (app, app_services, _temp_dir) = create_test_app_with_config_and_services(config).await;
@@ -410,6 +415,7 @@ async fn test_user_preferences_cloud_mode_rejects_local_tx_explorer_ids() {
         id: "bitfeed".to_string(),
         name: "Bitfeed".to_string(),
         base_url: Some("http://umbrel.local:8314".to_string()),
+        base_urls: Vec::new(),
         port: None,
     }]);
     let (app, app_services, _temp_dir) = create_test_app_with_config_and_services(config).await;

--- a/backend/tests/config_endpoint_tests.rs
+++ b/backend/tests/config_endpoint_tests.rs
@@ -155,7 +155,7 @@ async fn test_config_endpoint_self_hosted_with_single_tx_explorer() {
         id: "mempool".to_string(),
         name: "Mempool".to_string(),
         base_url: Some("http://umbrel.local:3006".to_string()),
-        base_urls: Vec::new(),
+        base_urls: vec!["http://umbrel.local:3006".to_string()],
         port: None,
     }]);
 
@@ -176,7 +176,10 @@ async fn test_config_endpoint_self_hosted_with_single_tx_explorer() {
         body["tx_explorers"][0]["base_url"],
         "http://umbrel.local:3006"
     );
-    assert!(body["tx_explorers"][0].get("base_urls").is_none());
+    assert_eq!(
+        body["tx_explorers"][0]["base_urls"],
+        json!(["http://umbrel.local:3006"])
+    );
     assert!(body["tx_explorers"][0]["port"].is_null());
 }
 

--- a/backend/tests/config_endpoint_tests.rs
+++ b/backend/tests/config_endpoint_tests.rs
@@ -176,7 +176,52 @@ async fn test_config_endpoint_self_hosted_with_single_tx_explorer() {
         body["tx_explorers"][0]["base_url"],
         "http://umbrel.local:3006"
     );
+    assert!(body["tx_explorers"][0].get("base_urls").is_none());
     assert!(body["tx_explorers"][0]["port"].is_null());
+}
+
+#[tokio::test]
+async fn test_config_endpoint_self_hosted_serializes_tx_explorer_base_urls() {
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        tempdir().unwrap().path().to_str().unwrap().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        None,
+    )
+    .with_tx_explorers(vec![TxExplorerConfig {
+        id: "mempool".to_string(),
+        name: "Mempool".to_string(),
+        base_url: None,
+        base_urls: vec![
+            "https://example-node.local:52127".to_string(),
+            "https://203.0.113.10:52127".to_string(),
+        ],
+        port: None,
+    }]);
+
+    let app = create_test_app_with_config(config).await;
+
+    let request = Request::builder()
+        .uri("/api/config")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = body_to_json(response.into_body()).await;
+    assert_eq!(body["tx_explorers"][0]["id"], "mempool");
+    assert!(body["tx_explorers"][0]["base_url"].is_null());
+    assert_eq!(
+        body["tx_explorers"][0]["base_urls"],
+        json!([
+            "https://example-node.local:52127",
+            "https://203.0.113.10:52127"
+        ])
+    );
 }
 
 #[tokio::test]

--- a/frontend/src/lib/__tests__/tx-explorers.test.ts
+++ b/frontend/src/lib/__tests__/tx-explorers.test.ts
@@ -3,6 +3,7 @@ import {
   PUBLIC_TX_EXPLORERS,
   buildTransactionExplorerUrl,
   buildTxExplorerOptions,
+  resolveExplorerBaseUrl,
   resolveSelectedTxExplorer,
 } from "../tx-explorers"
 
@@ -78,11 +79,6 @@ describe("tx explorer helpers", () => {
       id: "mempool",
       name: "Mempool",
       baseUrl: "https://example-node.local:52127",
-      candidateUrls: [
-        "https://192.0.2.10:52127",
-        "https://example-node.local:52127",
-        "https://203.0.113.10:52127",
-      ],
       isLocal: true,
     })
   })
@@ -116,12 +112,47 @@ describe("tx explorer helpers", () => {
       id: "btc-rpc-explorer",
       name: "BTC RPC Explorer",
       baseUrl: "https://192.0.2.10:49389",
-      candidateUrls: [
-        "https://192.0.2.10:49389",
-        "https://example-node.local:49389",
-      ],
       isLocal: true,
     })
+  })
+
+  it("resolves explorer base URLs before falling back to explicit base URL and port", () => {
+    expect(
+      resolveExplorerBaseUrl(
+        {
+          id: "mempool",
+          name: "Mempool",
+          base_url: "https://fallback.example:3006",
+          base_urls: ["https://example-node.local:52127"],
+          port: 3006,
+        },
+        { protocol: "https:", hostname: "example-node.local" }
+      )
+    ).toBe("https://example-node.local:52127")
+
+    expect(
+      resolveExplorerBaseUrl(
+        {
+          id: "mempool",
+          name: "Mempool",
+          base_url: "https://fallback.example:3006/",
+          port: 3006,
+        },
+        { protocol: "https:", hostname: "example-node.local" }
+      )
+    ).toBe("https://fallback.example:3006")
+
+    expect(
+      resolveExplorerBaseUrl(
+        {
+          id: "mempool",
+          name: "Mempool",
+          base_url: null,
+          port: 3006,
+        },
+        { protocol: "https:", hostname: "example-node.local" }
+      )
+    ).toBe("https://example-node.local:3006")
   })
 
   it("uses saved mempool-space preference even when local mempool is available", () => {

--- a/frontend/src/lib/__tests__/tx-explorers.test.ts
+++ b/frontend/src/lib/__tests__/tx-explorers.test.ts
@@ -83,6 +83,39 @@ describe("tx explorer helpers", () => {
     })
   })
 
+  it("chooses a local candidate URL matching the current browser protocol", () => {
+    const options = buildTxExplorerOptions(
+      {
+        tx_explorers: [
+          {
+            id: "mempool",
+            name: "Mempool",
+            base_url: "https://fallback.example:3006",
+            base_urls: [
+              "http://example-node.local:52127",
+              "https://example-node.local:52127",
+            ],
+            port: null,
+          },
+        ],
+        default_tx_explorer_id: "mempool-space",
+        ntfy_servers: [],
+        default_ntfy_server_id: "ntfy-sh",
+      },
+      {
+        protocol: "https:",
+        hostname: "example-node.local",
+      }
+    )
+
+    expect(options).toContainEqual({
+      id: "mempool",
+      name: "Mempool",
+      baseUrl: "https://example-node.local:52127",
+      isLocal: true,
+    })
+  })
+
   it("falls back to the first candidate URL when no browser hostname matches", () => {
     const options = buildTxExplorerOptions(
       {

--- a/frontend/src/lib/__tests__/tx-explorers.test.ts
+++ b/frontend/src/lib/__tests__/tx-explorers.test.ts
@@ -48,6 +48,82 @@ describe("tx explorer helpers", () => {
     expect(DEFAULT_TX_EXPLORER.id).toBe("mempool-space")
   })
 
+  it("chooses a local candidate URL matching the current browser hostname", () => {
+    const options = buildTxExplorerOptions(
+      {
+        tx_explorers: [
+          {
+            id: "mempool",
+            name: "Mempool",
+            base_url: null,
+            base_urls: [
+              "https://192.0.2.10:52127",
+              "https://example-node.local:52127",
+              "https://203.0.113.10:52127",
+            ],
+            port: null,
+          },
+        ],
+        default_tx_explorer_id: "mempool-space",
+        ntfy_servers: [],
+        default_ntfy_server_id: "ntfy-sh",
+      },
+      {
+        protocol: "https:",
+        hostname: "example-node.local",
+      }
+    )
+
+    expect(options).toContainEqual({
+      id: "mempool",
+      name: "Mempool",
+      baseUrl: "https://example-node.local:52127",
+      candidateUrls: [
+        "https://192.0.2.10:52127",
+        "https://example-node.local:52127",
+        "https://203.0.113.10:52127",
+      ],
+      isLocal: true,
+    })
+  })
+
+  it("falls back to the first candidate URL when no browser hostname matches", () => {
+    const options = buildTxExplorerOptions(
+      {
+        tx_explorers: [
+          {
+            id: "btc-rpc-explorer",
+            name: "BTC RPC Explorer",
+            base_url: null,
+            base_urls: [
+              "https://192.0.2.10:49389",
+              "https://example-node.local:49389",
+            ],
+            port: null,
+          },
+        ],
+        default_tx_explorer_id: "mempool-space",
+        ntfy_servers: [],
+        default_ntfy_server_id: "ntfy-sh",
+      },
+      {
+        protocol: "https:",
+        hostname: "example.onion",
+      }
+    )
+
+    expect(options).toContainEqual({
+      id: "btc-rpc-explorer",
+      name: "BTC RPC Explorer",
+      baseUrl: "https://192.0.2.10:49389",
+      candidateUrls: [
+        "https://192.0.2.10:49389",
+        "https://example-node.local:49389",
+      ],
+      isLocal: true,
+    })
+  })
+
   it("uses saved mempool-space preference even when local mempool is available", () => {
     const selected = resolveSelectedTxExplorer(
       [

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -21,6 +21,7 @@ export interface TxExplorerConfig {
   id: string
   name: string
   base_url: string | null
+  base_urls?: string[]
   port: number | null
 }
 

--- a/frontend/src/lib/tx-explorers.ts
+++ b/frontend/src/lib/tx-explorers.ts
@@ -4,6 +4,7 @@ export interface TxExplorerOption {
   id: string
   name: string
   baseUrl: string
+  candidateUrls?: string[]
   isLocal: boolean
 }
 
@@ -36,13 +37,70 @@ interface LocationLike {
 }
 
 function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "")
+  return baseUrl.trim().replace(/\/+$/, "")
+}
+
+function isBrowserSafeUrl(baseUrl: string): boolean {
+  try {
+    const parsed = new URL(baseUrl)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function uniqueNormalizedUrls(urls: string[]): string[] {
+  const normalizedUrls: string[] = []
+
+  for (const url of urls) {
+    const normalizedUrl = normalizeBaseUrl(url)
+    if (
+      normalizedUrl &&
+      isBrowserSafeUrl(normalizedUrl) &&
+      !normalizedUrls.includes(normalizedUrl)
+    ) {
+      normalizedUrls.push(normalizedUrl)
+    }
+  }
+
+  return normalizedUrls
+}
+
+function chooseBestCandidateUrl(
+  candidateUrls: string[],
+  location: LocationLike | null
+): string | null {
+  if (candidateUrls.length === 0) {
+    return null
+  }
+
+  if (location) {
+    const matchingUrl = candidateUrls.find((candidateUrl) => {
+      try {
+        return new URL(candidateUrl).hostname === location.hostname
+      } catch {
+        return false
+      }
+    })
+
+    if (matchingUrl) {
+      return matchingUrl
+    }
+  }
+
+  return candidateUrls[0]
 }
 
 export function resolveExplorerBaseUrl(
   explorer: TxExplorerConfig,
   location: LocationLike | null
 ): string | null {
+  const candidateUrls = uniqueNormalizedUrls(explorer.base_urls ?? [])
+  const bestCandidateUrl = chooseBestCandidateUrl(candidateUrls, location)
+  if (bestCandidateUrl) {
+    return bestCandidateUrl
+  }
+
   if (explorer.base_url) {
     return normalizeBaseUrl(explorer.base_url)
   }
@@ -61,6 +119,7 @@ export function buildTxExplorerOptions(
   const options = [...PUBLIC_TX_EXPLORERS]
 
   for (const explorer of config.tx_explorers) {
+    const candidateUrls = uniqueNormalizedUrls(explorer.base_urls ?? [])
     const baseUrl = resolveExplorerBaseUrl(explorer, location)
     if (!baseUrl) continue
 
@@ -68,6 +127,7 @@ export function buildTxExplorerOptions(
       id: explorer.id,
       name: explorer.name,
       baseUrl,
+      ...(candidateUrls.length > 0 ? { candidateUrls } : {}),
       isLocal: true,
     })
   }

--- a/frontend/src/lib/tx-explorers.ts
+++ b/frontend/src/lib/tx-explorers.ts
@@ -101,7 +101,7 @@ export function resolveExplorerBaseUrl(
     return bestCandidateUrl
   }
 
-  if (explorer.base_url) {
+  if (explorer.base_url && isBrowserSafeUrl(explorer.base_url)) {
     return normalizeBaseUrl(explorer.base_url)
   }
 

--- a/frontend/src/lib/tx-explorers.ts
+++ b/frontend/src/lib/tx-explorers.ts
@@ -74,10 +74,12 @@ function chooseBestCandidateUrl(
   }
 
   if (location) {
-    // Match by hostname only because Canary and the explorer normally use different ports.
+    // Match the browser scheme to avoid mixed-content blocks, but ignore ports because
+    // Canary and the explorer normally listen on different ports.
     const matchingUrl = candidateUrls.find((candidateUrl) => {
       try {
-        return new URL(candidateUrl).hostname === location.hostname
+        const parsedUrl = new URL(candidateUrl)
+        return parsedUrl.protocol === location.protocol && parsedUrl.hostname === location.hostname
       } catch {
         return false
       }

--- a/frontend/src/lib/tx-explorers.ts
+++ b/frontend/src/lib/tx-explorers.ts
@@ -4,7 +4,6 @@ export interface TxExplorerOption {
   id: string
   name: string
   baseUrl: string
-  candidateUrls?: string[]
   isLocal: boolean
 }
 
@@ -75,6 +74,7 @@ function chooseBestCandidateUrl(
   }
 
   if (location) {
+    // Match by hostname only because Canary and the explorer normally use different ports.
     const matchingUrl = candidateUrls.find((candidateUrl) => {
       try {
         return new URL(candidateUrl).hostname === location.hostname
@@ -119,7 +119,6 @@ export function buildTxExplorerOptions(
   const options = [...PUBLIC_TX_EXPLORERS]
 
   for (const explorer of config.tx_explorers) {
-    const candidateUrls = uniqueNormalizedUrls(explorer.base_urls ?? [])
     const baseUrl = resolveExplorerBaseUrl(explorer, location)
     if (!baseUrl) continue
 
@@ -127,7 +126,6 @@ export function buildTxExplorerOptions(
       id: explorer.id,
       name: explorer.name,
       baseUrl,
-      ...(candidateUrls.length > 0 ? { candidateUrls } : {}),
       isLocal: true,
     })
   }


### PR DESCRIPTION
## Summary\n- add support for multiple browser-facing transaction explorer URLs per explorer\n- choose the URL matching the hostname used to open Canary when possible\n- document the new URL-list env vars for self-hosted packaging layers\n\n## Testing\n- cargo test test_tx_explorer_url_list_env_validates_and_deduplicates_urls\n- cargo test test_load_detects_tx_explorer_url_lists_in_self_hosted_mode\n- fnm exec --using 22.22.0 pnpm test src/lib/__tests__/tx-explorers.test.ts --runInBand\n- cmux browser test with simulated local Mempool and BTC RPC Explorer URLs\n\nPhysical StartOS/Umbrel device testing will happen before the next release.