### PR TITLE
Add managed StartOS ntfy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Real-time notifications in 9 languages via **[ntfy.sh](https://ntfy.sh)** push n
 **Supported Languages:** English, Norwegian, Spanish, Portuguese, German, French, Japanese, Danish, Swedish
 
 > **Umbrel / Docker note:** On Umbrel, Canary auto-detects the local ntfy app through the Docker-internal URL provided by the Umbrel package. You should not need to enter `http://ntfy_app_1` manually. Use "Send Test Notification" in Settings to verify your configuration.
+>
+> **StartOS note:** StartOS packages can provision a scoped local ntfy publisher and pass it to Canary with `CANARY_NTFY_SERVER_URL`, `CANARY_NTFY_TOKEN`, and `CANARY_NTFY_TOPIC`. These values are used as defaults; settings saved in Canary remain authoritative.
 
 ## Self-Hosted vs. canarybitcoin.com
 

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -36,6 +36,13 @@ CANARY_SELF_HOSTED_ADMIN_PASSWORD=replace-with-a-strong-password
 # Most operators should not set this manually; Umbrel exports.sh sets it automatically.
 # Use NTFY_SERVER_URL for custom servers outside detected app integrations.
 # CANARY_UMBREL_NTFY_URL=http://ntfy_app_1
+#
+# Package-provisioned local ntfy defaults (OPTIONAL)
+# StartOS packages can set these after calling ntfy's provision-publisher action.
+# These values are defaults only; user-saved Canary Settings still win.
+# CANARY_NTFY_SERVER_URL=http://ntfy.startos
+# CANARY_NTFY_TOKEN=tk_...
+# CANARY_NTFY_TOPIC=canary
 
 #############################################
 # SELF-HOSTED MODE FEATURES

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -29,6 +29,9 @@ pub struct NtfyServerConfig {
     pub managed_auth: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManagedNtfyAccessToken(String);
+
 impl NtfyServerConfig {
     fn new(id: &str, name: &str, base_url: Option<String>, platform: Option<&str>) -> Option<Self> {
         Self::new_with_defaults(id, name, base_url, platform, None, false)
@@ -211,7 +214,7 @@ pub struct AppConfig {
     /// Default ntfy server URL used when no user or local server preference applies.
     ntfy_fallback_url: String,
     /// Scoped token for a package-provided ntfy server. Never serialized.
-    managed_ntfy_access_token: Option<String>,
+    managed_ntfy_access_token: Option<ManagedNtfyAccessToken>,
     /// BTCPay Server URL (e.g., https://btcpay.enogtjue.no)
     btcpay_url: Option<String>,
     /// BTCPay Server API key
@@ -442,6 +445,14 @@ impl AppConfig {
         }
         if operating_mode == OperatingMode::SelfHosted
             && startos_ntfy_url.is_some()
+            && startos_ntfy_token.is_none()
+        {
+            tracing::warn!(
+                "CANARY_NTFY_SERVER_URL is set without CANARY_NTFY_TOKEN; provisioned ntfy server will be available without managed auth"
+            );
+        }
+        if operating_mode == OperatingMode::SelfHosted
+            && startos_ntfy_url.is_some()
             && umbrel_ntfy_url.is_some()
         {
             tracing::warn!(
@@ -486,7 +497,7 @@ impl AppConfig {
         };
         let managed_ntfy_access_token =
             if operating_mode == OperatingMode::SelfHosted && has_managed_startos_auth {
-                startos_ntfy_token
+                startos_ntfy_token.map(ManagedNtfyAccessToken)
             } else {
                 None
             };
@@ -723,7 +734,9 @@ impl AppConfig {
             });
 
         if matches_managed_server {
-            self.managed_ntfy_access_token.clone()
+            self.managed_ntfy_access_token
+                .as_ref()
+                .map(|token| token.0.clone())
         } else {
             None
         }
@@ -1000,7 +1013,7 @@ impl AppConfig {
     /// Set package-managed ntfy access token on a test config (builder pattern)
     #[cfg(test)]
     pub fn with_managed_ntfy_access_token(mut self, token: &str) -> Self {
-        self.managed_ntfy_access_token = Some(token.to_string());
+        self.managed_ntfy_access_token = Some(ManagedNtfyAccessToken(token.to_string()));
         self
     }
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -440,6 +440,14 @@ impl AppConfig {
                 "CANARY_NTFY_TOKEN or CANARY_NTFY_TOPIC is set without CANARY_NTFY_SERVER_URL; provisioned ntfy defaults will be ignored"
             );
         }
+        if operating_mode == OperatingMode::SelfHosted
+            && startos_ntfy_url.is_some()
+            && umbrel_ntfy_url.is_some()
+        {
+            tracing::warn!(
+                "Both CANARY_NTFY_SERVER_URL and CANARY_UMBREL_NTFY_URL are set; multiple detected ntfy servers will be listed and no local ntfy default will be selected automatically"
+            );
+        }
         if operating_mode == OperatingMode::SelfHosted && configured_ntfy_fallback_url.is_some() {
             if startos_ntfy_url.is_some() {
                 tracing::warn!(
@@ -1520,6 +1528,91 @@ mod tests {
     }
 
     #[test]
+    fn test_load_ignores_invalid_startos_ntfy_topic() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_jwt = std::env::var("JWT_SECRET").ok();
+        let previous_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
+        let previous_server_url = std::env::var("CANARY_NTFY_SERVER_URL").ok();
+        let previous_token = std::env::var("CANARY_NTFY_TOKEN").ok();
+        let previous_topic = std::env::var("CANARY_NTFY_TOPIC").ok();
+        let previous_umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
+        std::env::set_var("CANARY_MODE", "self-hosted");
+        std::env::set_var("JWT_SECRET", "test-jwt-secret");
+        std::env::set_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", "test-admin-password");
+        std::env::set_var("CANARY_NTFY_SERVER_URL", "http://ntfy.startos/");
+        std::env::set_var("CANARY_NTFY_TOKEN", "tk_test");
+        std::env::set_var("CANARY_NTFY_TOPIC", "canary/topic");
+        std::env::remove_var("CANARY_UMBREL_NTFY_URL");
+        std::env::remove_var("NTFY_SERVER_URL");
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Mainnet),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .expect("self-hosted config should load");
+
+        assert_eq!(config.default_ntfy_server_id(), STARTOS_NTFY_SERVER_ID);
+        assert_eq!(config.ntfy_servers().len(), 1);
+        assert_eq!(config.ntfy_servers()[0].default_topic, None);
+        assert!(config.ntfy_servers()[0].managed_auth);
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("JWT_SECRET", previous_jwt);
+        restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
+        restore_env_var("CANARY_NTFY_SERVER_URL", previous_server_url);
+        restore_env_var("CANARY_NTFY_TOKEN", previous_token);
+        restore_env_var("CANARY_NTFY_TOPIC", previous_topic);
+        restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
+    }
+
+    #[test]
+    fn test_load_ignores_startos_ntfy_defaults_in_cloud_mode() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_server_url = std::env::var("CANARY_NTFY_SERVER_URL").ok();
+        let previous_token = std::env::var("CANARY_NTFY_TOKEN").ok();
+        let previous_topic = std::env::var("CANARY_NTFY_TOPIC").ok();
+        let previous_umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
+        std::env::set_var("CANARY_MODE", "cloud");
+        std::env::set_var("CANARY_NTFY_SERVER_URL", "http://ntfy.startos/");
+        std::env::set_var("CANARY_NTFY_TOKEN", "tk_test");
+        std::env::set_var("CANARY_NTFY_TOPIC", "canary");
+        std::env::remove_var("CANARY_UMBREL_NTFY_URL");
+        std::env::remove_var("NTFY_SERVER_URL");
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Mainnet),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .expect("cloud config should load");
+
+        assert_eq!(config.default_ntfy_server_id(), PUBLIC_NTFY_SERVER_ID);
+        assert_eq!(config.ntfy_server_url(), "https://ntfy.sh");
+        assert!(config.ntfy_servers().is_empty());
+        assert_eq!(
+            config.managed_ntfy_access_token_for_url("http://ntfy.startos", None),
+            None
+        );
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("CANARY_NTFY_SERVER_URL", previous_server_url);
+        restore_env_var("CANARY_NTFY_TOKEN", previous_token);
+        restore_env_var("CANARY_NTFY_TOPIC", previous_topic);
+        restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
+    }
+
+    #[test]
     fn test_load_does_not_guess_default_when_multiple_local_ntfy_servers_exist() {
         let _guard = ENV_LOCK.lock().unwrap();
         let previous_mode = std::env::var("CANARY_MODE").ok();
@@ -1779,6 +1872,48 @@ mod tests {
         let config = test_config(NetworkConfig::Mainnet);
 
         assert!(config.should_use_ntfy_auth_for_url("https://ntfy.sh", Some("https://ntfy.sh")));
+    }
+
+    #[test]
+    fn test_with_managed_ntfy_auth_only_fills_empty_auth_for_managed_server() {
+        let config = test_config_self_hosted(NetworkConfig::Mainnet)
+            .with_ntfy_servers(vec![NtfyServerConfig::new_with_defaults(
+                STARTOS_NTFY_SERVER_ID,
+                "ntfy",
+                Some("http://ntfy.startos".to_string()),
+                Some("startos"),
+                Some("canary".to_string()),
+                true,
+            )
+            .unwrap()])
+            .with_managed_ntfy_access_token("tk_managed");
+
+        match config.with_managed_ntfy_auth(NtfyAuth::None, "http://ntfy.startos", None) {
+            NtfyAuth::AccessToken(token) => assert_eq!(token, "tk_managed"),
+            other => panic!("expected managed access token, got {other:?}"),
+        }
+
+        match config.with_managed_ntfy_auth(
+            NtfyAuth::AccessToken("tk_user".to_string()),
+            "http://ntfy.startos",
+            None,
+        ) {
+            NtfyAuth::AccessToken(token) => assert_eq!(token, "tk_user"),
+            other => panic!("expected user access token, got {other:?}"),
+        }
+
+        assert!(matches!(
+            config.with_managed_ntfy_auth(NtfyAuth::None, "https://ntfy.sh", None),
+            NtfyAuth::None
+        ));
+        assert!(matches!(
+            config.with_managed_ntfy_auth(
+                NtfyAuth::None,
+                "http://ntfy.startos",
+                Some("http://ntfy.startos")
+            ),
+            NtfyAuth::None
+        ));
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -4,6 +4,7 @@ use clap::{Parser, ValueEnum};
 use serde::Serialize;
 
 pub const PUBLIC_NTFY_SERVER_ID: &str = "ntfy-sh";
+pub const STARTOS_NTFY_SERVER_ID: &str = "startos-ntfy";
 pub const UMBREL_NTFY_SERVER_ID: &str = "umbrel-ntfy";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -22,10 +23,23 @@ pub struct NtfyServerConfig {
     pub name: String,
     pub base_url: String,
     pub platform: Option<String>,
+    pub default_topic: Option<String>,
+    pub managed_auth: bool,
 }
 
 impl NtfyServerConfig {
     fn new(id: &str, name: &str, base_url: Option<String>, platform: Option<&str>) -> Option<Self> {
+        Self::new_with_defaults(id, name, base_url, platform, None, false)
+    }
+
+    fn new_with_defaults(
+        id: &str,
+        name: &str,
+        base_url: Option<String>,
+        platform: Option<&str>,
+        default_topic: Option<String>,
+        managed_auth: bool,
+    ) -> Option<Self> {
         let normalized_base_url = base_url
             .map(|url| url.trim().trim_end_matches('/').to_string())
             .filter(|url| !url.is_empty());
@@ -35,6 +49,8 @@ impl NtfyServerConfig {
             name: name.to_string(),
             base_url,
             platform: platform.map(str::to_string),
+            default_topic,
+            managed_auth,
         })
     }
 }
@@ -192,6 +208,8 @@ pub struct AppConfig {
     ntfy_servers: Vec<NtfyServerConfig>,
     /// Default ntfy server URL used when no user or local server preference applies.
     ntfy_fallback_url: String,
+    /// Scoped token for a package-provided ntfy server. Never serialized.
+    managed_ntfy_access_token: Option<String>,
     /// BTCPay Server URL (e.g., https://btcpay.enogtjue.no)
     btcpay_url: Option<String>,
     /// BTCPay Server API key
@@ -242,6 +260,31 @@ impl AppConfig {
         }
 
         urls
+    }
+
+    fn parse_non_empty_env(var_name: &str) -> Option<String> {
+        std::env::var(var_name)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    }
+
+    fn parse_ntfy_topic_env(var_name: &str) -> Option<String> {
+        let topic = Self::parse_non_empty_env(var_name)?;
+        let is_valid_topic = topic.len() <= 64
+            && topic
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+
+        if is_valid_topic {
+            Some(topic)
+        } else {
+            tracing::warn!(
+                "{} contains an invalid ntfy topic and will be ignored",
+                var_name
+            );
+            None
+        }
     }
 
     fn require_non_empty_config<'a>(
@@ -368,34 +411,71 @@ impl AppConfig {
         .flatten()
         .collect();
 
+        let startos_ntfy_url = Self::parse_url_env("CANARY_NTFY_SERVER_URL");
+        let startos_ntfy_token = Self::parse_non_empty_env("CANARY_NTFY_TOKEN");
+        let startos_ntfy_topic = Self::parse_ntfy_topic_env("CANARY_NTFY_TOPIC");
         let umbrel_ntfy_url = Self::parse_url_env("CANARY_UMBREL_NTFY_URL");
         let configured_ntfy_fallback_url = Self::parse_url_env("NTFY_SERVER_URL");
+        if operating_mode == OperatingMode::Cloud
+            && (startos_ntfy_url.is_some()
+                || startos_ntfy_token.is_some()
+                || startos_ntfy_topic.is_some())
+        {
+            tracing::warn!(
+                "CANARY_NTFY_* variables are only used in self-hosted mode; ignoring provisioned ntfy defaults in cloud mode"
+            );
+        }
         if operating_mode == OperatingMode::Cloud && umbrel_ntfy_url.is_some() {
             tracing::warn!(
                 "CANARY_UMBREL_NTFY_URL is only used in self-hosted mode; ignoring detected ntfy server in cloud mode"
             );
         }
         if operating_mode == OperatingMode::SelfHosted
-            && umbrel_ntfy_url.is_some()
+            && startos_ntfy_url.is_none()
+            && (startos_ntfy_token.is_some() || startos_ntfy_topic.is_some())
+        {
+            tracing::warn!(
+                "CANARY_NTFY_TOKEN or CANARY_NTFY_TOPIC is set without CANARY_NTFY_SERVER_URL; provisioned ntfy defaults will be ignored"
+            );
+        }
+        if operating_mode == OperatingMode::SelfHosted
+            && (startos_ntfy_url.is_some() || umbrel_ntfy_url.is_some())
             && configured_ntfy_fallback_url.is_some()
         {
             tracing::warn!(
-                "CANARY_UMBREL_NTFY_URL is set; detected Umbrel ntfy server will take precedence over NTFY_SERVER_URL"
+                "A detected ntfy server is set; detected local ntfy will take precedence over NTFY_SERVER_URL"
             );
         }
+        let has_managed_startos_auth = startos_ntfy_url.is_some() && startos_ntfy_token.is_some();
         let ntfy_servers = if operating_mode == OperatingMode::SelfHosted {
-            [NtfyServerConfig::new(
-                UMBREL_NTFY_SERVER_ID,
-                "ntfy",
-                umbrel_ntfy_url,
-                Some("umbrel"),
-            )]
+            [
+                NtfyServerConfig::new_with_defaults(
+                    STARTOS_NTFY_SERVER_ID,
+                    "ntfy",
+                    startos_ntfy_url,
+                    Some("startos"),
+                    startos_ntfy_topic,
+                    has_managed_startos_auth,
+                ),
+                NtfyServerConfig::new(
+                    UMBREL_NTFY_SERVER_ID,
+                    "ntfy",
+                    umbrel_ntfy_url,
+                    Some("umbrel"),
+                ),
+            ]
             .into_iter()
             .flatten()
             .collect()
         } else {
             Vec::new()
         };
+        let managed_ntfy_access_token =
+            if operating_mode == OperatingMode::SelfHosted && has_managed_startos_auth {
+                startos_ntfy_token
+            } else {
+                None
+            };
         let ntfy_fallback_url =
             configured_ntfy_fallback_url.unwrap_or_else(|| "https://ntfy.sh".to_string());
 
@@ -442,6 +522,7 @@ impl AppConfig {
             tx_explorers,
             ntfy_servers,
             ntfy_fallback_url,
+            managed_ntfy_access_token,
             btcpay_url,
             btcpay_api_key,
             btcpay_store_id,
@@ -603,6 +684,35 @@ impl AppConfig {
                 .ntfy_servers
                 .iter()
                 .any(|server| server.base_url.trim_end_matches('/') == normalized_server_url)
+    }
+
+    /// Return package-managed ntfy auth only for the exact detected server URL it belongs to.
+    pub fn managed_ntfy_access_token_for_url(
+        &self,
+        server_url: &str,
+        user_configured_server_url: Option<&str>,
+    ) -> Option<String> {
+        let normalized_server_url = server_url.trim().trim_end_matches('/');
+        let matches_user_configured_url = user_configured_server_url
+            .map(|url| url.trim().trim_end_matches('/'))
+            .filter(|url| !url.is_empty())
+            .is_some_and(|url| url == normalized_server_url);
+
+        if matches_user_configured_url {
+            return None;
+        }
+
+        let matches_managed_server = self.is_self_hosted_mode()
+            && self.ntfy_servers.iter().any(|server| {
+                server.managed_auth
+                    && server.base_url.trim_end_matches('/') == normalized_server_url
+            });
+
+        if matches_managed_server {
+            self.managed_ntfy_access_token.clone()
+        } else {
+            None
+        }
     }
 
     /// Auth may be sent only to explicitly configured user URLs or detected local integrations.
@@ -830,6 +940,7 @@ impl AppConfig {
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
             ntfy_fallback_url: "https://ntfy.sh".to_string(),
+            managed_ntfy_access_token: None,
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -853,6 +964,13 @@ impl AppConfig {
     /// Set ntfy fallback URL on a test config (builder pattern)
     pub fn with_ntfy_fallback_url(mut self, ntfy_fallback_url: &str) -> Self {
         self.ntfy_fallback_url = ntfy_fallback_url.to_string();
+        self
+    }
+
+    /// Set package-managed ntfy access token on a test config (builder pattern)
+    #[cfg(test)]
+    pub fn with_managed_ntfy_access_token(mut self, token: &str) -> Self {
+        self.managed_ntfy_access_token = Some(token.to_string());
         self
     }
 
@@ -943,6 +1061,7 @@ mod tests {
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
             ntfy_fallback_url: "https://ntfy.sh".to_string(),
+            managed_ntfy_access_token: None,
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -964,6 +1083,7 @@ mod tests {
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
             ntfy_fallback_url: "https://ntfy.sh".to_string(),
+            managed_ntfy_access_token: None,
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -985,6 +1105,7 @@ mod tests {
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
             ntfy_fallback_url: "https://ntfy.sh".to_string(),
+            managed_ntfy_access_token: None,
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1157,6 +1278,7 @@ mod tests {
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
             ntfy_fallback_url: "https://ntfy.sh".to_string(),
+            managed_ntfy_access_token: None,
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1256,6 +1378,72 @@ mod tests {
         restore_env_var("JWT_SECRET", previous_jwt);
         restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
         restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
+    }
+
+    #[test]
+    fn test_load_detects_startos_managed_ntfy_defaults_in_self_hosted_mode() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_jwt = std::env::var("JWT_SECRET").ok();
+        let previous_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
+        let previous_server_url = std::env::var("CANARY_NTFY_SERVER_URL").ok();
+        let previous_token = std::env::var("CANARY_NTFY_TOKEN").ok();
+        let previous_topic = std::env::var("CANARY_NTFY_TOPIC").ok();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
+        std::env::set_var("CANARY_MODE", "self-hosted");
+        std::env::set_var("JWT_SECRET", "test-jwt-secret");
+        std::env::set_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", "test-admin-password");
+        std::env::set_var("CANARY_NTFY_SERVER_URL", "http://ntfy.startos/");
+        std::env::set_var("CANARY_NTFY_TOKEN", " tk_test ");
+        std::env::set_var("CANARY_NTFY_TOPIC", "canary");
+        std::env::remove_var("NTFY_SERVER_URL");
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Mainnet),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .expect("self-hosted config should load");
+
+        assert_eq!(config.default_ntfy_server_id(), STARTOS_NTFY_SERVER_ID);
+        assert_eq!(config.ntfy_server_url(), "http://ntfy.startos");
+        assert_eq!(config.ntfy_servers().len(), 1);
+        assert_eq!(
+            config.ntfy_servers()[0].platform.as_deref(),
+            Some("startos")
+        );
+        assert_eq!(
+            config.ntfy_servers()[0].default_topic.as_deref(),
+            Some("canary")
+        );
+        assert!(config.ntfy_servers()[0].managed_auth);
+        assert_eq!(
+            config
+                .managed_ntfy_access_token_for_url("http://ntfy.startos", None)
+                .as_deref(),
+            Some("tk_test")
+        );
+        assert_eq!(
+            config.managed_ntfy_access_token_for_url(
+                "http://ntfy.startos",
+                Some("http://ntfy.startos")
+            ),
+            None
+        );
+        assert_eq!(
+            config.managed_ntfy_access_token_for_url("https://ntfy.sh", None),
+            None
+        );
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("JWT_SECRET", previous_jwt);
+        restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
+        restore_env_var("CANARY_NTFY_SERVER_URL", previous_server_url);
+        restore_env_var("CANARY_NTFY_TOKEN", previous_token);
+        restore_env_var("CANARY_NTFY_TOPIC", previous_topic);
         restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
     }
 
@@ -1511,6 +1699,7 @@ mod tests {
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
             ntfy_fallback_url: "https://ntfy.sh".to_string(),
+            managed_ntfy_access_token: None,
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1564,6 +1753,7 @@ mod tests {
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
             ntfy_fallback_url: "https://ntfy.sh".to_string(),
+            managed_ntfy_access_token: None,
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,
@@ -1591,6 +1781,7 @@ mod tests {
             tx_explorers: Vec::new(),
             ntfy_servers: Vec::new(),
             ntfy_fallback_url: "https://ntfy.sh".to_string(),
+            managed_ntfy_access_token: None,
             btcpay_url: None,
             btcpay_api_key: None,
             btcpay_store_id: None,

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -29,8 +29,14 @@ pub struct NtfyServerConfig {
     pub managed_auth: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 struct ManagedNtfyAccessToken(String);
+
+impl std::fmt::Debug for ManagedNtfyAccessToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ManagedNtfyAccessToken([redacted])")
+    }
+}
 
 impl NtfyServerConfig {
     fn new(id: &str, name: &str, base_url: Option<String>, platform: Option<&str>) -> Option<Self> {
@@ -1573,6 +1579,58 @@ mod tests {
         assert_eq!(config.ntfy_servers().len(), 1);
         assert_eq!(config.ntfy_servers()[0].default_topic, None);
         assert!(config.ntfy_servers()[0].managed_auth);
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("JWT_SECRET", previous_jwt);
+        restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
+        restore_env_var("CANARY_NTFY_SERVER_URL", previous_server_url);
+        restore_env_var("CANARY_NTFY_TOKEN", previous_token);
+        restore_env_var("CANARY_NTFY_TOPIC", previous_topic);
+        restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
+    }
+
+    #[test]
+    fn test_load_registers_startos_ntfy_url_without_managed_auth() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_jwt = std::env::var("JWT_SECRET").ok();
+        let previous_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
+        let previous_server_url = std::env::var("CANARY_NTFY_SERVER_URL").ok();
+        let previous_token = std::env::var("CANARY_NTFY_TOKEN").ok();
+        let previous_topic = std::env::var("CANARY_NTFY_TOPIC").ok();
+        let previous_umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
+        std::env::set_var("CANARY_MODE", "self-hosted");
+        std::env::set_var("JWT_SECRET", "test-jwt-secret");
+        std::env::set_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", "test-admin-password");
+        std::env::set_var("CANARY_NTFY_SERVER_URL", "http://ntfy.startos/");
+        std::env::remove_var("CANARY_NTFY_TOKEN");
+        std::env::set_var("CANARY_NTFY_TOPIC", "canary");
+        std::env::remove_var("CANARY_UMBREL_NTFY_URL");
+        std::env::remove_var("NTFY_SERVER_URL");
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Mainnet),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .expect("self-hosted config should load");
+
+        assert_eq!(config.default_ntfy_server_id(), STARTOS_NTFY_SERVER_ID);
+        assert_eq!(config.ntfy_servers().len(), 1);
+        assert_eq!(config.ntfy_servers()[0].base_url, "http://ntfy.startos");
+        assert_eq!(
+            config.ntfy_servers()[0].default_topic.as_deref(),
+            Some("canary")
+        );
+        assert!(!config.ntfy_servers()[0].managed_auth);
+        assert_eq!(
+            config.managed_ntfy_access_token_for_url("http://ntfy.startos", None),
+            None
+        );
 
         restore_env_var("CANARY_MODE", previous_mode);
         restore_env_var("JWT_SECRET", previous_jwt);

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -3,6 +3,8 @@ use bdk_wallet::bitcoin::Network;
 use clap::{Parser, ValueEnum};
 use serde::Serialize;
 
+use crate::ntfy_provider::NtfyAuth;
+
 pub const PUBLIC_NTFY_SERVER_ID: &str = "ntfy-sh";
 pub const STARTOS_NTFY_SERVER_ID: &str = "startos-ntfy";
 pub const UMBREL_NTFY_SERVER_ID: &str = "umbrel-ntfy";
@@ -438,13 +440,17 @@ impl AppConfig {
                 "CANARY_NTFY_TOKEN or CANARY_NTFY_TOPIC is set without CANARY_NTFY_SERVER_URL; provisioned ntfy defaults will be ignored"
             );
         }
-        if operating_mode == OperatingMode::SelfHosted
-            && (startos_ntfy_url.is_some() || umbrel_ntfy_url.is_some())
-            && configured_ntfy_fallback_url.is_some()
-        {
-            tracing::warn!(
-                "A detected ntfy server is set; detected local ntfy will take precedence over NTFY_SERVER_URL"
-            );
+        if operating_mode == OperatingMode::SelfHosted && configured_ntfy_fallback_url.is_some() {
+            if startos_ntfy_url.is_some() {
+                tracing::warn!(
+                    "CANARY_NTFY_SERVER_URL is set; detected StartOS ntfy server will take precedence over NTFY_SERVER_URL"
+                );
+            }
+            if umbrel_ntfy_url.is_some() {
+                tracing::warn!(
+                    "CANARY_UMBREL_NTFY_URL is set; detected Umbrel ntfy server will take precedence over NTFY_SERVER_URL"
+                );
+            }
         }
         let has_managed_startos_auth = startos_ntfy_url.is_some() && startos_ntfy_token.is_some();
         let ntfy_servers = if operating_mode == OperatingMode::SelfHosted {
@@ -713,6 +719,22 @@ impl AppConfig {
         } else {
             None
         }
+    }
+
+    /// Apply package-managed ntfy auth when no explicit user auth applies.
+    pub fn with_managed_ntfy_auth(
+        &self,
+        ntfy_auth: NtfyAuth,
+        server_url: &str,
+        user_configured_server_url: Option<&str>,
+    ) -> NtfyAuth {
+        if !matches!(ntfy_auth, NtfyAuth::None) {
+            return ntfy_auth;
+        }
+
+        self.managed_ntfy_access_token_for_url(server_url, user_configured_server_url)
+            .map(NtfyAuth::AccessToken)
+            .unwrap_or(NtfyAuth::None)
     }
 
     /// Auth may be sent only to explicitly configured user URLs or detected local integrations.
@@ -1390,6 +1412,7 @@ mod tests {
         let previous_server_url = std::env::var("CANARY_NTFY_SERVER_URL").ok();
         let previous_token = std::env::var("CANARY_NTFY_TOKEN").ok();
         let previous_topic = std::env::var("CANARY_NTFY_TOPIC").ok();
+        let previous_umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok();
         let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
 
         std::env::set_var("CANARY_MODE", "self-hosted");
@@ -1398,6 +1421,7 @@ mod tests {
         std::env::set_var("CANARY_NTFY_SERVER_URL", "http://ntfy.startos/");
         std::env::set_var("CANARY_NTFY_TOKEN", " tk_test ");
         std::env::set_var("CANARY_NTFY_TOPIC", "canary");
+        std::env::remove_var("CANARY_UMBREL_NTFY_URL");
         std::env::remove_var("NTFY_SERVER_URL");
 
         let config = AppConfig::load_from_args(AppConfigArgs {
@@ -1444,6 +1468,105 @@ mod tests {
         restore_env_var("CANARY_NTFY_SERVER_URL", previous_server_url);
         restore_env_var("CANARY_NTFY_TOKEN", previous_token);
         restore_env_var("CANARY_NTFY_TOPIC", previous_topic);
+        restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
+    }
+
+    #[test]
+    fn test_load_ignores_startos_ntfy_token_without_server_url() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_jwt = std::env::var("JWT_SECRET").ok();
+        let previous_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
+        let previous_server_url = std::env::var("CANARY_NTFY_SERVER_URL").ok();
+        let previous_token = std::env::var("CANARY_NTFY_TOKEN").ok();
+        let previous_topic = std::env::var("CANARY_NTFY_TOPIC").ok();
+        let previous_umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
+        std::env::set_var("CANARY_MODE", "self-hosted");
+        std::env::set_var("JWT_SECRET", "test-jwt-secret");
+        std::env::set_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", "test-admin-password");
+        std::env::remove_var("CANARY_NTFY_SERVER_URL");
+        std::env::set_var("CANARY_NTFY_TOKEN", "tk_without_url");
+        std::env::set_var("CANARY_NTFY_TOPIC", "canary");
+        std::env::remove_var("CANARY_UMBREL_NTFY_URL");
+        std::env::remove_var("NTFY_SERVER_URL");
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Mainnet),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .expect("self-hosted config should load");
+
+        assert_eq!(config.default_ntfy_server_id(), PUBLIC_NTFY_SERVER_ID);
+        assert_eq!(config.ntfy_server_url(), "https://ntfy.sh");
+        assert!(config.ntfy_servers().is_empty());
+        assert_eq!(
+            config.managed_ntfy_access_token_for_url("http://ntfy.startos", None),
+            None
+        );
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("JWT_SECRET", previous_jwt);
+        restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
+        restore_env_var("CANARY_NTFY_SERVER_URL", previous_server_url);
+        restore_env_var("CANARY_NTFY_TOKEN", previous_token);
+        restore_env_var("CANARY_NTFY_TOPIC", previous_topic);
+        restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
+        restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
+    }
+
+    #[test]
+    fn test_load_does_not_guess_default_when_multiple_local_ntfy_servers_exist() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous_mode = std::env::var("CANARY_MODE").ok();
+        let previous_jwt = std::env::var("JWT_SECRET").ok();
+        let previous_admin_password = std::env::var("CANARY_SELF_HOSTED_ADMIN_PASSWORD").ok();
+        let previous_server_url = std::env::var("CANARY_NTFY_SERVER_URL").ok();
+        let previous_token = std::env::var("CANARY_NTFY_TOKEN").ok();
+        let previous_topic = std::env::var("CANARY_NTFY_TOPIC").ok();
+        let previous_umbrel_ntfy_url = std::env::var("CANARY_UMBREL_NTFY_URL").ok();
+        let previous_ntfy_server_url = std::env::var("NTFY_SERVER_URL").ok();
+
+        std::env::set_var("CANARY_MODE", "self-hosted");
+        std::env::set_var("JWT_SECRET", "test-jwt-secret");
+        std::env::set_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", "test-admin-password");
+        std::env::set_var("CANARY_NTFY_SERVER_URL", "http://ntfy.startos/");
+        std::env::set_var("CANARY_NTFY_TOKEN", "tk_test");
+        std::env::set_var("CANARY_NTFY_TOPIC", "canary");
+        std::env::set_var("CANARY_UMBREL_NTFY_URL", "http://ntfy_app_1/");
+        std::env::remove_var("NTFY_SERVER_URL");
+
+        let config = AppConfig::load_from_args(AppConfigArgs {
+            network: Some(NetworkConfig::Mainnet),
+            electrum_url: None,
+            bind_address: Some("127.0.0.1:3000".to_string()),
+            data_dir: Some("./database".to_string()),
+        })
+        .expect("self-hosted config should load");
+
+        assert_eq!(config.default_ntfy_server_id(), PUBLIC_NTFY_SERVER_ID);
+        assert_eq!(config.ntfy_server_url(), "https://ntfy.sh");
+        assert_eq!(config.ntfy_servers().len(), 2);
+        assert_eq!(config.ntfy_servers()[0].id, STARTOS_NTFY_SERVER_ID);
+        assert_eq!(config.ntfy_servers()[1].id, UMBREL_NTFY_SERVER_ID);
+        assert_eq!(
+            config
+                .managed_ntfy_access_token_for_url("http://ntfy.startos", None)
+                .as_deref(),
+            Some("tk_test")
+        );
+
+        restore_env_var("CANARY_MODE", previous_mode);
+        restore_env_var("JWT_SECRET", previous_jwt);
+        restore_env_var("CANARY_SELF_HOSTED_ADMIN_PASSWORD", previous_admin_password);
+        restore_env_var("CANARY_NTFY_SERVER_URL", previous_server_url);
+        restore_env_var("CANARY_NTFY_TOKEN", previous_token);
+        restore_env_var("CANARY_NTFY_TOPIC", previous_topic);
+        restore_env_var("CANARY_UMBREL_NTFY_URL", previous_umbrel_ntfy_url);
         restore_env_var("NTFY_SERVER_URL", previous_ntfy_server_url);
     }
 

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -79,7 +79,7 @@ pub async fn send_test_ntfy_notification(
         config.should_use_ntfy_auth_for_url(&ntfy_server, user_ntfy_server_url.as_deref());
 
     // Look up user's ntfy auth credentials
-    let ntfy_auth = if should_use_ntfy_auth {
+    let mut ntfy_auth = if should_use_ntfy_auth {
         match app_services
             .metadata_db
             .get_user_ntfy_auth(&user.user_id)
@@ -94,6 +94,13 @@ pub async fn send_test_ntfy_notification(
     } else {
         NtfyAuth::None
     };
+    if matches!(ntfy_auth, NtfyAuth::None) {
+        if let Some(token) =
+            config.managed_ntfy_access_token_for_url(&ntfy_server, user_ntfy_server_url.as_deref())
+        {
+            ntfy_auth = NtfyAuth::AccessToken(token);
+        }
+    }
 
     // Look up user's preferred language
     let language = app_services

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -79,7 +79,7 @@ pub async fn send_test_ntfy_notification(
         config.should_use_ntfy_auth_for_url(&ntfy_server, user_ntfy_server_url.as_deref());
 
     // Look up user's ntfy auth credentials
-    let mut ntfy_auth = if should_use_ntfy_auth {
+    let ntfy_auth = if should_use_ntfy_auth {
         match app_services
             .metadata_db
             .get_user_ntfy_auth(&user.user_id)
@@ -94,13 +94,8 @@ pub async fn send_test_ntfy_notification(
     } else {
         NtfyAuth::None
     };
-    if matches!(ntfy_auth, NtfyAuth::None) {
-        if let Some(token) =
-            config.managed_ntfy_access_token_for_url(&ntfy_server, user_ntfy_server_url.as_deref())
-        {
-            ntfy_auth = NtfyAuth::AccessToken(token);
-        }
-    }
+    let ntfy_auth =
+        config.with_managed_ntfy_auth(ntfy_auth, &ntfy_server, user_ntfy_server_url.as_deref());
 
     // Look up user's preferred language
     let language = app_services

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -915,7 +915,7 @@ async fn main() -> anyhow::Result<()> {
                                     );
 
                                 // Get ntfy authentication credentials
-                                let mut ntfy_auth = if should_use_ntfy_auth {
+                                let ntfy_auth = if should_use_ntfy_auth {
                                     match notification_wallet_manager
                                         .metadata_db
                                         .get_user_ntfy_auth(&wallet_info.user_id)
@@ -930,16 +930,11 @@ async fn main() -> anyhow::Result<()> {
                                 } else {
                                     NtfyAuth::None
                                 };
-                                if matches!(ntfy_auth, NtfyAuth::None) {
-                                    if let Some(token) = notification_config
-                                        .managed_ntfy_access_token_for_url(
-                                            &ntfy_server,
-                                            user_ntfy_server_url.as_deref(),
-                                        )
-                                    {
-                                        ntfy_auth = NtfyAuth::AccessToken(token);
-                                    }
-                                }
+                                let ntfy_auth = notification_config.with_managed_ntfy_auth(
+                                    ntfy_auth,
+                                    &ntfy_server,
+                                    user_ntfy_server_url.as_deref(),
+                                );
 
                                 let ntfy_provider = NtfyProvider::with_client(
                                     ntfy_http_client.clone(),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -915,7 +915,7 @@ async fn main() -> anyhow::Result<()> {
                                     );
 
                                 // Get ntfy authentication credentials
-                                let ntfy_auth = if should_use_ntfy_auth {
+                                let mut ntfy_auth = if should_use_ntfy_auth {
                                     match notification_wallet_manager
                                         .metadata_db
                                         .get_user_ntfy_auth(&wallet_info.user_id)
@@ -930,6 +930,16 @@ async fn main() -> anyhow::Result<()> {
                                 } else {
                                     NtfyAuth::None
                                 };
+                                if matches!(ntfy_auth, NtfyAuth::None) {
+                                    if let Some(token) = notification_config
+                                        .managed_ntfy_access_token_for_url(
+                                            &ntfy_server,
+                                            user_ntfy_server_url.as_deref(),
+                                        )
+                                    {
+                                        ntfy_auth = NtfyAuth::AccessToken(token);
+                                    }
+                                }
 
                                 let ntfy_provider = NtfyProvider::with_client(
                                     ntfy_http_client.clone(),

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -344,6 +344,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "Lokal"
       },
       "auth": {

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -296,6 +296,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "Lokal"
       },
       "auth": {

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -344,6 +344,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "Local"
       },
       "auth": {

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -296,6 +296,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "Local"
       },
       "auth": {

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -296,6 +296,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "Local"
       },
       "auth": {

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -296,6 +296,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "ローカル"
       },
       "auth": {

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -344,6 +344,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "Lokal"
       },
       "auth": {

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -296,6 +296,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "Local"
       },
       "auth": {

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -344,6 +344,7 @@
       },
       "platform": {
         "umbrel": "Umbrel",
+        "startos": "StartOS",
         "local": "Lokal"
       },
       "auth": {

--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -213,6 +213,39 @@ describe('ContactModal', () => {
       expect(screen.queryByText(/ntfy_app_1/)).not.toBeInTheDocument()
     })
 
+    it('prefills ntfy topic from a managed server default topic', async () => {
+      const user = userEvent.setup()
+      mockApi.getConfig.mockResolvedValue({
+        tx_explorers: [],
+        default_tx_explorer_id: 'mempool-space',
+        ntfy_servers: [
+          {
+            id: 'startos-ntfy',
+            name: 'ntfy',
+            base_url: 'http://localhost:2586',
+            platform: 'startos',
+            default_topic: 'canary',
+            managed_auth: true,
+          },
+        ],
+        default_ntfy_server_id: 'startos-ntfy',
+      })
+
+      await act(async () => {
+        render(<ContactModal {...defaultProps} />)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('ntfy.sh Notifications')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('checkbox', { name: /ntfy\.sh Notifications/ }))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('ntfy Topic')).toHaveValue('canary')
+      })
+    })
+
     it('shows validation error when name is empty', async () => {
       const user = userEvent.setup()
       await act(async () => {

--- a/frontend/src/components/__tests__/contact-modal.test.tsx
+++ b/frontend/src/components/__tests__/contact-modal.test.tsx
@@ -187,7 +187,14 @@ describe('ContactModal', () => {
         tx_explorers: [],
         default_tx_explorer_id: 'mempool-space',
         ntfy_servers: [
-          { id: 'umbrel-ntfy', name: 'ntfy', base_url: 'http://ntfy_app_1', platform: 'umbrel' },
+          {
+            id: 'umbrel-ntfy',
+            name: 'ntfy',
+            base_url: 'http://ntfy_app_1',
+            platform: 'umbrel',
+            default_topic: null,
+            managed_auth: false,
+          },
         ],
         default_ntfy_server_id: 'umbrel-ntfy',
       })

--- a/frontend/src/components/contact-modal.tsx
+++ b/frontend/src/components/contact-modal.tsx
@@ -191,6 +191,12 @@ export function ContactModal({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, editContact, fetchProviders, providers.length])
 
+  useEffect(() => {
+    if (isOpen && enabledProviders['ntfy'] && ntfyServerTarget.defaultTopic && !userEditedNtfyTopic) {
+      setNtfyTopic(ntfyServerTarget.defaultTopic)
+    }
+  }, [enabledProviders, isOpen, ntfyServerTarget.defaultTopic, userEditedNtfyTopic])
+
   const handleClose = () => {
     setError(null)
     setIsDeleteModalOpen(false)
@@ -384,7 +390,7 @@ export function ContactModal({
         onChange={(e) => {
           const newName = e.target.value
           setName(newName)
-          if (enabledProviders['ntfy'] && !userEditedNtfyTopic) {
+          if (enabledProviders['ntfy'] && !userEditedNtfyTopic && !ntfyServerTarget.defaultTopic) {
             setNtfyTopic(generateDefaultNtfyTopic(newName, walletChecksum))
           }
         }}
@@ -412,7 +418,7 @@ export function ContactModal({
                     [provider.name]: e.target.checked
                   }))
                   if (provider.name === 'ntfy' && e.target.checked && !ntfyTopic && !userEditedNtfyTopic) {
-                    setNtfyTopic(generateDefaultNtfyTopic(name, walletChecksum))
+                    setNtfyTopic(ntfyServerTarget.defaultTopic || generateDefaultNtfyTopic(name, walletChecksum))
                   }
                 }}
                 disabled={isSubmitting}
@@ -515,7 +521,7 @@ export function ContactModal({
                       setNtfyTopic(value)
                       setUserEditedNtfyTopic(true)
                     }}
-                    defaultTopicPlaceholder={generateDefaultNtfyTopic(name || 'contact', walletChecksum)}
+                    defaultTopicPlaceholder={ntfyServerTarget.defaultTopic || generateDefaultNtfyTopic(name || 'contact', walletChecksum)}
                     disabled={isSubmitting}
                     ntfyServerUrl={ntfyServerTarget.url}
                     ntfyServerIsBrowserSafe={ntfyServerTarget.isBrowserSafe}

--- a/frontend/src/components/contact-modal.tsx
+++ b/frontend/src/components/contact-modal.tsx
@@ -120,6 +120,7 @@ export function ContactModal({
   })
 
   const isMobile = useIsMobile()
+  const ntfyEnabled = enabledProviders['ntfy'] || false
   const wizard = useContactWizard({
     name,
     enabledProviders,
@@ -192,10 +193,10 @@ export function ContactModal({
   }, [isOpen, editContact, fetchProviders, providers.length])
 
   useEffect(() => {
-    if (isOpen && enabledProviders['ntfy'] && ntfyServerTarget.defaultTopic && !userEditedNtfyTopic) {
+    if (isOpen && ntfyEnabled && ntfyServerTarget.defaultTopic && !userEditedNtfyTopic) {
       setNtfyTopic(ntfyServerTarget.defaultTopic)
     }
-  }, [enabledProviders, isOpen, ntfyServerTarget.defaultTopic, userEditedNtfyTopic])
+  }, [isOpen, ntfyEnabled, ntfyServerTarget.defaultTopic, userEditedNtfyTopic])
 
   const handleClose = () => {
     setError(null)
@@ -245,7 +246,7 @@ export function ContactModal({
     }
 
     // Check what's enabled
-    const hasNtfy = enabledProviders['ntfy'] || false
+    const hasNtfy = ntfyEnabled
     const hasSms = enabledProviders['twilio'] && providerValues['twilio']?.trim()
     const hasEmail = enabledProviders['email'] && providerValues['email']?.trim()
 

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -22,6 +22,16 @@ describe("NtfyServerSettings", () => {
     managedAuth: false,
   }
 
+  const startosNtfy: NtfyServerOption = {
+    id: "startos-ntfy",
+    name: "ntfy",
+    baseUrl: "http://localhost:2586",
+    isLocal: true,
+    platform: "startos",
+    defaultTopic: "canary",
+    managedAuth: true,
+  }
+
   const defaultProps = {
     ntfyServerUrl: "http://ntfy_app_1",
     onNtfyServerUrlChange: jest.fn(),
@@ -270,5 +280,34 @@ describe("NtfyServerSettings", () => {
     render(<NtfyServerSettings {...defaultProps} hasAnyNtfyChanges={true} />)
 
     expect(screen.getByRole("button", { name: "Send Test" })).toBeDisabled()
+  })
+
+  it("defaults test notifications to the managed server topic without clobbering edits", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <NtfyServerSettings
+        {...defaultProps}
+        ntfyServers={[publicNtfy, startosNtfy]}
+        selectedNtfyServerId="startos-ntfy"
+        ntfyServerUrl="http://localhost:2586"
+      />
+    )
+
+    const topicInput = document.querySelector("#ntfy-test-topic")
+    expect(topicInput).toHaveValue("canary")
+
+    await user.clear(topicInput as HTMLInputElement)
+    await user.type(topicInput as HTMLInputElement, "custom-topic")
+
+    rerender(
+      <NtfyServerSettings
+        {...defaultProps}
+        ntfyServers={[publicNtfy, { ...startosNtfy, defaultTopic: "changed-topic" }]}
+        selectedNtfyServerId="startos-ntfy"
+        ntfyServerUrl="http://localhost:2586"
+      />
+    )
+
+    expect(document.querySelector("#ntfy-test-topic")).toHaveValue("custom-topic")
   })
 })

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -11,6 +11,7 @@ describe("NtfyServerSettings", () => {
     baseUrl: "http://ntfy_app_1",
     isLocal: true,
     platform: "umbrel",
+    managedAuth: false,
   }
 
   const publicNtfy: NtfyServerOption = {
@@ -18,6 +19,7 @@ describe("NtfyServerSettings", () => {
     name: "ntfy",
     baseUrl: "https://ntfy.sh",
     isLocal: false,
+    managedAuth: false,
   }
 
   const defaultProps = {

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback, type ReactNode } from "react"
+import { useState, useCallback, useEffect, type ReactNode } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
@@ -71,9 +71,11 @@ export function NtfyServerSettings({
   const publicServers = ntfyServers.filter((server) => !server.isLocal)
   const localServers = ntfyServers.filter((server) => server.isLocal)
   const publicServer = publicServers[0]
+  const selectedServer = ntfyServers.find((server) => server.id === selectedNtfyServerId)
   const isLocalSelection = localServers.some((server) => server.id === selectedNtfyServerId)
+  const isManagedAuthSelection = selectedServer?.managedAuth === true
   // ntfy.sh supports accounts/private topics, so auth stays available for both public and local servers.
-  const showAuthSection = Boolean(ntfyServerUrl || isLocalSelection)
+  const showAuthSection = Boolean(ntfyServerUrl || isLocalSelection) && !isManagedAuthSelection
   const hasLocalServers = localServers.length > 0
   const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl ?? "" : ntfyServerUrl
   const startEditingPublicUrl = () => {
@@ -96,7 +98,11 @@ export function NtfyServerSettings({
     setIsEditingPublicUrl(false)
   }
   const localServerSubtitle = (server: NtfyServerOption) =>
-    server.platform === "umbrel" ? t("ntfy.platform.umbrel") : t("ntfy.platform.local")
+    server.platform === "umbrel"
+      ? t("ntfy.platform.umbrel")
+      : server.platform === "startos"
+        ? "StartOS"
+        : t("ntfy.platform.local")
   const publicServerRow = publicServer ? (
     <div className="space-y-2">
       {hasLocalServers ? (
@@ -203,7 +209,7 @@ export function NtfyServerSettings({
                     <NtfyServerOptionRow key={server.id} server={server} subtitle={localServerSubtitle(server)} />
                   ))}
                 </div>
-                <p className="text-sm text-muted-foreground">{t("ntfy.localAuthNote")}</p>
+                {!isManagedAuthSelection && <p className="text-sm text-muted-foreground">{t("ntfy.localAuthNote")}</p>}
               </div>
             </RadioGroup>
           ) : (
@@ -318,6 +324,7 @@ export function NtfyServerSettings({
           <TestNotificationSection
             savedServerUrl={ntfyServerUrl || userPreferences?.ntfy_server_url || null}
             hasUnsavedSettings={hasAnyNtfyChanges}
+            defaultTopic={selectedServer?.defaultTopic}
           />
         </div>
       </CardContent>
@@ -391,14 +398,20 @@ function NtfyServerStaticRow({
 function TestNotificationSection({
   savedServerUrl,
   hasUnsavedSettings,
+  defaultTopic,
 }: {
   savedServerUrl: string | null
   hasUnsavedSettings: boolean
+  defaultTopic?: string
 }) {
   const t = useTranslations("settings")
-  const [topic, setTopic] = useState("canary-test")
+  const [topic, setTopic] = useState(defaultTopic || "canary-test")
   const [isSending, setIsSending] = useState(false)
   const [result, setResult] = useState<{ success: boolean; message: string; topicUrl?: string } | null>(null)
+
+  useEffect(() => {
+    setTopic(defaultTopic || "canary-test")
+  }, [defaultTopic])
 
   const handleSendTest = useCallback(async () => {
     setIsSending(true)

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -101,7 +101,7 @@ export function NtfyServerSettings({
     server.platform === "umbrel"
       ? t("ntfy.platform.umbrel")
       : server.platform === "startos"
-        ? "StartOS"
+        ? t("ntfy.platform.startos")
         : t("ntfy.platform.local")
   const publicServerRow = publicServer ? (
     <div className="space-y-2">

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -74,6 +74,10 @@ export function NtfyServerSettings({
   const selectedServer = ntfyServers.find((server) => server.id === selectedNtfyServerId)
   const isLocalSelection = localServers.some((server) => server.id === selectedNtfyServerId)
   const isManagedAuthSelection = selectedServer?.managedAuth === true
+  const platformLabels: Record<string, string> = {
+    umbrel: t("ntfy.platform.umbrel"),
+    startos: t("ntfy.platform.startos"),
+  }
   // ntfy.sh supports accounts/private topics, so auth stays available for both public and local servers.
   const showAuthSection = Boolean(ntfyServerUrl || isLocalSelection) && !isManagedAuthSelection
   const hasLocalServers = localServers.length > 0
@@ -98,11 +102,7 @@ export function NtfyServerSettings({
     setIsEditingPublicUrl(false)
   }
   const localServerSubtitle = (server: NtfyServerOption) =>
-    server.platform === "umbrel"
-      ? t("ntfy.platform.umbrel")
-      : server.platform === "startos"
-        ? t("ntfy.platform.startos")
-        : t("ntfy.platform.local")
+    server.platform ? (platformLabels[server.platform] ?? t("ntfy.platform.local")) : t("ntfy.platform.local")
   const publicServerRow = publicServer ? (
     <div className="space-y-2">
       {hasLocalServers ? (
@@ -406,12 +406,15 @@ function TestNotificationSection({
 }) {
   const t = useTranslations("settings")
   const [topic, setTopic] = useState(defaultTopic || "canary-test")
+  const [hasUserEditedTopic, setHasUserEditedTopic] = useState(false)
   const [isSending, setIsSending] = useState(false)
   const [result, setResult] = useState<{ success: boolean; message: string; topicUrl?: string } | null>(null)
 
   useEffect(() => {
-    setTopic(defaultTopic || "canary-test")
-  }, [defaultTopic])
+    if (!hasUserEditedTopic) {
+      setTopic(defaultTopic || "canary-test")
+    }
+  }, [defaultTopic, hasUserEditedTopic])
 
   const handleSendTest = useCallback(async () => {
     setIsSending(true)
@@ -449,7 +452,10 @@ function TestNotificationSection({
           type="text"
           placeholder={t("ntfy.test.topicPlaceholder")}
           value={topic}
-          onChange={(e) => setTopic(e.target.value)}
+          onChange={(e) => {
+            setHasUserEditedTopic(true)
+            setTopic(e.target.value)
+          }}
           disabled={isSending}
         />
         <Button

--- a/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
+++ b/frontend/src/hooks/__tests__/useNtfyServerUrl.test.ts
@@ -91,6 +91,8 @@ describe("useNtfyServerTarget", () => {
           name: "ntfy",
           base_url: "http://umbrel",
           platform: "umbrel",
+          default_topic: null,
+          managed_auth: false,
         },
       ],
       default_ntfy_server_id: UMBREL_NTFY_SERVER_ID,
@@ -113,6 +115,8 @@ describe("useNtfyServerTarget", () => {
           name: "ntfy",
           base_url: "http://ntfy_app_1",
           platform: "umbrel",
+          default_topic: null,
+          managed_auth: false,
         },
       ],
       default_ntfy_server_id: UMBREL_NTFY_SERVER_ID,
@@ -122,6 +126,34 @@ describe("useNtfyServerTarget", () => {
 
     await waitFor(() => {
       expect(result.current).toEqual({ url: "http://ntfy_app_1", isBrowserSafe: false })
+    })
+  })
+
+  it("returns the provisioned default topic when a local server provides one", async () => {
+    mockApi.getConfig.mockResolvedValue({
+      tx_explorers: [],
+      default_tx_explorer_id: "mempool-space",
+      ntfy_servers: [
+        {
+          id: "startos-ntfy",
+          name: "ntfy",
+          base_url: "http://ntfy.startos",
+          platform: "startos",
+          default_topic: "canary",
+          managed_auth: true,
+        },
+      ],
+      default_ntfy_server_id: "startos-ntfy",
+    })
+
+    const { result } = renderHook(() => useNtfyServerTarget())
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        url: "http://ntfy.startos",
+        isBrowserSafe: true,
+        defaultTopic: "canary",
+      })
     })
   })
 

--- a/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
@@ -69,6 +69,8 @@ describe("useUserPreferences", () => {
           name: "ntfy",
           base_url: "http://ntfy_app_1",
           platform: "umbrel",
+          default_topic: null,
+          managed_auth: false,
         },
       ],
       default_ntfy_server_id: UMBREL_NTFY_SERVER_ID,

--- a/frontend/src/hooks/useNtfyServerUrl.ts
+++ b/frontend/src/hooks/useNtfyServerUrl.ts
@@ -9,7 +9,13 @@ import {
 } from "@/lib/ntfy-servers"
 
 const DEFAULT_NTFY_URL = PUBLIC_NTFY_SERVER_URL
-let inFlightNtfyTargetRequest: Promise<{ url: string; isBrowserSafe: boolean }> | null = null
+interface NtfyServerTarget {
+  url: string
+  isBrowserSafe: boolean
+  defaultTopic?: string
+}
+
+let inFlightNtfyTargetRequest: Promise<NtfyServerTarget> | null = null
 let inFlightNtfyTargetRequestAuthState: boolean | null = null
 
 export function resetNtfyServerTargetCacheForTests() {
@@ -52,10 +58,12 @@ export function normalizeNtfyUrl(url: string): string | null {
  * Returns a validated, normalized URL that is safe to use in href attributes.
  * Falls back to https://ntfy.sh if no custom server is configured or on error.
  */
-export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
+export function useNtfyServerTarget(): NtfyServerTarget {
   const { isAuthenticated, isLoading } = useAuth()
-  const [ntfyServerUrl, setNtfyServerUrl] = useState(DEFAULT_NTFY_URL)
-  const [isBrowserSafe, setIsBrowserSafe] = useState(true)
+  const [ntfyServerTarget, setNtfyServerTarget] = useState<NtfyServerTarget>({
+    url: DEFAULT_NTFY_URL,
+    isBrowserSafe: true,
+  })
 
   useEffect(() => {
     if (isLoading) return
@@ -65,8 +73,7 @@ export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
     getNtfyServerTargetRequest(isAuthenticated)
       .then((target) => {
         if (cancelled) return
-        setNtfyServerUrl(target.url)
-        setIsBrowserSafe(target.isBrowserSafe)
+        setNtfyServerTarget(target)
       })
       .catch(() => {
         // Fall back to default ntfy.sh
@@ -77,19 +84,14 @@ export function useNtfyServerTarget(): { url: string; isBrowserSafe: boolean } {
     }
   }, [isAuthenticated, isLoading])
 
-  return {
-    url: ntfyServerUrl,
-    isBrowserSafe,
-  }
+  return ntfyServerTarget
 }
 
 export function useNtfyServerUrl(): string {
   return useNtfyServerTarget().url
 }
 
-function getNtfyServerTargetRequest(
-  isAuthenticated: boolean
-): Promise<{ url: string; isBrowserSafe: boolean }> {
+function getNtfyServerTargetRequest(isAuthenticated: boolean): Promise<NtfyServerTarget> {
   if (!inFlightNtfyTargetRequest || inFlightNtfyTargetRequestAuthState !== isAuthenticated) {
     inFlightNtfyTargetRequestAuthState = isAuthenticated
     // Deduplicate concurrent mounts only; sequential mounts should refetch current preferences.
@@ -102,9 +104,7 @@ function getNtfyServerTargetRequest(
   return inFlightNtfyTargetRequest
 }
 
-async function resolveNtfyServerTarget(
-  isAuthenticated: boolean
-): Promise<{ url: string; isBrowserSafe: boolean }> {
+async function resolveNtfyServerTarget(isAuthenticated: boolean): Promise<NtfyServerTarget> {
   const [config, prefs] = await Promise.all([
     api.getConfig(),
     isAuthenticated ? api.getUserPreferences().catch(() => null) : Promise.resolve(null),
@@ -121,8 +121,12 @@ async function resolveNtfyServerTarget(
     return { url: DEFAULT_NTFY_URL, isBrowserSafe: true }
   }
 
-  return {
+  const target: NtfyServerTarget = {
     url: normalized,
     isBrowserSafe: isBrowserSafeNtfyUrl(normalized),
   }
+  if (selectedServer.defaultTopic) {
+    target.defaultTopic = selectedServer.defaultTopic
+  }
+  return target
 }

--- a/frontend/src/lib/__tests__/ntfy-servers.test.ts
+++ b/frontend/src/lib/__tests__/ntfy-servers.test.ts
@@ -10,7 +10,14 @@ describe("ntfy server helpers", () => {
     tx_explorers: [],
     default_tx_explorer_id: "mempool-space",
     ntfy_servers: [
-      { id: "umbrel-ntfy", name: "ntfy", base_url: "http://ntfy_app_1/", platform: "umbrel" },
+      {
+        id: "umbrel-ntfy",
+        name: "ntfy",
+        base_url: "http://ntfy_app_1/",
+        platform: "umbrel",
+        default_topic: null,
+        managed_auth: false,
+      },
     ],
     default_ntfy_server_id: "umbrel-ntfy",
   }
@@ -24,6 +31,7 @@ describe("ntfy server helpers", () => {
         baseUrl: "http://ntfy_app_1",
         isLocal: true,
         platform: "umbrel",
+        managedAuth: false,
       },
     ])
   })
@@ -109,11 +117,43 @@ describe("ntfy server helpers", () => {
       tx_explorers: [],
       default_tx_explorer_id: "mempool-space",
       ntfy_servers: [
-        { id: "blank-ntfy", name: "ntfy", base_url: "   ", platform: "umbrel" },
+        {
+          id: "blank-ntfy",
+          name: "ntfy",
+          base_url: "   ",
+          platform: "umbrel",
+          default_topic: null,
+          managed_auth: false,
+        },
       ],
       default_ntfy_server_id: "blank-ntfy",
     })
 
     expect(options).toEqual([PUBLIC_NTFY_SERVER])
+  })
+
+  it("preserves managed auth and default topic metadata", () => {
+    const options = buildNtfyServerOptions({
+      tx_explorers: [],
+      default_tx_explorer_id: "mempool-space",
+      ntfy_servers: [
+        {
+          id: "startos-ntfy",
+          name: "ntfy",
+          base_url: "http://ntfy.startos",
+          platform: "startos",
+          default_topic: "canary",
+          managed_auth: true,
+        },
+      ],
+      default_ntfy_server_id: "startos-ntfy",
+    })
+
+    expect(options[1]).toMatchObject({
+      id: "startos-ntfy",
+      baseUrl: "http://ntfy.startos",
+      defaultTopic: "canary",
+      managedAuth: true,
+    })
   })
 })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,6 +30,8 @@ export interface NtfyServerConfig {
   name: string
   base_url: string
   platform: string | null
+  default_topic: string | null
+  managed_auth: boolean
 }
 
 export interface AppConfigResponse {

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -12,7 +12,7 @@ export interface NtfyServerOption {
   isLocal: boolean
   platform?: string
   defaultTopic?: string
-  managedAuth?: boolean
+  managedAuth: boolean
 }
 
 export const PUBLIC_NTFY_SERVER: NtfyServerOption = {
@@ -20,6 +20,7 @@ export const PUBLIC_NTFY_SERVER: NtfyServerOption = {
   name: "ntfy",
   baseUrl: PUBLIC_NTFY_SERVER_URL,
   isLocal: false,
+  managedAuth: false,
 }
 
 function normalizeBaseUrl(baseUrl: string): string {

--- a/frontend/src/lib/ntfy-servers.ts
+++ b/frontend/src/lib/ntfy-servers.ts
@@ -2,6 +2,7 @@ import type { AppConfigResponse } from "@/lib/api"
 
 export const PUBLIC_NTFY_SERVER_URL = "https://ntfy.sh"
 export const PUBLIC_NTFY_SERVER_ID = "ntfy-sh"
+export const STARTOS_NTFY_SERVER_ID = "startos-ntfy"
 export const UMBREL_NTFY_SERVER_ID = "umbrel-ntfy"
 
 export interface NtfyServerOption {
@@ -10,6 +11,8 @@ export interface NtfyServerOption {
   baseUrl: string
   isLocal: boolean
   platform?: string
+  defaultTopic?: string
+  managedAuth?: boolean
 }
 
 export const PUBLIC_NTFY_SERVER: NtfyServerOption = {
@@ -31,6 +34,8 @@ export function buildNtfyServerOptions(config: AppConfigResponse): NtfyServerOpt
       baseUrl: normalizeBaseUrl(server.base_url),
       isLocal: true,
       platform: server.platform ?? undefined,
+      defaultTopic: server.default_topic ?? undefined,
+      managedAuth: server.managed_auth,
     }))
     .filter((server) => server.baseUrl.length > 0)
 


### PR DESCRIPTION
## Summary
- detect StartOS-provisioned ntfy server defaults from environment in self-hosted mode
- keep managed ntfy auth server-side while exposing default topic and managed-auth metadata to the UI
- prefill StartOS ntfy topics and hide manual auth controls for managed ntfy servers

Refs #392

## Tests
- cargo fmt --manifest-path backend/Cargo.toml --check
- cargo test --manifest-path backend/Cargo.toml ntfy -- --test-threads=1
- fnm exec --using 22.22.0 pnpm test src/lib/__tests__/ntfy-servers.test.ts src/hooks/__tests__/useNtfyServerUrl.test.ts --runInBand
- fnm exec --using 22.22.0 pnpm test src/components/settings/__tests__/ntfy-server-settings.test.tsx src/components/__tests__/contact-modal.test.tsx src/hooks/__tests__/useUserPreferences.test.tsx --runInBand
- fnm exec --using 22.22.0 pnpm lint
- fnm exec --using 22.22.0 pnpm build
- Chrome: verified StartOS ntfy option, managed auth hidden, default topic canary, and Send test success against local ntfy