### PR TITLE
Avoid empty footer timestamp separator

### DIFF
--- a/frontend/src/components/__tests__/app-footer.test.tsx
+++ b/frontend/src/components/__tests__/app-footer.test.tsx
@@ -41,8 +41,9 @@ describe('AppFooter', () => {
 
     render(<AppFooter />)
 
-    expect(screen.getByText('Block 892,441')).toBeInTheDocument()
-    expect(screen.queryByText(/•/)).not.toBeInTheDocument()
+    const blockInfo = screen.getByText('Block 892,441')
+    expect(blockInfo).toBeInTheDocument()
+    expect(blockInfo).not.toHaveTextContent('•')
   })
 
   it('renders the timestamp separator with relative time text', () => {

--- a/frontend/src/components/__tests__/app-footer.test.tsx
+++ b/frontend/src/components/__tests__/app-footer.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import { AppFooter } from '../app-footer'
+
+const mockUseAuth = jest.fn()
+const mockUseBlockHeader = jest.fn()
+const mockUseRelativeTime = jest.fn()
+
+jest.mock('../../contexts/auth-context', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+jest.mock('../../hooks/useBlockHeader', () => ({
+  useBlockHeader: () => mockUseBlockHeader(),
+}))
+
+jest.mock('../../hooks/useRelativeTime', () => ({
+  useRelativeTime: (timestamp: number | undefined) => mockUseRelativeTime(timestamp),
+}))
+
+jest.mock('../../hooks/useFormatters', () => ({
+  useFormatters: () => ({
+    formatNumber: (value: number) => value.toLocaleString('en-US'),
+  }),
+}))
+
+describe('AppFooter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseAuth.mockReturnValue({ isCloudMode: false })
+    mockUseBlockHeader.mockReturnValue({
+      blockHeader: {
+        height: 892441,
+        timestamp: 1744178400,
+        network: 'mainnet',
+      },
+    })
+  })
+
+  it('does not render the timestamp separator while relative time is empty', () => {
+    mockUseRelativeTime.mockReturnValue('')
+
+    render(<AppFooter />)
+
+    expect(screen.getByText('Block 892,441')).toBeInTheDocument()
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument()
+  })
+
+  it('renders the timestamp separator with relative time text', () => {
+    mockUseRelativeTime.mockReturnValue('2 minutes ago')
+
+    render(<AppFooter />)
+
+    expect(screen.getByText('Block 892,441 • 2 minutes ago')).toBeInTheDocument()
+  })
+
+  it('renders the network fallback when no block header is available', () => {
+    mockUseBlockHeader.mockReturnValue({ blockHeader: null })
+    mockUseRelativeTime.mockReturnValue('')
+
+    render(<AppFooter />)
+
+    expect(screen.getByText('Connecting to network...')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/app-footer.tsx
+++ b/frontend/src/components/app-footer.tsx
@@ -33,7 +33,8 @@ export function AppFooter() {
             <h3 className="text-lg font-bold tracking-wide">{t('appName')}</h3>
             {blockHeader ? (
               <p className="text-muted-foreground text-sm">
-                {t('blockInfo', { height: formatNumber(blockHeader.height) })} • {blockHeaderTime}
+                {t('blockInfo', { height: formatNumber(blockHeader.height) })}
+                {blockHeaderTime && ` • ${blockHeaderTime}`}
               </p>
             ) : (
               <p className="text-muted-foreground text-sm">{tCommon('connectingToNetwork')}</p>


### PR DESCRIPTION
## Summary
- render the footer timestamp separator only when relative time text is available
- add AppFooter coverage for empty relative time, populated relative time, and no block header

## Tests
- pnpm test -- app-footer

Fixes #356