### PR TITLE
Improve self-hosted login UX

### DIFF
--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -56,7 +56,8 @@
     "addWallet": "Tilføj wallet",
     "alreadyUser": "Allerede bruger? Log ind",
     "contact": "Kontakt",
-    "subscription": "Abonnement"
+    "subscription": "Abonnement",
+    "adminLabel": "Admin"
   },
   "contactPage": {
     "title": "Kontakt",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -56,7 +56,8 @@
     "addWallet": "Wallet hinzufügen",
     "alreadyUser": "Bereits registriert? Anmelden",
     "contact": "Kontakt",
-    "subscription": "Abonnement"
+    "subscription": "Abonnement",
+    "adminLabel": "Admin"
   },
   "contactPage": {
     "title": "Kontakt",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -56,7 +56,8 @@
     "addWallet": "Add Wallet",
     "alreadyUser": "Already a user? Sign in",
     "contact": "Contact",
-    "subscription": "Subscription"
+    "subscription": "Subscription",
+    "adminLabel": "Admin"
   },
   "contactPage": {
     "title": "Contact",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -56,7 +56,8 @@
     "addWallet": "Agregar Billetera",
     "alreadyUser": "¿Ya tienes cuenta? Inicia sesión",
     "contact": "Contacto",
-    "subscription": "Suscripción"
+    "subscription": "Suscripción",
+    "adminLabel": "Admin"
   },
   "contactPage": {
     "title": "Contacto",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -56,7 +56,8 @@
     "addWallet": "Ajouter un portefeuille",
     "alreadyUser": "Déjà inscrit ? Se connecter",
     "contact": "Contact",
-    "subscription": "Abonnement"
+    "subscription": "Abonnement",
+    "adminLabel": "Admin"
   },
   "contactPage": {
     "title": "Contact",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -56,7 +56,8 @@
     "addWallet": "ウォレットを追加",
     "alreadyUser": "既にアカウントをお持ちですか？ログイン",
     "contact": "お問い合わせ",
-    "subscription": "サブスクリプション"
+    "subscription": "サブスクリプション",
+    "adminLabel": "管理者"
   },
   "contactPage": {
     "title": "お問い合わせ",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -56,7 +56,8 @@
     "addWallet": "Legg til lommebok",
     "alreadyUser": "Allerede bruker? Logg inn",
     "contact": "Kontakt",
-    "subscription": "Abonnement"
+    "subscription": "Abonnement",
+    "adminLabel": "Admin"
   },
   "contactPage": {
     "title": "Kontakt",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -56,7 +56,8 @@
     "addWallet": "Adicionar Carteira",
     "alreadyUser": "Já tem conta? Entre",
     "contact": "Contato",
-    "subscription": "Assinatura"
+    "subscription": "Assinatura",
+    "adminLabel": "Admin"
   },
   "contactPage": {
     "title": "Contato",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -56,7 +56,8 @@
     "addWallet": "Lägg till plånbok",
     "alreadyUser": "Redan användare? Logga in",
     "contact": "Kontakt",
-    "subscription": "Prenumeration"
+    "subscription": "Prenumeration",
+    "adminLabel": "Admin"
   },
   "contactPage": {
     "title": "Kontakt",

--- a/frontend/src/app/__tests__/self-hosted-auth-routes.test.tsx
+++ b/frontend/src/app/__tests__/self-hosted-auth-routes.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SignInPage from '../sign-in/page'
 import SignOutPage from '../sign-out/page'
+import { SELF_HOSTED_ADMIN_EMAIL } from '@/lib/constants'
 
 const mockPush = jest.fn()
 const mockUseAuth = jest.fn()
@@ -44,7 +45,7 @@ describe('self-hosted auth routes', () => {
     render(<SignInPage />)
 
     expect(screen.queryByLabelText('Email')).not.toBeInTheDocument()
-    expect(screen.getByDisplayValue('admin@local')).toHaveAttribute('autocomplete', 'username')
+    expect(screen.getByDisplayValue(SELF_HOSTED_ADMIN_EMAIL)).toHaveAttribute('autocomplete', 'username')
     expect(screen.getByLabelText('Password')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: "Don't have an account? Sign up" })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Forgot your password?' })).not.toBeInTheDocument()
@@ -65,7 +66,7 @@ describe('self-hosted auth routes', () => {
     await user.click(screen.getByRole('button', { name: 'Sign in' }))
 
     await waitFor(() => {
-      expect(login).toHaveBeenCalledWith('admin@local', 'correct-horse-battery')
+      expect(login).toHaveBeenCalledWith(SELF_HOSTED_ADMIN_EMAIL, 'correct-horse-battery')
     })
   })
 
@@ -73,7 +74,7 @@ describe('self-hosted auth routes', () => {
     mockUseAuth.mockReturnValue({
       ...unauthenticatedSelfHostedAuth,
       isAuthenticated: true,
-      user: { id: 1, email: 'admin@local', is_admin: true, is_demo: false, email_verified: true },
+      user: { id: 1, email: SELF_HOSTED_ADMIN_EMAIL, is_admin: true, is_demo: false, email_verified: true },
       login: jest.fn(),
       logout: jest.fn(),
     })
@@ -90,7 +91,7 @@ describe('self-hosted auth routes', () => {
     mockUseAuth.mockReturnValue({
       ...unauthenticatedSelfHostedAuth,
       isAuthenticated: true,
-      user: { id: 1, email: 'admin@local', is_admin: true, is_demo: false, email_verified: true },
+      user: { id: 1, email: SELF_HOSTED_ADMIN_EMAIL, is_admin: true, is_demo: false, email_verified: true },
       login: jest.fn(),
       logout,
     })

--- a/frontend/src/app/__tests__/self-hosted-auth-routes.test.tsx
+++ b/frontend/src/app/__tests__/self-hosted-auth-routes.test.tsx
@@ -51,7 +51,7 @@ describe('self-hosted auth routes', () => {
     expect(screen.queryByRole('button', { name: 'Forgot your password?' })).not.toBeInTheDocument()
   })
 
-  it('submits self-hosted login with admin@local and the entered password', async () => {
+  it('submits self-hosted login with the default admin email and the entered password', async () => {
     const user = userEvent.setup()
     const login = jest.fn().mockResolvedValue(undefined)
     mockUseAuth.mockReturnValue({

--- a/frontend/src/app/__tests__/self-hosted-auth-routes.test.tsx
+++ b/frontend/src/app/__tests__/self-hosted-auth-routes.test.tsx
@@ -40,10 +40,11 @@ describe('self-hosted auth routes', () => {
     })
   })
 
-  it('renders self-hosted sign-in with the built-in admin email', () => {
+  it('renders self-hosted sign-in with only the password field visible', () => {
     render(<SignInPage />)
 
-    expect(screen.getByLabelText('Email')).toHaveValue('admin@local')
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('admin@local')).toHaveAttribute('autocomplete', 'username')
     expect(screen.getByLabelText('Password')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: "Don't have an account? Sign up" })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Forgot your password?' })).not.toBeInTheDocument()

--- a/frontend/src/app/sign-in/page.tsx
+++ b/frontend/src/app/sign-in/page.tsx
@@ -135,7 +135,7 @@ export default function SignInPage() {
               // Hidden username hint so password managers can pair the fixed
               // self-hosted username with the visible password field.
               <input
-                type="text"
+                type="email"
                 name="username"
                 value={SELF_HOSTED_ADMIN_EMAIL}
                 autoComplete="username"

--- a/frontend/src/app/sign-in/page.tsx
+++ b/frontend/src/app/sign-in/page.tsx
@@ -132,6 +132,8 @@ export default function SignInPage() {
 
           <form onSubmit={handleLogin} className="space-y-4">
             {isSelfHostedMode ? (
+              // Hidden username hint so password managers can pair the fixed
+              // self-hosted username with the visible password field.
               <input
                 type="text"
                 name="username"
@@ -151,7 +153,7 @@ export default function SignInPage() {
                   placeholder={tCommon('emailPlaceholder')}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  autoComplete="username"
+                  autoComplete="email"
                   required
                   disabled={isLoading}
                 />

--- a/frontend/src/app/sign-in/page.tsx
+++ b/frontend/src/app/sign-in/page.tsx
@@ -138,9 +138,8 @@ export default function SignInPage() {
                 value={SELF_HOSTED_ADMIN_EMAIL}
                 autoComplete="username"
                 readOnly
-                className="sr-only"
+                className="hidden"
                 tabIndex={-1}
-                aria-hidden="true"
               />
             ) : (
               <div className="space-y-2">

--- a/frontend/src/app/sign-in/page.tsx
+++ b/frontend/src/app/sign-in/page.tsx
@@ -14,12 +14,14 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { ApiError, getTranslatedApiError } from '@/lib/utils'
 
+const SELF_HOSTED_ADMIN_EMAIL = 'admin@local'
+
 export default function SignInPage() {
   const t = useTranslations('auth.signIn')
   const tCommon = useTranslations('common')
   const tErrors = useTranslations('errors.api')
   const { login, isAuthenticated, isSelfHostedMode } = useAuth()
-  const [email, setEmail] = useState(isSelfHostedMode ? 'admin@local' : '')
+  const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
@@ -38,7 +40,7 @@ export default function SignInPage() {
     setIsLoading(true)
 
     try {
-      await login(email, password)
+      await login(isSelfHostedMode ? SELF_HOSTED_ADMIN_EMAIL : email, password)
       // Navigation is handled by the login function in auth context
     } catch (err) {
       if (err instanceof ApiError) {
@@ -130,26 +132,43 @@ export default function SignInPage() {
           )}
 
           <form onSubmit={handleLogin} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="email">{tCommon('emailLabel')}</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder={tCommon('emailPlaceholder')}
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                disabled={isLoading}
+            {isSelfHostedMode ? (
+              <input
+                type="text"
+                name="username"
+                value={SELF_HOSTED_ADMIN_EMAIL}
+                autoComplete="username"
+                readOnly
+                className="sr-only"
+                tabIndex={-1}
+                aria-hidden="true"
               />
-            </div>
+            ) : (
+              <div className="space-y-2">
+                <Label htmlFor="email">{tCommon('emailLabel')}</Label>
+                <Input
+                  id="email"
+                  name="username"
+                  type="email"
+                  placeholder={tCommon('emailPlaceholder')}
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="username"
+                  required
+                  disabled={isLoading}
+                />
+              </div>
+            )}
             <div className="space-y-2">
               <Label htmlFor="password">{tCommon('passwordLabel')}</Label>
               <Input
                 id="password"
+                name="password"
                 type="password"
                 placeholder={t('passwordPlaceholder')}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
                 required
                 disabled={isLoading}
               />
@@ -157,7 +176,7 @@ export default function SignInPage() {
             <Button
               type="submit"
               className="w-full"
-              disabled={isLoading || !email || !password}
+              disabled={isLoading || (!isSelfHostedMode && !email) || !password}
             >
               {isLoading ? (
                 <>

--- a/frontend/src/app/sign-in/page.tsx
+++ b/frontend/src/app/sign-in/page.tsx
@@ -140,7 +140,7 @@ export default function SignInPage() {
                 value={SELF_HOSTED_ADMIN_EMAIL}
                 autoComplete="username"
                 readOnly
-                className="hidden"
+                hidden
                 tabIndex={-1}
               />
             ) : (
@@ -176,7 +176,7 @@ export default function SignInPage() {
             <Button
               type="submit"
               className="w-full"
-              disabled={isLoading || (!isSelfHostedMode && !email) || !password}
+              disabled={isLoading || !password || (!isSelfHostedMode && !email)}
             >
               {isLoading ? (
                 <>

--- a/frontend/src/app/sign-in/page.tsx
+++ b/frontend/src/app/sign-in/page.tsx
@@ -13,8 +13,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { ApiError, getTranslatedApiError } from '@/lib/utils'
-
-const SELF_HOSTED_ADMIN_EMAIL = 'admin@local'
+import { SELF_HOSTED_ADMIN_EMAIL } from '@/lib/constants'
 
 export default function SignInPage() {
   const t = useTranslations('auth.signIn')

--- a/frontend/src/components/__tests__/user-dropdown.test.tsx
+++ b/frontend/src/components/__tests__/user-dropdown.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { UserDropdown } from '../user-dropdown'
+
+const mockPush = jest.fn()
+const mockUseAuth = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}))
+
+jest.mock('../../contexts/auth-context', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+describe('UserDropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows a self-hosted admin label without exposing admin@local', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'admin@local', name: 'Admin', is_admin: true, is_demo: false, email_verified: true },
+      isCloudMode: false,
+      isSelfHostedMode: true,
+    })
+
+    render(<UserDropdown />)
+
+    expect(screen.getByRole('button', { name: /admin/i })).toBeInTheDocument()
+    expect(screen.queryByText('admin@local')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /admin/i }))
+
+    expect(screen.getAllByText('Admin')).toHaveLength(2)
+    expect(screen.queryByText('admin@local')).not.toBeInTheDocument()
+  })
+
+  it('keeps cloud user email visible', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, email: 'user@example.com', name: 'Cloud User', is_admin: false, is_demo: false, email_verified: true },
+      isCloudMode: true,
+      isSelfHostedMode: false,
+    })
+
+    render(<UserDropdown />)
+
+    expect(screen.getByRole('button', { name: /cloud user/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /cloud user/i }))
+
+    expect(screen.getByText('user@example.com')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/user-dropdown.test.tsx
+++ b/frontend/src/components/__tests__/user-dropdown.test.tsx
@@ -21,7 +21,7 @@ describe('UserDropdown', () => {
     jest.clearAllMocks()
   })
 
-  it('shows a self-hosted admin label without exposing admin@local', async () => {
+  it('shows a self-hosted admin label without exposing the default admin email', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({
       user: { id: 1, email: SELF_HOSTED_ADMIN_EMAIL, name: 'Admin', is_admin: true, is_demo: false, email_verified: true },

--- a/frontend/src/components/__tests__/user-dropdown.test.tsx
+++ b/frontend/src/components/__tests__/user-dropdown.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { UserDropdown } from '../user-dropdown'
+import { SELF_HOSTED_ADMIN_EMAIL } from '@/lib/constants'
 
 const mockPush = jest.fn()
 const mockUseAuth = jest.fn()
@@ -23,7 +24,7 @@ describe('UserDropdown', () => {
   it('shows a self-hosted admin label without exposing admin@local', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({
-      user: { id: 1, email: 'admin@local', name: 'Admin', is_admin: true, is_demo: false, email_verified: true },
+      user: { id: 1, email: SELF_HOSTED_ADMIN_EMAIL, name: 'Admin', is_admin: true, is_demo: false, email_verified: true },
       isCloudMode: false,
       isSelfHostedMode: true,
     })
@@ -31,12 +32,12 @@ describe('UserDropdown', () => {
     render(<UserDropdown />)
 
     expect(screen.getByRole('button', { name: /admin/i })).toBeInTheDocument()
-    expect(screen.queryByText('admin@local')).not.toBeInTheDocument()
+    expect(screen.queryByText(SELF_HOSTED_ADMIN_EMAIL)).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /admin/i }))
 
     expect(screen.getAllByText('Admin')).toHaveLength(2)
-    expect(screen.queryByText('admin@local')).not.toBeInTheDocument()
+    expect(screen.queryByText(SELF_HOSTED_ADMIN_EMAIL)).not.toBeInTheDocument()
   })
 
   it('keeps cloud user email visible', async () => {

--- a/frontend/src/components/user-dropdown.tsx
+++ b/frontend/src/components/user-dropdown.tsx
@@ -29,7 +29,7 @@ export function UserDropdown() {
   }
 
   const isSelfHostedAdmin = isSelfHostedMode && user.email === SELF_HOSTED_ADMIN_EMAIL
-  const displayName = isSelfHostedAdmin ? (user.name || 'Admin') : (user.name || user.email)
+  const displayName = isSelfHostedAdmin ? tNav('adminLabel') : (user.name || user.email)
   const currentTier = user.subscription_tier || 'personal'
   const isDemoUser = user.email === DEMO_USER_EMAIL
   const showEmail = !isDemoUser && !isSelfHostedAdmin

--- a/frontend/src/components/user-dropdown.tsx
+++ b/frontend/src/components/user-dropdown.tsx
@@ -28,7 +28,7 @@ export function UserDropdown() {
     return null
   }
 
-  const isSelfHostedAdmin = isSelfHostedMode && user.email === SELF_HOSTED_ADMIN_EMAIL
+  const isSelfHostedAdmin = isSelfHostedMode && user.email.toLowerCase() === SELF_HOSTED_ADMIN_EMAIL.toLowerCase()
   const displayName = isSelfHostedAdmin ? tNav('adminLabel') : (user.name || user.email)
   const currentTier = user.subscription_tier || 'personal'
   const isDemoUser = user.email === DEMO_USER_EMAIL

--- a/frontend/src/components/user-dropdown.tsx
+++ b/frontend/src/components/user-dropdown.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { User, LogOut, ChevronDown, CreditCard, Settings, MessageSquare } from 'lucide-react'
 import { getTierDisplayName } from '@/lib/pricing-data'
+import { DEMO_USER_EMAIL, SELF_HOSTED_ADMIN_EMAIL } from '@/lib/constants'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 
@@ -27,10 +28,10 @@ export function UserDropdown() {
     return null
   }
 
-  const isSelfHostedAdmin = isSelfHostedMode && user.email === 'admin@local'
+  const isSelfHostedAdmin = isSelfHostedMode && user.email === SELF_HOSTED_ADMIN_EMAIL
   const displayName = isSelfHostedAdmin ? (user.name || 'Admin') : (user.name || user.email)
   const currentTier = user.subscription_tier || 'personal'
-  const isDemoUser = user.email === 'demo@canarybitcoin.com'
+  const isDemoUser = user.email === DEMO_USER_EMAIL
   const showEmail = !isDemoUser && !isSelfHostedAdmin
 
   return (

--- a/frontend/src/components/user-dropdown.tsx
+++ b/frontend/src/components/user-dropdown.tsx
@@ -18,7 +18,7 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 
 export function UserDropdown() {
-  const { user, isCloudMode } = useAuth()
+  const { user, isCloudMode, isSelfHostedMode } = useAuth()
   const router = useRouter()
   const [isOpen, setIsOpen] = useState(false)
   const tNav = useTranslations('nav')
@@ -27,9 +27,11 @@ export function UserDropdown() {
     return null
   }
 
-  const displayName = user.name || user.email
+  const isSelfHostedAdmin = isSelfHostedMode && user.email === 'admin@local'
+  const displayName = isSelfHostedAdmin ? (user.name || 'Admin') : (user.name || user.email)
   const currentTier = user.subscription_tier || 'personal'
   const isDemoUser = user.email === 'demo@canarybitcoin.com'
+  const showEmail = !isDemoUser && !isSelfHostedAdmin
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -46,10 +48,10 @@ export function UserDropdown() {
       <DropdownMenuContent align="end" className="w-64">
         <div className="flex items-start justify-between gap-2 p-3">
           <div className="flex flex-col space-y-1 leading-none min-w-0 flex-1">
-            {user.name && (
-              <p className="text-sm font-medium truncate">{user.name}</p>
+            {(user.name || isSelfHostedAdmin) && (
+              <p className="text-sm font-medium truncate">{displayName}</p>
             )}
-            {!isDemoUser && (
+            {showEmail && (
               <p className="text-xs text-muted-foreground truncate">{user.email}</p>
             )}
             {!user.is_admin && !isDemoUser && (

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -10,6 +10,8 @@
 // =============================================================================
 
 export const SUPPORT_EMAIL = 'support@canarybitcoin.com'
+export const SELF_HOSTED_ADMIN_EMAIL = 'admin@local'
+export const DEMO_USER_EMAIL = 'demo@canarybitcoin.com'
 
 // =============================================================================
 // Validation Regex Patterns


### PR DESCRIPTION
## Summary
- hide the visible email field in self-hosted sign-in while preserving a hidden username field for password managers
- submit the fixed admin@local username internally for self-hosted login
- show Admin instead of admin@local in the self-hosted user dropdown

Closes #381

## Tests
- pnpm test -- self-hosted-auth-routes user-dropdown
- pnpm lint