### PR TITLE
Move self-hosted settings into user dropdown

### DIFF
--- a/frontend/src/components/__tests__/app-header.test.tsx
+++ b/frontend/src/components/__tests__/app-header.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { AppHeader } from '../app-header'
+
+const mockUseAuth = jest.fn()
+const mockUsePathname = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}))
+
+jest.mock('../../contexts/auth-context', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+jest.mock('../user-dropdown', () => ({
+  UserDropdown: () => <div data-testid="user-dropdown" />,
+}))
+
+describe('AppHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUsePathname.mockReturnValue('/wallets')
+  })
+
+  it('does not render a standalone settings button in self-hosted mode', () => {
+    mockUseAuth.mockReturnValue({
+      isCloudMode: false,
+      user: { id: 1, email: 'admin@local', is_admin: true, is_demo: false, email_verified: true },
+    })
+
+    render(<AppHeader />)
+
+    expect(screen.queryByRole('button', { name: 'Settings' })).not.toBeInTheDocument()
+    expect(screen.getByTestId('user-dropdown')).toBeInTheDocument()
+  })
+
+  it('keeps the add wallet button available for authenticated self-hosted users', () => {
+    mockUseAuth.mockReturnValue({
+      isCloudMode: false,
+      user: { id: 1, email: 'admin@local', is_admin: true, is_demo: false, email_verified: true },
+    })
+
+    render(<AppHeader />)
+
+    expect(screen.getByRole('button', { name: 'Add Wallet' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/user-dropdown.test.tsx
+++ b/frontend/src/components/__tests__/user-dropdown.test.tsx
@@ -21,7 +21,7 @@ describe('UserDropdown', () => {
     jest.clearAllMocks()
   })
 
-  it('shows a self-hosted admin label without exposing the default admin email', async () => {
+  it('shows self-hosted Settings and Sign out without cloud-only items', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({
       user: { id: 1, email: SELF_HOSTED_ADMIN_EMAIL, name: 'Admin', is_admin: true, is_demo: false, email_verified: true },
@@ -38,9 +38,16 @@ describe('UserDropdown', () => {
 
     expect(screen.getAllByText('Admin')).toHaveLength(2)
     expect(screen.queryByText(SELF_HOSTED_ADMIN_EMAIL)).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings')
+    expect(screen.queryByRole('link', { name: 'Contact' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Subscription' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('menuitem', { name: 'Sign out' }))
+
+    expect(mockPush).toHaveBeenCalledWith('/sign-out')
   })
 
-  it('keeps cloud user email visible', async () => {
+  it('keeps cloud non-admin menu items visible', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({
       user: { id: 2, email: 'user@example.com', name: 'Cloud User', is_admin: false, is_demo: false, email_verified: true },
@@ -55,5 +62,43 @@ describe('UserDropdown', () => {
     await user.click(screen.getByRole('button', { name: /cloud user/i }))
 
     expect(screen.getByText('user@example.com')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings')
+    expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact')
+    expect(screen.getByRole('link', { name: 'Subscription' })).toHaveAttribute('href', '/subscription')
+  })
+
+  it('keeps cloud admin subscription hidden', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      user: { id: 3, email: 'admin@example.com', name: 'Cloud Admin', is_admin: true, is_demo: false, email_verified: true },
+      isCloudMode: true,
+      isSelfHostedMode: false,
+    })
+
+    render(<UserDropdown />)
+
+    await user.click(screen.getByRole('button', { name: /cloud admin/i }))
+
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings')
+    expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact')
+    expect(screen.queryByRole('link', { name: 'Subscription' })).not.toBeInTheDocument()
+  })
+
+  it('keeps cloud demo dropdown minimal', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      user: { id: 4, email: 'demo@canarybitcoin.com', name: 'Demo User', is_admin: false, is_demo: true, email_verified: true },
+      isCloudMode: true,
+      isSelfHostedMode: false,
+    })
+
+    render(<UserDropdown />)
+
+    await user.click(screen.getByRole('button', { name: /demo user/i }))
+
+    expect(screen.queryByRole('link', { name: 'Settings' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Contact' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Subscription' })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Sign out' })).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/app-header.tsx
+++ b/frontend/src/components/app-header.tsx
@@ -4,7 +4,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { Plus, Settings } from "lucide-react"
+import { Plus } from "lucide-react"
 import { UserDropdown } from "@/components/user-dropdown"
 import { useAuth } from "@/contexts/auth-context"
 import { useTranslations } from "next-intl"
@@ -47,21 +47,6 @@ export function AppHeader() {
             >
               <Plus size={16} />
               <span className="hidden sm:inline" aria-hidden="true">{tNav('addWallet')}</span>
-            </Button>
-          </Link>
-        )}
-
-        {/* Settings button for self-hosted mode */}
-        {!isCloudMode && (
-          <Link href="/settings">
-            <Button
-              variant="outline"
-              size="sm"
-              className="gap-1.5 sm:gap-2"
-              aria-label={tNav('settings')}
-            >
-              <Settings size={16} />
-              <span className="hidden sm:inline" aria-hidden="true">{tNav('settings')}</span>
             </Button>
           </Link>
         )}

--- a/frontend/src/components/user-dropdown.tsx
+++ b/frontend/src/components/user-dropdown.tsx
@@ -33,6 +33,9 @@ export function UserDropdown() {
   const currentTier = user.subscription_tier || 'personal'
   const isDemoUser = user.email === DEMO_USER_EMAIL
   const showEmail = !isDemoUser && !isSelfHostedAdmin
+  const showTierBadge = isCloudMode && !user.is_admin && !isDemoUser
+  const showSettings = !isDemoUser
+  const showCloudMenuItems = isCloudMode && !isDemoUser
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -55,7 +58,7 @@ export function UserDropdown() {
             {showEmail && (
               <p className="text-xs text-muted-foreground truncate">{user.email}</p>
             )}
-            {!user.is_admin && !isDemoUser && (
+            {showTierBadge && (
               <div className="flex items-center gap-2 mt-1">
                 <Badge variant="secondary" className="text-xs">
                   {getTierDisplayName(currentTier)}
@@ -65,7 +68,7 @@ export function UserDropdown() {
           </div>
         </div>
         
-        {isCloudMode && !isDemoUser && (
+        {showSettings && (
           <>
             <DropdownMenuSeparator />
 
@@ -76,20 +79,24 @@ export function UserDropdown() {
               </DropdownMenuItem>
             </Link>
 
-            <Link href="/contact" className="block">
-              <DropdownMenuItem className="cursor-pointer">
-                <MessageSquare className="mr-2 h-4 w-4" />
-                <span>{tNav('contact')}</span>
-              </DropdownMenuItem>
-            </Link>
+            {showCloudMenuItems && (
+              <>
+                <Link href="/contact" className="block">
+                  <DropdownMenuItem className="cursor-pointer">
+                    <MessageSquare className="mr-2 h-4 w-4" />
+                    <span>{tNav('contact')}</span>
+                  </DropdownMenuItem>
+                </Link>
 
-            {!user.is_admin && (
-              <Link href="/subscription" className="block">
-                <DropdownMenuItem className="cursor-pointer">
-                  <CreditCard className="mr-2 h-4 w-4" />
-                  <span>{tNav('subscription')}</span>
-                </DropdownMenuItem>
-              </Link>
+                {!user.is_admin && (
+                  <Link href="/subscription" className="block">
+                    <DropdownMenuItem className="cursor-pointer">
+                      <CreditCard className="mr-2 h-4 w-4" />
+                      <span>{tNav('subscription')}</span>
+                    </DropdownMenuItem>
+                  </Link>
+                )}
+              </>
             )}
 
             <DropdownMenuSeparator />

--- a/frontend/src/components/user-dropdown.tsx
+++ b/frontend/src/components/user-dropdown.tsx
@@ -33,6 +33,7 @@ export function UserDropdown() {
   const currentTier = user.subscription_tier || 'personal'
   const isDemoUser = user.email === DEMO_USER_EMAIL
   const showEmail = !isDemoUser && !isSelfHostedAdmin
+  // Subscription tiers are cloud-only; keep self-hosted account menus minimal.
   const showTierBadge = isCloudMode && !user.is_admin && !isDemoUser
   const showSettings = !isDemoUser
   const showCloudMenuItems = isCloudMode && !isDemoUser
@@ -99,7 +100,9 @@ export function UserDropdown() {
               </>
             )}
 
-            <DropdownMenuSeparator />
+            {showCloudMenuItems && (
+              <DropdownMenuSeparator />
+            )}
           </>
         )}
 

--- a/frontend/src/components/user-dropdown.tsx
+++ b/frontend/src/components/user-dropdown.tsx
@@ -37,6 +37,7 @@ export function UserDropdown() {
   const showTierBadge = isCloudMode && !user.is_admin && !isDemoUser
   const showSettings = !isDemoUser
   const showCloudMenuItems = isCloudMode && !isDemoUser
+  const showSignOutSeparator = showSettings || (isCloudMode && isDemoUser)
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -99,14 +100,10 @@ export function UserDropdown() {
                 )}
               </>
             )}
-
-            {showCloudMenuItems && (
-              <DropdownMenuSeparator />
-            )}
           </>
         )}
 
-        {isCloudMode && isDemoUser && (
+        {showSignOutSeparator && (
           <DropdownMenuSeparator />
         )}
 


### PR DESCRIPTION
## Summary
- remove the standalone self-hosted Settings button from the app header
- share the existing dropdown Settings item with self-hosted users
- keep Contact and Subscription cloud-only while preserving cloud demo/admin behavior

Closes #379

## Tests
- pnpm test -- app-header user-dropdown
- pnpm lint