### PR TITLE
Fix unused address watches stuck syncing

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -98,3 +98,7 @@ path = "system_tests/batch_transaction_scenarios.rs"
 [[test]]
 name = "mempool_chain_scenarios"
 path = "system_tests/mempool_chain_scenarios.rs"
+
+[[test]]
+name = "address_watch_scenarios"
+path = "system_tests/address_watch_scenarios.rs"

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -38,6 +38,15 @@ static MAINNET_GENESIS_COINBASE_TXID: LazyLock<Txid> = LazyLock::new(|| {
 /// Electrum server cannot serve the block 0 header.
 const MAINNET_GENESIS_BLOCK_TIMESTAMP: u64 = 1231006505;
 
+/// Result of an address watch synchronization attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AddressWatchSyncResult {
+    /// The sync completed successfully after querying Electrum.
+    Completed { has_changes: bool },
+    /// The sync was skipped because no Electrum client or manager was available.
+    SkippedNoClient,
+}
+
 fn current_unix_timestamp_or(default: u64, context: &str) -> u64 {
     current_unix_timestamp().unwrap_or_else(|error| {
         warn!(
@@ -1808,13 +1817,13 @@ impl WalletSyncService {
 
     /// See: https://github.com/rust-bitcoin/rust-miniscript/issues/294
     /// See: https://github.com/bitcoindevkit/bdk_wallet/issues/174
-    pub async fn sync_address_watch(
+    pub(crate) async fn sync_address_watch(
         &self,
         wallet_checksum: &str,
         descriptor: &str,
         electrum_manager: Option<&ElectrumClientManager>,
         suppress_notifications: bool,
-    ) -> Result<bool> {
+    ) -> Result<AddressWatchSyncResult> {
         let sync_start = Instant::now();
         debug!("[{}] Starting address-based sync", wallet_checksum);
         let network = self.config.network.to_bdk_network();
@@ -1830,7 +1839,7 @@ impl WalletSyncService {
                         "[{}] No Electrum client available for address watch",
                         wallet_checksum
                     );
-                    return Ok(false);
+                    return Ok(AddressWatchSyncResult::SkippedNoClient);
                 }
             },
             None => {
@@ -1838,7 +1847,7 @@ impl WalletSyncService {
                     "[{}] No Electrum manager available for address watch",
                     wallet_checksum
                 );
-                return Ok(false);
+                return Ok(AddressWatchSyncResult::SkippedNoClient);
             }
         };
 
@@ -2073,19 +2082,19 @@ impl WalletSyncService {
             );
         }
 
-        Ok(has_changes)
+        Ok(AddressWatchSyncResult::Completed { has_changes })
     }
 
     /// Sync a group of address watches that share the same descriptor.
     /// Queries Electrum once and fans out the results (transactions, balance,
     /// notifications) to each watcher independently.
-    pub async fn sync_address_watch_group(
+    pub(crate) async fn sync_address_watch_group(
         &self,
         wallet_checksums: &[String],
         descriptor: &str,
         electrum_manager: Option<&ElectrumClientManager>,
         suppress_notifications: bool,
-    ) -> Result<bool> {
+    ) -> Result<AddressWatchSyncResult> {
         let sync_start = Instant::now();
         let network = self.config.network.to_bdk_network();
         info!(
@@ -2102,12 +2111,12 @@ impl WalletSyncService {
                 Some(c) => c,
                 None => {
                     warn!("No Electrum client available for grouped address watch");
-                    return Ok(false);
+                    return Ok(AddressWatchSyncResult::SkippedNoClient);
                 }
             },
             None => {
                 warn!("No Electrum manager available for grouped address watch");
-                return Ok(false);
+                return Ok(AddressWatchSyncResult::SkippedNoClient);
             }
         };
 
@@ -2380,7 +2389,9 @@ impl WalletSyncService {
             );
         }
 
-        Ok(any_changes)
+        Ok(AddressWatchSyncResult::Completed {
+            has_changes: any_changes,
+        })
     }
 
     /// Send balance alert notification using existing notification system

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -2,6 +2,7 @@ use crate::config::AppConfig;
 use crate::config::NetworkConfig;
 use crate::electrum::{ElectrumClient, ElectrumClientManager};
 use crate::metadata::{MetadataDb, TransactionNotification, WalletMetadata};
+use crate::sync::AddressWatchSyncResult;
 use crate::utils::{parse_multipath_descriptor, strip_key_origin};
 use anyhow::{anyhow, Result};
 use bdk_wallet::rusqlite::Connection;
@@ -197,7 +198,7 @@ impl WalletCreationService {
                 )
                 .await
             {
-                Ok(true) => {
+                Ok(AddressWatchSyncResult::Completed { has_changes }) => {
                     // Mark as ready only after successful sync
                     if let Err(e) = metadata_db
                         .update_wallet_status_if_not_deleted(&checksum_clone, "ready")
@@ -208,9 +209,12 @@ impl WalletCreationService {
                             checksum_clone, e
                         );
                     }
-                    debug!("[{}] Initial watch sync completed", checksum_clone);
+                    debug!(
+                        "[{}] Initial watch sync completed (changes={})",
+                        checksum_clone, has_changes
+                    );
                 }
-                Ok(false) => {
+                Ok(AddressWatchSyncResult::SkippedNoClient) => {
                     debug!(
                         "[{}] No Electrum client yet, wallet stays pending",
                         checksum_clone
@@ -1086,7 +1090,7 @@ impl WalletManager {
                                 )
                                 .await
                             {
-                                Ok(true) => {
+                                Ok(AddressWatchSyncResult::Completed { .. }) => {
                                     // Promote pending watcher to ready
                                     if is_pending {
                                         if let Err(e) = metadata_db
@@ -1104,7 +1108,7 @@ impl WalletManager {
                                     }
                                     Ok(watcher_count)
                                 }
-                                Ok(false) => Ok(watcher_count), // No Electrum client, skip
+                                Ok(AddressWatchSyncResult::SkippedNoClient) => Ok(watcher_count),
                                 Err(e) => {
                                     warn!("Failed to sync address watch {}: {}", checksums[0], e);
                                     Err(e)
@@ -1124,7 +1128,7 @@ impl WalletManager {
                                 )
                                 .await
                             {
-                                Ok(true) => {
+                                Ok(AddressWatchSyncResult::Completed { .. }) => {
                                     // Promote any pending watchers to ready
                                     for w in &watchers {
                                         if w.status == "pending" {
@@ -1144,7 +1148,7 @@ impl WalletManager {
                                     }
                                     Ok(watcher_count)
                                 }
-                                Ok(false) => Ok(watcher_count), // No Electrum client, skip
+                                Ok(AddressWatchSyncResult::SkippedNoClient) => Ok(watcher_count),
                                 Err(e) => {
                                     warn!(
                                         "Failed to sync address watch group ({}): {}",

--- a/backend/system_tests/address_watch_scenarios.rs
+++ b/backend/system_tests/address_watch_scenarios.rs
@@ -1,0 +1,93 @@
+mod common;
+use common::docker_environment::IsolatedTestEnvironment;
+
+use canary::subscription::SubscriptionTier;
+use canary::wallet::WalletCreationService;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// System tests for single-address watch scenarios.
+#[tokio::test]
+#[ignore] // System test - requires Docker
+async fn test_unused_bech32_address_watch_becomes_ready_after_empty_sync() {
+    let env = IsolatedTestEnvironment::new()
+        .await
+        .expect("Failed to create test environment");
+
+    let bitcoin_container = format!("test-bitcoin-{}", env.test_id);
+    let unused_address = IsolatedTestEnvironment::bitcoin_cli(
+        &bitcoin_container,
+        &["-rpcwallet=bob", "getnewaddress", "", "bech32"],
+    )
+    .expect("Failed to generate unused bech32 address")
+    .trim()
+    .to_string();
+
+    let wallet_creation_service = WalletCreationService::new(
+        env.wallet_manager.wallet_dir.clone(),
+        env.metadata_db.clone(),
+        env.wallet_manager.get_electrum_client().await,
+        env.wallet_manager.get_network(),
+        env.wallet_manager.clone(),
+    );
+
+    let created_wallet = wallet_creation_service
+        .create_wallet_non_blocking(
+            "Unused address watch",
+            &unused_address,
+            "foss-user",
+            true,
+            Some("auto"),
+            Some("20"),
+        )
+        .await
+        .expect("Failed to create unused address watch");
+
+    assert_eq!(created_wallet.status, "pending");
+    assert_eq!(created_wallet.wallet_type, "address");
+
+    let start = std::time::Instant::now();
+    let timeout = Duration::from_secs(30);
+    loop {
+        let wallet = env
+            .metadata_db
+            .get_wallet_by_checksum(&created_wallet.checksum)
+            .await
+            .expect("Failed to fetch address watch")
+            .expect("Address watch missing from database");
+
+        if wallet.status == "ready" {
+            assert_eq!(wallet.wallet_type, "address");
+            assert_eq!(wallet.balance_total, Some(0));
+            assert!(
+                wallet.last_synced_at.is_some(),
+                "empty successful address sync should set last_synced_at"
+            );
+
+            let transactions = env
+                .get_wallet_transactions(&created_wallet.checksum)
+                .await
+                .expect("Failed to fetch address watch transactions");
+            assert!(
+                transactions.is_empty(),
+                "unused address watch should not create transactions"
+            );
+            return;
+        }
+
+        if start.elapsed() > timeout {
+            panic!(
+                "Address watch {} stayed {} after {:?}",
+                created_wallet.checksum,
+                wallet.status,
+                start.elapsed()
+            );
+        }
+
+        env.wallet_manager
+            .sync_tier_parallel(SubscriptionTier::Team)
+            .await
+            .expect("Failed to sync team wallets while waiting for address watch readiness");
+        sleep(Duration::from_millis(500)).await;
+    }
+}


### PR DESCRIPTION
## Summary
- distinguish completed address-watch syncs from skipped Electrum-client syncs
- promote pending single-address watches to ready after any successful sync, including empty history and zero balance
- add an ignored regtest system test covering an unused bech32 address watch

Fixes #390

## Testing
- cargo test --test wallet_handlers_tests
- cargo test --test address_watch_scenarios
- API verification on local regtest: POST /api/wallets returned pending, follow-up GET returned ready with wallet_type=address, balance_total=0, last_synced_at set
- Chrome verification on local regtest: added unused address through UI, wallet became clickable/ready, showed empty detail state and delete control, console errors []

Note: full ignored Docker system test was not run to completion because another cmux workspace was already running a regtest Bitcoin Core/Fulcrum stack; manual API and Chrome verification used that existing stack instead.