### PR TITLE
Redesign settings endpoint selectors

### DIFF
--- a/backend/src/handlers/user_preferences.rs
+++ b/backend/src/handlers/user_preferences.rs
@@ -183,35 +183,45 @@ pub async fn update_user_preferences(
 
     if let Some(preferred_tx_explorer_id_update) = &request.preferred_tx_explorer_id {
         let explorer_id_to_store = match preferred_tx_explorer_id_update.as_deref() {
-            None | Some("") => None,
+            None => None,
             Some(preferred_tx_explorer_id) => {
-                let is_supported_public_explorer = matches!(
-                    preferred_tx_explorer_id,
-                    "mempool-space" | "bitfeed-public" | "btc-rpc-explorer-public"
-                );
-                let is_configured_local_explorer = config.is_self_hosted_mode()
-                    && config
-                        .tx_explorers()
-                        .iter()
-                        .any(|explorer| explorer.id == preferred_tx_explorer_id);
+                let preferred_tx_explorer_id = preferred_tx_explorer_id.trim();
+                if preferred_tx_explorer_id.is_empty() {
+                    None
+                } else {
+                    let custom_explorer_id =
+                        canonical_custom_tx_explorer_id(preferred_tx_explorer_id);
+                    let is_supported_public_explorer = matches!(
+                        preferred_tx_explorer_id,
+                        "mempool-space" | "bitfeed-public" | "btc-rpc-explorer-public"
+                    );
+                    let is_configured_local_explorer = config.is_self_hosted_mode()
+                        && config
+                            .tx_explorers()
+                            .iter()
+                            .any(|explorer| explorer.id == preferred_tx_explorer_id);
 
-                if !is_supported_public_explorer && !is_configured_local_explorer {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(ErrorResponse::new(format!(
-                            "Unsupported tx explorer: {}",
-                            preferred_tx_explorer_id
-                        ))),
-                    )
-                        .into_response();
+                    if !is_supported_public_explorer
+                        && custom_explorer_id.is_none()
+                        && !is_configured_local_explorer
+                    {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(ErrorResponse::coded(
+                                "unsupported_tx_explorer",
+                                format!("Unsupported tx explorer: {}", preferred_tx_explorer_id),
+                            )),
+                        )
+                            .into_response();
+                    }
+                    Some(custom_explorer_id.unwrap_or_else(|| preferred_tx_explorer_id.to_string()))
                 }
-                Some(preferred_tx_explorer_id)
             }
         };
 
         if let Err(e) = app_services
             .metadata_db
-            .update_user_preferred_tx_explorer_id(&user.user_id, explorer_id_to_store)
+            .update_user_preferred_tx_explorer_id(&user.user_id, explorer_id_to_store.as_deref())
             .await
         {
             return (
@@ -370,4 +380,17 @@ pub async fn update_user_preferences(
         ntfy_username,
     })
     .into_response()
+}
+
+fn canonical_custom_tx_explorer_id(preferred_tx_explorer_id: &str) -> Option<String> {
+    let template = preferred_tx_explorer_id.strip_prefix("custom:")?;
+    let trimmed_template = template.trim();
+
+    if trimmed_template.contains("{txid}")
+        && (trimmed_template.starts_with("http://") || trimmed_template.starts_with("https://"))
+    {
+        Some(format!("custom:{}", trimmed_template))
+    } else {
+        None
+    }
 }

--- a/backend/tests/config_endpoint_tests.rs
+++ b/backend/tests/config_endpoint_tests.rs
@@ -371,7 +371,7 @@ async fn test_user_preferences_accepts_supported_tx_explorer_ids() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["preferred_tx_explorer_id"], "mempool-space");
 
-    let (status, body) = update_tx_explorer_preference(app, &token, "bitfeed").await;
+    let (status, body) = update_tx_explorer_preference(app, &token, " bitfeed ").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["preferred_tx_explorer_id"], "bitfeed");
 }
@@ -398,6 +398,115 @@ async fn test_user_preferences_rejects_unsupported_tx_explorer_id() {
     let (status, body) = update_tx_explorer_preference(app, &token, "unknown").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(body["error"], "Unsupported tx explorer: unknown");
+}
+
+#[tokio::test]
+async fn test_user_preferences_accepts_custom_tx_explorer_template() {
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        tempdir().unwrap().path().to_str().unwrap().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        Some(TEST_JWT_SECRET.to_string()),
+    );
+    let (app, app_services, _temp_dir) = create_test_app_with_config_and_services(config).await;
+    let token = auth_token_for_user(
+        &app_services,
+        TEST_JWT_SECRET,
+        "custom-explorer-user@example.com",
+    )
+    .await;
+
+    let custom_preference = "custom:https://example.com/transaction/{txid}";
+    let (status, body) =
+        update_tx_explorer_preference(app.clone(), &token, custom_preference).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["preferred_tx_explorer_id"], custom_preference);
+
+    let custom_preference_with_spaces = " custom:https://example.com/tx/{txid} ";
+    let (status, body) =
+        update_tx_explorer_preference(app.clone(), &token, custom_preference_with_spaces).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["preferred_tx_explorer_id"],
+        "custom:https://example.com/tx/{txid}"
+    );
+
+    let custom_preference_with_inner_spaces = "custom: https://example.com/tx/{txid} ";
+    let (status, body) =
+        update_tx_explorer_preference(app, &token, custom_preference_with_inner_spaces).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["preferred_tx_explorer_id"],
+        "custom:https://example.com/tx/{txid}"
+    );
+}
+
+#[tokio::test]
+async fn test_user_preferences_accepts_custom_tx_explorer_template_in_cloud_mode() {
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        tempdir().unwrap().path().to_str().unwrap().to_string(),
+        OperatingMode::Cloud,
+        Some("http://localhost:3001".to_string()),
+        Some(TEST_JWT_SECRET.to_string()),
+    );
+    let (app, app_services, _temp_dir) = create_test_app_with_config_and_services(config).await;
+    let token = auth_token_for_user(
+        &app_services,
+        TEST_JWT_SECRET,
+        "cloud-custom-explorer-user@example.com",
+    )
+    .await;
+
+    let custom_preference = "custom:https://example.com/transaction/{txid}";
+    let (status, body) = update_tx_explorer_preference(app, &token, custom_preference).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["preferred_tx_explorer_id"], custom_preference);
+}
+
+#[tokio::test]
+async fn test_user_preferences_rejects_invalid_custom_tx_explorer_template() {
+    let config = AppConfig::new_for_test(
+        NetworkConfig::Regtest,
+        Some("tcp://127.0.0.1:50001".to_string()),
+        "127.0.0.1:3000".to_string(),
+        tempdir().unwrap().path().to_str().unwrap().to_string(),
+        OperatingMode::SelfHosted,
+        None,
+        Some(TEST_JWT_SECRET.to_string()),
+    );
+    let (app, app_services, _temp_dir) = create_test_app_with_config_and_services(config).await;
+    let token = auth_token_for_user(
+        &app_services,
+        TEST_JWT_SECRET,
+        "invalid-custom-explorer-user@example.com",
+    )
+    .await;
+
+    for custom_preference in [
+        "custom:https://example.com/transaction/",
+        "custom:ftp://example.com/transaction/{txid}",
+        "custom:",
+        "custom:   ",
+    ] {
+        let (status, body) =
+            update_tx_explorer_preference(app.clone(), &token, custom_preference).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            body["error"],
+            format!("Unsupported tx explorer: {}", custom_preference.trim())
+        );
+    }
 }
 
 #[tokio::test]

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -338,6 +338,7 @@
       "serverLabel": "ntfy Server URL",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "Lokal ntfy kræver godkendelse. Opret et adgangstoken i ntfy og indsæt det nedenfor.",
+      "customUrl": "Brugerdefineret URL",
       "validation": {
         "urlRequired": "ntfy-server URL er påkrævet",
         "urlProtocol": "ntfy-server URL skal starte med http:// eller https://",
@@ -390,6 +391,15 @@
       "note": "Det valgte mål bruges til transaktionslinks og erstatningstransaktioner i hele appen.",
       "publicGroup": "Offentlig",
       "localGroup": "Lokal",
+      "custom": {
+        "title": "Brugerdefineret udforsker",
+        "endpointLabel": "Brugerdefineret URL",
+        "label": "URL til brugerdefineret udforsker",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "Forhåndsvisning: {url}",
+        "validation": "Indtast en URL, der starter med http:// eller https:// og indeholder '{txid}'.",
+        "saveFailed": "Kunne ikke gemme brugerdefineret udforsker"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -290,6 +290,7 @@
       "serverLabel": "ntfy Server-URL",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "Lokales ntfy erfordert Authentifizierung. Erstellen Sie ein Zugriffstoken in ntfy und fügen Sie es unten ein.",
+      "customUrl": "Benutzerdefinierte URL",
       "validation": {
         "urlRequired": "ntfy-Server-URL ist erforderlich",
         "urlProtocol": "ntfy-Server-URL muss mit http:// oder https:// beginnen",
@@ -390,6 +391,15 @@
       "note": "Der ausgewählte Explorer wird appweit für Transaktions- und Ersatztransaktionslinks verwendet.",
       "publicGroup": "Öffentlich",
       "localGroup": "Lokal",
+      "custom": {
+        "title": "Benutzerdefinierter Explorer",
+        "endpointLabel": "Benutzerdefinierte URL",
+        "label": "URL für benutzerdefinierten Explorer",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "Vorschau: {url}",
+        "validation": "Gib eine URL ein, die mit http:// oder https:// beginnt und '{txid}' enthält.",
+        "saveFailed": "Benutzerdefinierter Explorer konnte nicht gespeichert werden"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -338,6 +338,7 @@
       "serverLabel": "ntfy Server URL",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "Local ntfy requires authentication. Create an access token in ntfy and paste it below.",
+      "customUrl": "Custom URL",
       "validation": {
         "urlRequired": "ntfy server URL is required",
         "urlProtocol": "ntfy server URL must start with http:// or https://",
@@ -390,6 +391,15 @@
       "note": "The selected explorer is used for transaction and replacement transaction links throughout the app.",
       "publicGroup": "Public",
       "localGroup": "Local",
+      "custom": {
+        "title": "Custom explorer",
+        "endpointLabel": "Custom URL",
+        "label": "Custom explorer URL",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "Preview: {url}",
+        "validation": "Enter a URL starting with http:// or https:// and include '{txid}'.",
+        "saveFailed": "Failed to save custom explorer"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -290,6 +290,7 @@
       "serverLabel": "URL del Servidor ntfy",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "ntfy local requiere autenticación. Crea un token de acceso en ntfy y pégalo abajo.",
+      "customUrl": "URL personalizada",
       "validation": {
         "urlRequired": "La URL del servidor ntfy es obligatoria",
         "urlProtocol": "La URL del servidor ntfy debe comenzar con http:// o https://",
@@ -390,6 +391,15 @@
       "note": "El explorador seleccionado se usa para enlaces de transacciones y transacciones de reemplazo en toda la app.",
       "publicGroup": "Público",
       "localGroup": "Local",
+      "custom": {
+        "title": "Explorador personalizado",
+        "endpointLabel": "URL personalizada",
+        "label": "URL del explorador personalizado",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "Vista previa: {url}",
+        "validation": "Ingresa una URL que comience con http:// o https:// e incluya '{txid}'.",
+        "saveFailed": "No se pudo guardar el explorador personalizado"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -290,6 +290,7 @@
       "serverLabel": "URL du serveur ntfy",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "Le ntfy local nécessite une authentification. Créez un token d'accès dans ntfy et collez-le ci-dessous.",
+      "customUrl": "URL personnalisée",
       "validation": {
         "urlRequired": "L'URL du serveur ntfy est requise",
         "urlProtocol": "L'URL du serveur ntfy doit commencer par http:// ou https://",
@@ -390,6 +391,15 @@
       "note": "L'explorateur choisi est utilisé pour les liens de transaction et de remplacement dans toute l'application.",
       "publicGroup": "Public",
       "localGroup": "Local",
+      "custom": {
+        "title": "Explorateur personnalisé",
+        "endpointLabel": "URL personnalisée",
+        "label": "URL de l’explorateur personnalisé",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "Aperçu : {url}",
+        "validation": "Saisissez une URL commençant par http:// ou https:// et contenant '{txid}'.",
+        "saveFailed": "Impossible d’enregistrer l’explorateur personnalisé"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -290,6 +290,7 @@
       "serverLabel": "ntfyサーバーURL",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "ローカルntfyには認証が必要です。ntfyでアクセストークンを作成し、下に貼り付けてください。",
+      "customUrl": "カスタムURL",
       "validation": {
         "urlRequired": "ntfyサーバーURLは必須です",
         "urlProtocol": "ntfyサーバーURLはhttp://またはhttps://で始まる必要があります",
@@ -390,6 +391,15 @@
       "note": "選択したエクスプローラーは、アプリ全体のトランザクションリンクと置換トランザクションリンクに使われます。",
       "publicGroup": "パブリック",
       "localGroup": "ローカル",
+      "custom": {
+        "title": "カスタムエクスプローラー",
+        "endpointLabel": "カスタムURL",
+        "label": "カスタムエクスプローラーURL",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "プレビュー: {url}",
+        "validation": "http:// または https:// で始まり、'{txid}' を含むURLを入力してください。",
+        "saveFailed": "カスタムエクスプローラーを保存できませんでした"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -338,6 +338,7 @@
       "serverLabel": "ntfy-server URL",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "Lokal ntfy krever autentisering. Opprett et tilgangstoken i ntfy og lim det inn nedenfor.",
+      "customUrl": "Egendefinert URL",
       "validation": {
         "urlRequired": "ntfy-server URL er påkrevd",
         "urlProtocol": "ntfy-server URL må starte med http:// eller https://",
@@ -390,6 +391,15 @@
       "note": "Det valgte målet brukes for transaksjonslenker og erstatningstransaksjoner i hele appen.",
       "publicGroup": "Offentlig",
       "localGroup": "Lokal",
+      "custom": {
+        "title": "Egendefinert utforsker",
+        "endpointLabel": "Egendefinert URL",
+        "label": "URL for egendefinert utforsker",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "Forhåndsvisning: {url}",
+        "validation": "Skriv inn en URL som starter med http:// eller https:// og inkluder '{txid}'.",
+        "saveFailed": "Kunne ikke lagre egendefinert utforsker"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -290,6 +290,7 @@
       "serverLabel": "URL do Servidor ntfy",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "O ntfy local requer autenticação. Crie um token de acesso no ntfy e cole-o abaixo.",
+      "customUrl": "URL personalizada",
       "validation": {
         "urlRequired": "A URL do servidor ntfy é obrigatória",
         "urlProtocol": "A URL do servidor ntfy deve começar com http:// ou https://",
@@ -390,6 +391,15 @@
       "note": "O explorador selecionado é usado para links de transação e de transação substituta em todo o app.",
       "publicGroup": "Público",
       "localGroup": "Local",
+      "custom": {
+        "title": "Explorador personalizado",
+        "endpointLabel": "URL personalizada",
+        "label": "URL do explorador personalizado",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "Prévia: {url}",
+        "validation": "Insira uma URL que comece com http:// ou https:// e inclua '{txid}'.",
+        "saveFailed": "Não foi possível salvar o explorador personalizado"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -338,6 +338,7 @@
       "serverLabel": "URL för ntfy-server",
       "serverPlaceholder": "https://ntfy.sh",
       "localAuthNote": "Lokal ntfy kräver autentisering. Skapa en åtkomsttoken i ntfy och klistra in den nedan.",
+      "customUrl": "Anpassad URL",
       "validation": {
         "urlRequired": "ntfy-serverns URL krävs",
         "urlProtocol": "ntfy-serverns URL måste börja med http:// eller https://",
@@ -390,6 +391,15 @@
       "note": "Det valda målet används för transaktionslänkar och ersättningstransaktioner i hela appen.",
       "publicGroup": "Offentlig",
       "localGroup": "Lokal",
+      "custom": {
+        "title": "Anpassad utforskare",
+        "endpointLabel": "Anpassad URL",
+        "label": "URL för anpassad utforskare",
+        "placeholder": "https://example.com/tx/'{txid}'",
+        "preview": "Förhandsvisning: {url}",
+        "validation": "Ange en URL som börjar med http:// eller https:// och innehåller '{txid}'.",
+        "saveFailed": "Det gick inte att spara anpassad utforskare"
+      },
       "platform": {
         "mynode": "MyNode",
         "umbrel": "Umbrel",

--- a/frontend/public/images/ntfy.svg
+++ b/frontend/public/images/ntfy.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="#2E7D32"/>
+  <path d="M20 29.5C20 22.6 25.4 17 32 17C38.6 17 44 22.6 44 29.5V36L48 42H16L20 36V29.5Z" fill="#F7FFF7"/>
+  <path d="M28 45H36C35.4 47.3 33.9 48.5 32 48.5C30.1 48.5 28.6 47.3 28 45Z" fill="#F7FFF7"/>
+  <path d="M39.5 15L48.5 9.5L44 20.5L52.5 19L42.5 30.5L45.5 22.5L37.5 24L39.5 15Z" fill="#9CCC65"/>
+</svg>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -65,8 +65,14 @@ export default function SettingsPage() {
           <TxExplorerSettings
             explorers={preferences.availableTxExplorers}
             selectedExplorerId={preferences.selectedTxExplorerId}
+            savedExplorerId={preferences.savedTxExplorerId}
+            customExplorerUrl={preferences.customTxExplorerUrl}
+            savedCustomExplorerUrl={preferences.savedCustomTxExplorerUrl}
+            settingsError={preferences.txExplorerSettingsError}
             isUpdating={preferences.isUpdatingTxExplorer}
             onExplorerChange={preferences.handleTxExplorerChange}
+            onCustomExplorerUrlChange={preferences.setCustomTxExplorerUrl}
+            onCustomExplorerSave={preferences.handleCustomTxExplorerSave}
           />
         )}
 

--- a/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/ntfy-server-settings.test.tsx
@@ -66,9 +66,11 @@ describe("NtfyServerSettings", () => {
     render(<NtfyServerSettings {...defaultProps} />)
 
     expect(screen.getByText("Push Notifications")).toBeInTheDocument()
-    expect(screen.getAllByText("ntfy")).toHaveLength(2)
+    expect(screen.getByText("ntfy")).toBeInTheDocument()
+    expect(screen.getByAltText("ntfy logo")).toBeInTheDocument()
     expect(screen.getByText("https://ntfy.sh")).toBeInTheDocument()
     expect(screen.getByText("Umbrel")).toBeInTheDocument()
+    expect(screen.getByText("Custom URL")).toBeInTheDocument()
     expect(screen.queryByText("http://ntfy_app_1")).not.toBeInTheDocument()
     expect(screen.getByText(/Create an access token in ntfy/)).toBeInTheDocument()
   })
@@ -79,12 +81,12 @@ describe("NtfyServerSettings", () => {
 
     render(<NtfyServerSettings {...defaultProps} onNtfyServerChange={onNtfyServerChange} />)
 
-    await user.click(screen.getAllByRole("radio", { name: "ntfy" })[0])
+    await user.click(screen.getByRole("radio", { name: "https://ntfy.sh" }))
 
     expect(onNtfyServerChange).toHaveBeenCalledWith("ntfy-sh")
   })
 
-  it("does not show a radio button when only public ntfy is available", () => {
+  it("shows public and custom endpoints when only public ntfy is available", () => {
     render(
       <NtfyServerSettings
         {...defaultProps}
@@ -95,68 +97,39 @@ describe("NtfyServerSettings", () => {
     )
 
     expect(screen.getByText("ntfy")).toBeInTheDocument()
-    expect(screen.queryByRole("radio")).not.toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "https://ntfy.sh" })).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "Custom URL" })).toBeInTheDocument()
   })
 
-  it("edits the public/custom URL inline", async () => {
+  it("keeps a selected custom endpoint stable when no public ntfy entry is available", async () => {
     const user = userEvent.setup()
-    const onNtfySettingsSave = jest.fn()
 
     function ControlledSettings() {
-      const [serverUrl, setServerUrl] = useState("https://ntfy.example.com")
+      const [serverUrl, setServerUrl] = useState("http://ntfy_app_1")
+      const [selectedServerId, setSelectedServerId] = useState("umbrel-ntfy")
 
       return (
         <NtfyServerSettings
           {...defaultProps}
-          selectedNtfyServerId="ntfy-sh"
+          ntfyServers={[localNtfy]}
+          selectedNtfyServerId={selectedServerId}
           ntfyServerUrl={serverUrl}
           onNtfyServerUrlChange={setServerUrl}
-          onNtfySettingsSave={onNtfySettingsSave}
+          onNtfyServerChange={setSelectedServerId}
         />
       )
     }
 
     render(<ControlledSettings />)
 
-    expect(screen.getByText("https://ntfy.example.com")).toBeInTheDocument()
-    expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
-
-    await user.click(screen.getByRole("button", { name: /edit/i }))
-
-    expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("https://ntfy.example.com")
-    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
-    await user.clear(screen.getByLabelText("ntfy Server URL"))
-    await user.type(screen.getByLabelText("ntfy Server URL"), "https://ntfy.changed.example.com")
-    await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
-
-    expect(onNtfySettingsSave).toHaveBeenCalledTimes(1)
+    await user.click(screen.getByRole("radio", { name: "Custom URL" }))
+    expect(screen.getByRole("radio", { name: "Custom URL" })).toBeChecked()
+    expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("")
   })
 
-  it("does not save inline public URL edits when the URL is unchanged", async () => {
+  it("edits the custom URL inline", async () => {
     const user = userEvent.setup()
-    const onNtfySettingsSave = jest.fn()
-    const onClearNtfySettingsErrors = jest.fn()
-    render(
-      <NtfyServerSettings
-        {...defaultProps}
-        selectedNtfyServerId="ntfy-sh"
-        ntfyServerUrl="https://ntfy.example.com"
-        onNtfySettingsSave={onNtfySettingsSave}
-        onClearNtfySettingsErrors={onClearNtfySettingsErrors}
-      />
-    )
-
-    await user.click(screen.getByRole("button", { name: /edit/i }))
-    await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
-
-    expect(onNtfySettingsSave).not.toHaveBeenCalled()
-    expect(onClearNtfySettingsErrors).toHaveBeenCalled()
-    expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
-  })
-
-  it("keeps the public URL editor open when save validation fails", async () => {
-    const user = userEvent.setup()
-    const onNtfySettingsSave = jest.fn().mockResolvedValue(false)
+    const onNtfyServerChange = jest.fn()
 
     function ControlledSettings() {
       const [serverUrl, setServerUrl] = useState("https://ntfy.example.com")
@@ -167,7 +140,33 @@ describe("NtfyServerSettings", () => {
           selectedNtfyServerId="ntfy-sh"
           ntfyServerUrl={serverUrl}
           onNtfyServerUrlChange={setServerUrl}
-          onNtfySettingsSave={onNtfySettingsSave}
+          onNtfyServerChange={onNtfyServerChange}
+        />
+      )
+    }
+
+    render(<ControlledSettings />)
+
+    expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("https://ntfy.example.com")
+
+    await user.clear(screen.getByLabelText("ntfy Server URL"))
+    await user.type(screen.getByLabelText("ntfy Server URL"), "https://ntfy.changed.example.com")
+
+    expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("https://ntfy.changed.example.com")
+  })
+
+  it("keeps the custom URL editor visible when validation fails", async () => {
+    const user = userEvent.setup()
+
+    function ControlledSettings() {
+      const [serverUrl, setServerUrl] = useState("https://ntfy.example.com")
+
+      return (
+        <NtfyServerSettings
+          {...defaultProps}
+          selectedNtfyServerId="ntfy-sh"
+          ntfyServerUrl={serverUrl}
+          onNtfyServerUrlChange={setServerUrl}
           ntfySettingsError="URL must start with http:// or https://"
         />
       )
@@ -175,59 +174,41 @@ describe("NtfyServerSettings", () => {
 
     render(<ControlledSettings />)
 
-    await user.click(screen.getByRole("button", { name: /edit/i }))
     await user.clear(screen.getByLabelText("ntfy Server URL"))
     await user.type(screen.getByLabelText("ntfy Server URL"), "ntfy.example.com")
-    await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
 
-    expect(onNtfySettingsSave).toHaveBeenCalledTimes(1)
     expect(screen.getByLabelText("ntfy Server URL")).toBeInTheDocument()
     expect(screen.getByText("URL must start with http:// or https://")).toBeInTheDocument()
   })
 
-  it("does not save inline public URL edits when only trailing slashes change", async () => {
+  it("switches between public, local, and custom endpoints", async () => {
     const user = userEvent.setup()
-    const onNtfySettingsSave = jest.fn()
 
     function ControlledSettings() {
       const [serverUrl, setServerUrl] = useState("https://ntfy.example.com")
+      const [selectedServerId, setSelectedServerId] = useState("ntfy-sh")
 
       return (
         <NtfyServerSettings
           {...defaultProps}
-          selectedNtfyServerId="ntfy-sh"
+          selectedNtfyServerId={selectedServerId}
           ntfyServerUrl={serverUrl}
           onNtfyServerUrlChange={setServerUrl}
-          onNtfySettingsSave={onNtfySettingsSave}
+          onNtfyServerChange={(serverId) => {
+            setSelectedServerId(serverId)
+            setServerUrl(serverId === "umbrel-ntfy" ? "http://ntfy_app_1" : "https://ntfy.sh")
+          }}
         />
       )
     }
 
     render(<ControlledSettings />)
 
-    await user.click(screen.getByRole("button", { name: /edit/i }))
-    await user.type(screen.getByLabelText("ntfy Server URL"), "/")
-    await user.click(screen.getAllByRole("button", { name: /^save$/i })[0])
+    await user.click(screen.getByRole("radio", { name: "Umbrel" }))
+    expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
 
-    expect(onNtfySettingsSave).not.toHaveBeenCalled()
-  })
-
-  it("restores the public/custom URL when cancelling inline edit", async () => {
-    const user = userEvent.setup()
-    const onNtfyServerUrlChange = jest.fn()
-    render(
-      <NtfyServerSettings
-        {...defaultProps}
-        selectedNtfyServerId="ntfy-sh"
-        ntfyServerUrl="https://ntfy.example.com"
-        onNtfyServerUrlChange={onNtfyServerUrlChange}
-      />
-    )
-
-    await user.click(screen.getByRole("button", { name: /edit/i }))
-    await user.click(screen.getByRole("button", { name: /cancel/i }))
-
-    expect(onNtfyServerUrlChange).toHaveBeenCalledWith("https://ntfy.example.com")
+    await user.click(screen.getByRole("radio", { name: "Custom URL" }))
+    expect(screen.getByLabelText("ntfy Server URL")).toHaveValue("")
   })
 
   it("closes the public URL editor when switching servers", async () => {
@@ -253,15 +234,13 @@ describe("NtfyServerSettings", () => {
 
     render(<ControlledSettings />)
 
-    await user.click(screen.getByRole("button", { name: /edit/i }))
     expect(screen.getByLabelText("ntfy Server URL")).toBeInTheDocument()
 
-    await user.click(screen.getAllByRole("radio", { name: "ntfy" })[1])
+    await user.click(screen.getByRole("radio", { name: "Umbrel" }))
     expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
 
-    await user.click(screen.getAllByRole("radio", { name: "ntfy" })[0])
-    expect(screen.queryByLabelText("ntfy Server URL")).not.toBeInTheDocument()
-    expect(screen.getByText("https://ntfy.example.com")).toBeInTheDocument()
+    await user.click(screen.getByRole("radio", { name: "Custom URL" }))
+    expect(screen.getByLabelText("ntfy Server URL")).toBeInTheDocument()
   })
 
   it("shows auth controls for public ntfy", () => {

--- a/frontend/src/components/settings/__tests__/tx-explorer-settings.test.tsx
+++ b/frontend/src/components/settings/__tests__/tx-explorer-settings.test.tsx
@@ -11,23 +11,31 @@ describe("TxExplorerSettings", () => {
     platform: "umbrel",
     isLocal: true,
   }
+  const defaultProps = {
+    customExplorerUrl: "",
+    savedCustomExplorerUrl: "",
+    savedExplorerId: "mempool-space",
+    settingsError: null,
+    isUpdating: false,
+    onExplorerChange: jest.fn(),
+    onCustomExplorerUrlChange: jest.fn(),
+    onCustomExplorerSave: jest.fn(),
+  }
 
   it("renders public and local explorer options when local mempool is available", () => {
     render(
       <TxExplorerSettings
+        {...defaultProps}
         explorers={[DEFAULT_TX_EXPLORER, localMempool]}
         selectedExplorerId="mempool-space"
-        isUpdating={false}
-        onExplorerChange={jest.fn()}
       />
     )
 
     expect(screen.getByText("Transaction Explorer")).toBeInTheDocument()
-    expect(screen.getByText("Public")).toBeInTheDocument()
-    expect(screen.getByText("Local")).toBeInTheDocument()
-    expect(screen.getByLabelText("Mempool Space")).toBeInTheDocument()
-    expect(screen.getByLabelText("Mempool")).toBeInTheDocument()
-    expect(screen.getByAltText("Mempool Space logo")).toBeInTheDocument()
+    expect(screen.queryByText("Public")).not.toBeInTheDocument()
+    expect(screen.getByText("Mempool")).toBeInTheDocument()
+    expect(screen.getByLabelText("https://mempool.space")).toBeInTheDocument()
+    expect(screen.getByLabelText("Umbrel")).toBeInTheDocument()
     expect(screen.getByAltText("Mempool logo")).toBeInTheDocument()
     expect(screen.getByText("https://mempool.space")).toBeInTheDocument()
     expect(screen.getByText("Umbrel")).toBeInTheDocument()
@@ -37,48 +45,49 @@ describe("TxExplorerSettings", () => {
   it("renders all public explorer options", () => {
     render(
       <TxExplorerSettings
+        {...defaultProps}
         explorers={PUBLIC_TX_EXPLORERS}
         selectedExplorerId="mempool-space"
-        isUpdating={false}
-        onExplorerChange={jest.fn()}
       />
     )
 
-    expect(screen.getByText("Public")).toBeInTheDocument()
+    expect(screen.queryByText("Public")).not.toBeInTheDocument()
     expect(screen.queryByText("Local")).not.toBeInTheDocument()
-    expect(screen.getByLabelText("Mempool Space")).toBeInTheDocument()
-    expect(screen.getByLabelText("Bitfeed")).toBeInTheDocument()
-    expect(screen.getByLabelText("BTC RPC Explorer")).toBeInTheDocument()
+    expect(screen.getByText("Mempool")).toBeInTheDocument()
+    expect(screen.getByText("Bitfeed")).toBeInTheDocument()
+    expect(screen.getByText("BTC RPC Explorer")).toBeInTheDocument()
     expect(screen.getByText("https://mempool.space")).toBeInTheDocument()
     expect(screen.getByText("https://bitfeed.live")).toBeInTheDocument()
     expect(screen.getByText("https://bitcoinexplorer.org")).toBeInTheDocument()
+    expect(screen.getByLabelText("https://bitfeed.live")).toBeInTheDocument()
+    expect(screen.getByLabelText("https://bitcoinexplorer.org")).toBeInTheDocument()
+    expect(screen.getByLabelText("Custom URL")).toBeInTheDocument()
+    expect(screen.getByLabelText("Custom explorer URL")).toBeInTheDocument()
   })
 
   it("falls back to a local label when a local explorer has no platform", () => {
     render(
       <TxExplorerSettings
+        {...defaultProps}
         explorers={[DEFAULT_TX_EXPLORER, { ...localMempool, platform: undefined }]}
         selectedExplorerId="mempool-space"
-        isUpdating={false}
-        onExplorerChange={jest.fn()}
       />
     )
 
-    expect(screen.getAllByText("Local")).toHaveLength(2)
+    expect(screen.getByText("Local")).toBeInTheDocument()
     expect(screen.queryByText("http://umbrel.local:3006")).not.toBeInTheDocument()
   })
 
   it("falls back to a local label when a local explorer has an unknown platform", () => {
     render(
       <TxExplorerSettings
+        {...defaultProps}
         explorers={[DEFAULT_TX_EXPLORER, { ...localMempool, platform: "unknown-node" }]}
         selectedExplorerId="mempool-space"
-        isUpdating={false}
-        onExplorerChange={jest.fn()}
       />
     )
 
-    expect(screen.getAllByText("Local")).toHaveLength(2)
+    expect(screen.getByText("Local")).toBeInTheDocument()
     expect(screen.queryByText("unknown-node")).not.toBeInTheDocument()
   })
 
@@ -88,28 +97,128 @@ describe("TxExplorerSettings", () => {
 
     render(
       <TxExplorerSettings
+        {...defaultProps}
         explorers={[DEFAULT_TX_EXPLORER, localMempool]}
         selectedExplorerId="mempool-space"
-        isUpdating={false}
         onExplorerChange={onExplorerChange}
       />
     )
 
-    await user.click(screen.getByLabelText("Mempool"))
+    await user.click(screen.getByLabelText("Umbrel"))
 
     expect(onExplorerChange).toHaveBeenCalledWith("mempool")
   })
 
-  it("does not render when only mempool.space is available", () => {
-    const { container } = render(
+  it("saves a custom explorer URL template", async () => {
+    const user = userEvent.setup()
+    const onCustomExplorerUrlChange = jest.fn()
+    const onCustomExplorerSave = jest.fn()
+
+    render(
       <TxExplorerSettings
-        explorers={[DEFAULT_TX_EXPLORER]}
-        selectedExplorerId="mempool-space"
-        isUpdating={false}
-        onExplorerChange={jest.fn()}
+        {...defaultProps}
+        explorers={PUBLIC_TX_EXPLORERS}
+        selectedExplorerId="custom"
+        customExplorerUrl="https://example.com/tx/{txid}"
+        savedCustomExplorerUrl=""
+        onCustomExplorerUrlChange={onCustomExplorerUrlChange}
+        onCustomExplorerSave={onCustomExplorerSave}
       />
     )
 
-    expect(container).toBeEmptyDOMElement()
+    expect(screen.getByText("Preview: https://example.com/tx/<transaction-id>")).toBeInTheDocument()
+    await user.type(screen.getByLabelText("Custom explorer URL"), "a")
+    await user.click(screen.getByRole("button", { name: /^save$/i }))
+
+    expect(onCustomExplorerUrlChange).toHaveBeenCalled()
+    expect(onCustomExplorerSave).toHaveBeenCalled()
+  })
+
+  it("disables custom explorer save until the URL template is valid", () => {
+    render(
+      <TxExplorerSettings
+        {...defaultProps}
+        explorers={PUBLIC_TX_EXPLORERS}
+        selectedExplorerId="custom"
+        customExplorerUrl=""
+        savedCustomExplorerUrl=""
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled()
+  })
+
+  it("marks the custom explorer URL input invalid when an error is shown", () => {
+    render(
+      <TxExplorerSettings
+        {...defaultProps}
+        explorers={PUBLIC_TX_EXPLORERS}
+        selectedExplorerId="custom"
+        customExplorerUrl="not-a-url"
+        settingsError="Invalid custom explorer URL"
+      />
+    )
+
+    expect(screen.getByLabelText("Custom explorer URL")).toHaveAttribute("aria-invalid", "true")
+  })
+
+  it("selects the custom explorer option when the custom URL input is focused", async () => {
+    const user = userEvent.setup()
+    const onExplorerChange = jest.fn()
+
+    render(
+      <TxExplorerSettings
+        {...defaultProps}
+        explorers={PUBLIC_TX_EXPLORERS}
+        selectedExplorerId="mempool-space"
+        onExplorerChange={onExplorerChange}
+      />
+    )
+
+    await user.click(screen.getByLabelText("Custom explorer URL"))
+
+    expect(onExplorerChange).toHaveBeenCalledWith("custom")
+  })
+
+  it("keeps custom explorer save enabled when switching back to a saved template that is not the active preference", () => {
+    render(
+      <TxExplorerSettings
+        {...defaultProps}
+        explorers={PUBLIC_TX_EXPLORERS}
+        selectedExplorerId="custom"
+        savedExplorerId="mempool-space"
+        customExplorerUrl="https://example.com/tx/{txid}"
+        savedCustomExplorerUrl="https://example.com/tx/{txid}"
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeEnabled()
+  })
+
+  it("disables custom explorer save when the custom template is already the active preference", () => {
+    render(
+      <TxExplorerSettings
+        {...defaultProps}
+        explorers={PUBLIC_TX_EXPLORERS}
+        selectedExplorerId="custom"
+        savedExplorerId="custom"
+        customExplorerUrl="https://example.com/tx/{txid}"
+        savedCustomExplorerUrl="https://example.com/tx/{txid}"
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled()
+  })
+
+  it("still renders custom explorer when only mempool.space is available", () => {
+    const { container } = render(
+      <TxExplorerSettings
+        {...defaultProps}
+        explorers={[DEFAULT_TX_EXPLORER]}
+        selectedExplorerId="mempool-space"
+      />
+    )
+
+    expect(container).not.toBeEmptyDOMElement()
   })
 })

--- a/frontend/src/components/settings/endpoint-option.tsx
+++ b/frontend/src/components/settings/endpoint-option.tsx
@@ -1,0 +1,19 @@
+import { Label } from "@/components/ui/label"
+import { RadioGroupItem } from "@/components/ui/radio-group"
+
+interface EndpointOptionProps {
+  id: string
+  value: string
+  label: string
+}
+
+export function EndpointOption({ id, value, label }: EndpointOptionProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <RadioGroupItem id={id} value={value} />
+      <Label htmlFor={id} className="min-w-0 cursor-pointer break-all text-sm font-normal text-muted-foreground">
+        {label}
+      </Label>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/ntfy-server-settings.tsx
+++ b/frontend/src/components/settings/ntfy-server-settings.tsx
@@ -1,18 +1,22 @@
 "use client"
 
-import { useState, useCallback, useEffect, type ReactNode } from "react"
+import { useState, useCallback, useEffect } from "react"
+import Image from "next/image"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { RadioGroup } from "@/components/ui/radio-group"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ErrorDisplay, SuccessDisplay } from "@/components/ui/error-display"
-import { Bell, Pencil } from "lucide-react"
+import { EndpointOption } from "@/components/settings/endpoint-option"
+import { Bell } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { api } from "@/lib/api"
 import type { UserPreferences, NtfyAuthType } from "@/hooks/useUserPreferences"
 import { isBrowserSafeNtfyUrl, type NtfyServerOption } from "@/lib/ntfy-servers"
+
+const NTFY_CUSTOM_ENDPOINT_ID = "ntfy-custom"
 
 interface NtfyServerSettingsProps {
   ntfyServerUrl: string
@@ -65,8 +69,9 @@ export function NtfyServerSettings({
 }: NtfyServerSettingsProps) {
   const t = useTranslations("settings")
   const tCommon = useTranslations("common")
-  const [isEditingPublicUrl, setIsEditingPublicUrl] = useState(false)
-  const [publicUrlBeforeEdit, setPublicUrlBeforeEdit] = useState("")
+  if (ntfyServers.length === 0) {
+    return null
+  }
 
   const publicServers = ntfyServers.filter((server) => !server.isLocal)
   const localServers = ntfyServers.filter((server) => server.isLocal)
@@ -80,105 +85,36 @@ export function NtfyServerSettings({
   }
   // ntfy.sh supports accounts/private topics, so auth stays available for both public and local servers.
   const showAuthSection = Boolean(ntfyServerUrl || isLocalSelection) && !isManagedAuthSelection
-  const hasLocalServers = localServers.length > 0
-  const publicServerDisplayUrl = isLocalSelection ? publicServer?.baseUrl ?? "" : ntfyServerUrl
-  const startEditingPublicUrl = () => {
-    setPublicUrlBeforeEdit(publicServerDisplayUrl)
-    setIsEditingPublicUrl(true)
-  }
-  const cancelEditingPublicUrl = () => {
-    onNtfyServerUrlChange(publicUrlBeforeEdit)
-    onClearNtfySettingsErrors()
-    setIsEditingPublicUrl(false)
-  }
-  const saveEditingPublicUrl = async () => {
-    onClearNtfySettingsErrors()
-    if (normalizeEditablePublicUrl(ntfyServerUrl) !== normalizeEditablePublicUrl(publicUrlBeforeEdit)) {
-      const didSave = await onNtfySettingsSave()
-      if (didSave === false) {
-        return
-      }
-    }
-    setIsEditingPublicUrl(false)
-  }
   const localServerSubtitle = (server: NtfyServerOption) =>
     server.platform ? (platformLabels[server.platform] ?? t("ntfy.platform.local")) : t("ntfy.platform.local")
-  const publicServerRow = publicServer ? (
-    <div className="space-y-2">
-      {hasLocalServers ? (
-        <NtfyServerOptionRow
-          server={publicServer}
-          subtitle={renderPublicServerSubtitle()}
-          subtitleAction={renderPublicServerAction()}
-        />
-      ) : (
-        <NtfyServerStaticRow
-          server={publicServer}
-          subtitle={renderPublicServerSubtitle()}
-          subtitleAction={renderPublicServerAction()}
-        />
-      )}
-    </div>
-  ) : null
+  const publicBaseUrl = publicServer?.baseUrl ?? "https://ntfy.sh"
+  const providerName = publicServer?.name ?? localServers[0]?.name ?? "ntfy"
+  const selectedEndpointId = isLocalSelection
+    ? selectedNtfyServerId
+    : normalizeEditablePublicUrl(ntfyServerUrl) === normalizeEditablePublicUrl(publicBaseUrl)
+      ? (publicServer?.id ?? NTFY_CUSTOM_ENDPOINT_ID)
+      : NTFY_CUSTOM_ENDPOINT_ID
 
-  function renderPublicServerSubtitle() {
-    return selectedNtfyServerId === publicServer?.id && isEditingPublicUrl ? (
-      <Input
-        id="ntfy-server"
-        aria-label={t("ntfy.serverLabel")}
-        type="url"
-        placeholder={t("ntfy.serverPlaceholder")}
-        value={ntfyServerUrl}
-        onChange={(e) => {
-          onNtfyServerUrlChange(e.target.value)
-          onClearNtfySettingsErrors()
-        }}
-        disabled={isUpdatingNtfySettings}
-        className="h-8"
-      />
-    ) : (
-      publicServerDisplayUrl || publicServer?.baseUrl || ""
-    )
-  }
-
-  function renderPublicServerAction() {
-    if (selectedNtfyServerId !== publicServer?.id) {
-      return null
+  const handleEndpointChange = (endpointId: string) => {
+    onClearNtfySettingsErrors()
+    if (endpointId === NTFY_CUSTOM_ENDPOINT_ID) {
+      onNtfyServerChange(publicServer?.id ?? NTFY_CUSTOM_ENDPOINT_ID)
+      if (
+        isLocalSelection ||
+        normalizeEditablePublicUrl(ntfyServerUrl) === normalizeEditablePublicUrl(publicBaseUrl)
+      ) {
+        onNtfyServerUrlChange("")
+      }
+      return
     }
 
-    return isEditingPublicUrl ? (
-      <div className="flex shrink-0 items-center gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={cancelEditingPublicUrl}
-          disabled={isUpdatingNtfySettings}
-        >
-          {tCommon("cancel")}
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          onClick={saveEditingPublicUrl}
-          disabled={isUpdatingNtfySettings}
-        >
-          {isUpdatingNtfySettings ? tCommon("saving") : tCommon("save")}
-        </Button>
-      </div>
-    ) : (
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={startEditingPublicUrl}
-        disabled={isUpdatingNtfySettings}
-        className="shrink-0"
-      >
-        <Pencil className="h-4 w-4" />
-        {tCommon("edit")}
-      </Button>
-    )
+    const server = ntfyServers.find((option) => option.id === endpointId)
+    if (!server) return
+
+    onNtfyServerChange(server.id)
+    if (!server.isLocal) {
+      onNtfyServerUrlChange(server.baseUrl)
+    }
   }
 
   return (
@@ -192,28 +128,73 @@ export function NtfyServerSettings({
       </CardHeader>
       <CardContent>
         <div className="space-y-6">
-          {hasLocalServers ? (
+          {publicServer || localServers.length > 0 ? (
             <RadioGroup
-              value={selectedNtfyServerId}
-              onValueChange={(serverId) => {
-                setIsEditingPublicUrl(false)
-                onNtfyServerChange(serverId)
-              }}
+              value={selectedEndpointId}
+              onValueChange={handleEndpointChange}
               disabled={isUpdatingNtfySettings}
-              className="space-y-4"
+              className="space-y-3"
             >
-              {publicServerRow}
-              <div className="space-y-2">
-                <div className="space-y-3">
-                  {localServers.map((server) => (
-                    <NtfyServerOptionRow key={server.id} server={server} subtitle={localServerSubtitle(server)} />
-                  ))}
+              <div className="rounded-md border p-3">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-background">
+                    <Image
+                      src="/images/ntfy.svg"
+                      alt="ntfy logo"
+                      width={32}
+                      height={32}
+                      className="h-full w-full object-contain"
+                    />
+                  </div>
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Label>{providerName}</Label>
+                    <div className="space-y-2 pt-1">
+                      {localServers.map((server) => (
+                        <EndpointOption
+                          key={server.id}
+                          id={`ntfy-server-${server.id}`}
+                          value={server.id}
+                          label={localServerSubtitle(server)}
+                        />
+                      ))}
+                      {publicServer ? (
+                        <EndpointOption
+                          id={`ntfy-server-${publicServer.id}`}
+                          value={publicServer.id}
+                          label={publicServer.baseUrl}
+                        />
+                      ) : null}
+                      <div className="space-y-2">
+                        <EndpointOption
+                          id="ntfy-server-custom"
+                          value={NTFY_CUSTOM_ENDPOINT_ID}
+                          label={t("ntfy.customUrl")}
+                        />
+                        {selectedEndpointId === NTFY_CUSTOM_ENDPOINT_ID && (
+                          <Input
+                            id="ntfy-server"
+                            aria-label={t("ntfy.serverLabel")}
+                            type="url"
+                            placeholder={t("ntfy.serverPlaceholder")}
+                            value={ntfyServerUrl}
+                            onChange={(e) => {
+                              onNtfyServerUrlChange(e.target.value)
+                              onClearNtfySettingsErrors()
+                            }}
+                            disabled={isUpdatingNtfySettings}
+                            className="ml-6 max-w-xl"
+                          />
+                        )}
+                      </div>
+                    </div>
+                  </div>
                 </div>
-                {!isManagedAuthSelection && <p className="text-sm text-muted-foreground">{t("ntfy.localAuthNote")}</p>}
               </div>
             </RadioGroup>
-          ) : (
-            publicServerRow
+          ) : null}
+
+          {isLocalSelection && !isManagedAuthSelection && (
+            <p className="text-sm text-muted-foreground">{t("ntfy.localAuthNote")}</p>
           )}
 
           {showAuthSection && (
@@ -334,65 +315,6 @@ export function NtfyServerSettings({
 
 function normalizeEditablePublicUrl(url: string): string {
   return url.trim().replace(/\/+$/, "")
-}
-
-function NtfyServerOptionRow({
-  server,
-  subtitle,
-  subtitleAction,
-}: {
-  server: NtfyServerOption
-  subtitle: ReactNode
-  subtitleAction?: ReactNode
-}) {
-  return (
-    <div className="flex items-start gap-3 rounded-md border p-3">
-      <RadioGroupItem value={server.id} id={`ntfy-server-${server.id}`} className="mt-1" />
-      <div className="min-w-0 flex-1 space-y-1">
-        <div className="space-y-1">
-          <div className="min-w-0">
-            <Label
-              htmlFor={`ntfy-server-${server.id}`}
-              className="cursor-pointer"
-            >
-              {server.name}
-            </Label>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0 flex-1 break-all text-sm text-muted-foreground">{subtitle}</div>
-            {subtitleAction}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// Separate row components keep non-selectable public-only settings outside RadioGroup semantics.
-function NtfyServerStaticRow({
-  server,
-  subtitle,
-  subtitleAction,
-}: {
-  server: NtfyServerOption
-  subtitle: ReactNode
-  subtitleAction?: ReactNode
-}) {
-  return (
-    <div className="flex items-start gap-3 rounded-md border p-3">
-      <div className="min-w-0 flex-1 space-y-1">
-        <div className="space-y-1">
-          <div className="min-w-0">
-            <Label>{server.name}</Label>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0 flex-1 break-all text-sm text-muted-foreground">{subtitle}</div>
-            {subtitleAction}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
 }
 
 function TestNotificationSection({

--- a/frontend/src/components/settings/tx-explorer-settings.tsx
+++ b/frontend/src/components/settings/tx-explorer-settings.tsx
@@ -2,48 +2,79 @@
 
 import Image from "next/image"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
-import { ExternalLink } from "lucide-react"
+import { RadioGroup } from "@/components/ui/radio-group"
+import { ErrorDisplay } from "@/components/ui/error-display"
+import { EndpointOption } from "@/components/settings/endpoint-option"
+import { Blocks, Link } from "lucide-react"
 import { useTranslations } from "next-intl"
-import type { TxExplorerOption } from "@/lib/tx-explorers"
+import {
+  CUSTOM_TX_EXPLORER_ID,
+  isValidCustomTxExplorerTemplate,
+  type TxExplorerOption,
+} from "@/lib/tx-explorers"
 
 const EXPLORER_LOGOS: Record<string, string> = {
-  "mempool-space": "/images/explorers/mempool.svg",
   mempool: "/images/explorers/mempool.svg",
-  "bitfeed-public": "/images/explorers/bitfeed.svg",
   bitfeed: "/images/explorers/bitfeed.svg",
-  "btc-rpc-explorer-public": "/images/explorers/btc-rpc-explorer.svg",
   "btc-rpc-explorer": "/images/explorers/btc-rpc-explorer.svg",
 }
 
 interface TxExplorerSettingsProps {
   explorers: TxExplorerOption[]
   selectedExplorerId: string
+  savedExplorerId: string
+  customExplorerUrl: string
+  savedCustomExplorerUrl: string
+  settingsError: string | null
   isUpdating: boolean
   onExplorerChange: (explorerId: string) => void
+  onCustomExplorerUrlChange: (url: string) => void
+  onCustomExplorerSave: () => Promise<boolean>
+}
+
+interface ExplorerProvider {
+  key: string
+  name: string
+  logo?: string
+  options: TxExplorerOption[]
 }
 
 export function TxExplorerSettings({
   explorers,
   selectedExplorerId,
+  savedExplorerId,
+  customExplorerUrl,
+  savedCustomExplorerUrl,
+  settingsError,
   isUpdating,
   onExplorerChange,
+  onCustomExplorerUrlChange,
+  onCustomExplorerSave,
 }: TxExplorerSettingsProps) {
   const t = useTranslations("settings")
-  const publicExplorers = explorers.filter((explorer) => !explorer.isLocal)
-  const localExplorers = explorers.filter((explorer) => explorer.isLocal)
+  const tCommon = useTranslations("common")
   const platformLabels: Record<string, string> = {
     mynode: t("txExplorer.platform.mynode"),
     umbrel: t("txExplorer.platform.umbrel"),
     startos: t("txExplorer.platform.startos"),
   }
+  const providerGroups = groupExplorersByProvider(explorers)
+  const selectedCustom = selectedExplorerId === CUSTOM_TX_EXPLORER_ID
+  const customUrlIsSaved =
+    savedExplorerId === CUSTOM_TX_EXPLORER_ID &&
+    customExplorerUrl.trim() === savedCustomExplorerUrl.trim()
+  const canSaveCustomUrl =
+    selectedCustom && !isUpdating && isValidCustomTxExplorerTemplate(customExplorerUrl) && !customUrlIsSaved
+  const showCustomPreview = selectedCustom && isValidCustomTxExplorerTemplate(customExplorerUrl)
 
-  if (explorers.length < 2) {
+  if (explorers.length === 0) {
     return null
   }
 
-  const explorerSubtitle = (explorer: TxExplorerOption) => {
+  const endpointLabel = (explorer: TxExplorerOption) => {
     if (!explorer.isLocal) {
       return explorer.baseUrl
     }
@@ -53,38 +84,11 @@ export function TxExplorerSettings({
       : t("txExplorer.platform.local")
   }
 
-  const renderExplorerOption = (explorer: TxExplorerOption) => (
-    <div key={explorer.id} className="flex items-start gap-3 rounded-md border p-3">
-      <RadioGroupItem value={explorer.id} id={`tx-explorer-${explorer.id}`} className="mt-1" />
-      <div className="flex min-w-0 flex-1 items-start gap-3">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-background">
-          {EXPLORER_LOGOS[explorer.id] ? (
-            <Image
-              src={EXPLORER_LOGOS[explorer.id]}
-              alt={`${explorer.name} logo`}
-              width={32}
-              height={32}
-              className="h-full w-full object-contain"
-            />
-          ) : (
-            <ExternalLink className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-          )}
-        </div>
-        <div className="min-w-0 space-y-1">
-          <Label htmlFor={`tx-explorer-${explorer.id}`} className="cursor-pointer">
-            {explorer.name}
-          </Label>
-          <p className="break-all text-sm text-muted-foreground">{explorerSubtitle(explorer)}</p>
-        </div>
-      </div>
-    </div>
-  )
-
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
-          <ExternalLink className="h-5 w-5" />
+          <Blocks className="h-5 w-5" />
           {t("txExplorer.title")}
         </CardTitle>
         <CardDescription>{t("txExplorer.description")}</CardDescription>
@@ -94,26 +98,132 @@ export function TxExplorerSettings({
           value={selectedExplorerId}
           onValueChange={onExplorerChange}
           disabled={isUpdating}
-          className="space-y-4"
+          className="space-y-3"
         >
-          <div className="space-y-2">
-            <p className="text-sm font-medium">{t("txExplorer.publicGroup")}</p>
-            <div className="space-y-3">
-              {publicExplorers.map(renderExplorerOption)}
-            </div>
-          </div>
-
-          {localExplorers.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-sm font-medium">{t("txExplorer.localGroup")}</p>
-              <div className="space-y-3">
-                {localExplorers.map(renderExplorerOption)}
+          {providerGroups.map((provider) => (
+            <div key={provider.key} className="rounded-md border p-3">
+              <div className="flex items-start gap-3">
+                <ExplorerIcon logo={provider.logo} name={provider.name} />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <Label>{provider.name}</Label>
+                  <div className="space-y-2 pt-1">
+                    {provider.options.map((explorer) => (
+                      <EndpointOption
+                        key={explorer.id}
+                        id={`tx-explorer-${explorer.id}`}
+                        value={explorer.id}
+                        label={endpointLabel(explorer)}
+                      />
+                    ))}
+                  </div>
+                </div>
               </div>
             </div>
-          )}
+          ))}
+
+          <div className="rounded-md border p-3">
+            <div className="flex items-start gap-3">
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-background">
+                <Link className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+              </div>
+              <div className="min-w-0 flex-1 space-y-2">
+                <Label>{t("txExplorer.custom.title")}</Label>
+                <div className="space-y-2 pt-1">
+                  <EndpointOption
+                    id="tx-explorer-custom"
+                    value={CUSTOM_TX_EXPLORER_ID}
+                    label={t("txExplorer.custom.endpointLabel")}
+                  />
+                  <div className="ml-6 flex flex-col gap-2 sm:flex-row">
+                    <Input
+                      aria-label={t("txExplorer.custom.label")}
+                      aria-invalid={Boolean(settingsError)}
+                      type="url"
+                      placeholder={t("txExplorer.custom.placeholder")}
+                      value={customExplorerUrl}
+                      onFocus={() => onExplorerChange(CUSTOM_TX_EXPLORER_ID)}
+                      onChange={(event) => onCustomExplorerUrlChange(event.target.value)}
+                      disabled={isUpdating}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={onCustomExplorerSave}
+                      disabled={!canSaveCustomUrl}
+                      className="shrink-0"
+                    >
+                      {isUpdating ? tCommon("saving") : tCommon("save")}
+                    </Button>
+                  </div>
+                  {showCustomPreview && (
+                    <p className="ml-6 break-all text-sm text-muted-foreground">
+                      {t("txExplorer.custom.preview", {
+                        url: customExplorerUrl.trim().replaceAll("{txid}", "<transaction-id>"),
+                      })}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
         </RadioGroup>
+        {settingsError && <ErrorDisplay message={settingsError} variant="inline" />}
         <p className="text-sm text-muted-foreground">{t("txExplorer.note")}</p>
       </CardContent>
     </Card>
+  )
+}
+
+function groupExplorersByProvider(explorers: TxExplorerOption[]): ExplorerProvider[] {
+  const groups = new Map<string, ExplorerProvider>()
+
+  for (const explorer of explorers) {
+    const key = explorerProviderKey(explorer)
+    const existingGroup = groups.get(key)
+    if (existingGroup) {
+      existingGroup.options.push(explorer)
+    } else {
+      groups.set(key, {
+        key,
+        name: explorerProviderName(key, explorer),
+        logo: EXPLORER_LOGOS[key],
+        options: [explorer],
+      })
+    }
+  }
+
+  return Array.from(groups.values())
+}
+
+function explorerProviderKey(explorer: TxExplorerOption): string {
+  const normalizedId = explorer.id.toLowerCase()
+  const normalizedName = explorer.name.toLowerCase()
+
+  if (normalizedId.includes("mempool") || normalizedName.includes("mempool")) return "mempool"
+  if (normalizedId.includes("bitfeed") || normalizedName.includes("bitfeed")) return "bitfeed"
+  if (normalizedId.includes("btc-rpc") || normalizedName.includes("btc rpc")) return "btc-rpc-explorer"
+  return normalizedId
+}
+
+function explorerProviderName(key: string, explorer: TxExplorerOption): string {
+  if (key === "mempool") return "Mempool"
+  return explorer.name
+}
+
+function ExplorerIcon({ logo, name }: { logo?: string; name: string }) {
+  return (
+    <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-background">
+      {logo ? (
+        <Image
+          src={logo}
+          alt={`${name} logo`}
+          width={32}
+          height={32}
+          className="h-full w-full object-contain"
+        />
+      ) : (
+        <Link className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+      )}
+    </div>
   )
 }

--- a/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useUserPreferences.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useUserPreferences } from "../useUserPreferences"
 import { PUBLIC_NTFY_SERVER_ID, UMBREL_NTFY_SERVER_ID } from "@/lib/ntfy-servers"
+import { CUSTOM_TX_EXPLORER_ID } from "@/lib/tx-explorers"
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: jest.fn() }),
@@ -24,6 +25,9 @@ function PreferencesProbe({ isAuthenticated = true }: { isAuthenticated?: boolea
     <div>
       <div data-testid="selected-ntfy-server">{preferences.selectedNtfyServerId}</div>
       <div data-testid="has-ntfy-changes">{String(preferences.hasAnyNtfyChanges)}</div>
+      <div data-testid="selected-tx-explorer">{preferences.selectedTxExplorerId}</div>
+      <div data-testid="saved-tx-explorer">{preferences.savedTxExplorerId}</div>
+      <div data-testid="saved-custom-tx-explorer-url">{preferences.savedCustomTxExplorerUrl}</div>
       <input
         aria-label="ntfy server url"
         value={preferences.ntfyServerUrl}
@@ -44,7 +48,28 @@ function PreferencesProbe({ isAuthenticated = true }: { isAuthenticated?: boolea
       <button type="button" onClick={() => preferences.handleNtfySettingsSave()}>
         Save ntfy
       </button>
+      <input
+        aria-label="custom tx explorer url"
+        value={preferences.customTxExplorerUrl}
+        onChange={(event) => preferences.setCustomTxExplorerUrl(event.target.value)}
+      />
+      <button
+        type="button"
+        onClick={() => preferences.handleTxExplorerChange("mempool-space")}
+      >
+        Select mempool.space
+      </button>
+      <button
+        type="button"
+        onClick={() => preferences.handleTxExplorerChange(CUSTOM_TX_EXPLORER_ID)}
+      >
+        Select custom tx explorer
+      </button>
+      <button type="button" onClick={() => preferences.handleCustomTxExplorerSave()}>
+        Save custom tx explorer
+      </button>
       <div data-testid="ntfy-settings-error">{preferences.ntfySettingsError ?? ""}</div>
+      <div data-testid="tx-settings-error">{preferences.txExplorerSettingsError ?? ""}</div>
     </div>
   )
 }
@@ -190,5 +215,99 @@ describe("useUserPreferences", () => {
 
     expect(mockApi.updateUserPreferences).not.toHaveBeenCalled()
     expect(screen.getByTestId("ntfy-settings-error")).toHaveTextContent("Failed to save")
+  })
+
+  it("clears stale custom tx explorer state when switching to a predefined explorer", async () => {
+    const user = userEvent.setup()
+    mockApi.getUserPreferences.mockResolvedValue({
+      preferred_fiat_currency: "USD",
+      preferred_tx_explorer_id: "custom:https://example.com/tx/{txid}",
+      ntfy_server_url: null,
+      ntfy_has_access_token: false,
+      ntfy_has_credentials: false,
+      ntfy_username: null,
+    })
+    mockApi.updateUserPreferences
+      .mockResolvedValueOnce({
+        preferred_fiat_currency: "USD",
+        preferred_tx_explorer_id: "mempool-space",
+        ntfy_server_url: null,
+        ntfy_has_access_token: false,
+        ntfy_has_credentials: false,
+        ntfy_username: null,
+      })
+      .mockResolvedValueOnce({
+        preferred_fiat_currency: "USD",
+        preferred_tx_explorer_id: "custom:https://example.com/tx/{txid}",
+        ntfy_server_url: null,
+        ntfy_has_access_token: false,
+        ntfy_has_credentials: false,
+        ntfy_username: null,
+      })
+
+    render(<PreferencesProbe />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tx-explorer")).toHaveTextContent(CUSTOM_TX_EXPLORER_ID)
+      expect(screen.getByTestId("saved-tx-explorer")).toHaveTextContent(CUSTOM_TX_EXPLORER_ID)
+      expect(screen.getByTestId("saved-custom-tx-explorer-url")).toHaveTextContent(
+        "https://example.com/tx/{txid}"
+      )
+    })
+
+    await user.click(screen.getByRole("button", { name: "Select mempool.space" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tx-explorer")).toHaveTextContent("mempool-space")
+      expect(screen.getByTestId("saved-tx-explorer")).toHaveTextContent("mempool-space")
+      expect(screen.getByTestId("saved-custom-tx-explorer-url")).toHaveTextContent("")
+      expect(screen.getByRole("textbox", { name: "custom tx explorer url" })).toHaveValue("")
+    })
+
+    await user.click(screen.getByRole("button", { name: "Select custom tx explorer" }))
+    expect(screen.getByTestId("selected-tx-explorer")).toHaveTextContent(CUSTOM_TX_EXPLORER_ID)
+    expect(screen.getByTestId("saved-tx-explorer")).toHaveTextContent("mempool-space")
+
+    fireEvent.change(screen.getByRole("textbox", { name: "custom tx explorer url" }), {
+      target: { value: "https://example.com/tx/{txid}" },
+    })
+    await user.click(screen.getByRole("button", { name: "Save custom tx explorer" }))
+
+    await waitFor(() => {
+      expect(mockApi.updateUserPreferences).toHaveBeenLastCalledWith({
+        preferred_tx_explorer_id: "custom:https://example.com/tx/{txid}",
+      })
+      expect(screen.getByTestId("saved-tx-explorer")).toHaveTextContent(CUSTOM_TX_EXPLORER_ID)
+    })
+  })
+
+  it("keeps the typed custom tx explorer URL when the API save fails", async () => {
+    const user = userEvent.setup()
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {})
+    mockApi.updateUserPreferences.mockRejectedValueOnce(new Error("save failed"))
+
+    render(<PreferencesProbe />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tx-explorer")).toHaveTextContent("mempool-space")
+    })
+
+    await user.click(screen.getByRole("button", { name: "Select custom tx explorer" }))
+    fireEvent.change(screen.getByRole("textbox", { name: "custom tx explorer url" }), {
+      target: { value: " https://example.com/tx/{txid} " },
+    })
+    await user.click(screen.getByRole("button", { name: "Save custom tx explorer" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tx-settings-error")).toHaveTextContent("Failed to save custom explorer")
+    })
+    expect(screen.getByRole("textbox", { name: "custom tx explorer url" })).toHaveValue(
+      " https://example.com/tx/{txid} "
+    )
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to update custom tx explorer preference:",
+      expect.any(Error)
+    )
+    consoleError.mockRestore()
   })
 })

--- a/frontend/src/hooks/useTxExplorer.ts
+++ b/frontend/src/hooks/useTxExplorer.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { useTranslations } from "next-intl"
 import { api } from "@/lib/api"
 import {
   DEFAULT_TX_EXPLORER,
@@ -24,14 +25,17 @@ export function invalidateTxExplorerCache() {
   }
 }
 
-function getTxExplorerRequest(): Promise<TxExplorerOption> {
+function getTxExplorerRequest(customExplorerName: string): Promise<TxExplorerOption> {
   if (cachedTxExplorer) {
+    if (cachedTxExplorer.isCustom) {
+      return Promise.resolve({ ...cachedTxExplorer, name: customExplorerName })
+    }
     return Promise.resolve(cachedTxExplorer)
   }
 
   if (!inFlightExplorerRequest) {
     const requestGeneration = txExplorerCacheGeneration
-    inFlightExplorerRequest = resolveTxExplorer()
+    inFlightExplorerRequest = resolveTxExplorer(customExplorerName)
       .then((explorer) => {
         if (requestGeneration === txExplorerCacheGeneration) {
           cachedTxExplorer = explorer
@@ -46,7 +50,7 @@ function getTxExplorerRequest(): Promise<TxExplorerOption> {
   return inFlightExplorerRequest
 }
 
-async function resolveTxExplorer(): Promise<TxExplorerOption> {
+async function resolveTxExplorer(customExplorerName: string): Promise<TxExplorerOption> {
   const [config, preferences] = await Promise.all([
     api.getConfig(),
     api.getUserPreferences().catch(() => null),
@@ -61,11 +65,14 @@ async function resolveTxExplorer(): Promise<TxExplorerOption> {
   return resolveSelectedTxExplorer(
     options,
     preferences?.preferred_tx_explorer_id ?? null,
-    config.default_tx_explorer_id
+    config.default_tx_explorer_id,
+    customExplorerName
   )
 }
 
 export function useTxExplorer(): TxExplorerOption {
+  const tSettings = useTranslations("settings")
+  const customExplorerName = tSettings("txExplorer.custom.title")
   const [txExplorer, setTxExplorer] = useState<TxExplorerOption>(DEFAULT_TX_EXPLORER)
 
   useEffect(() => {
@@ -76,7 +83,7 @@ export function useTxExplorer(): TxExplorerOption {
       requestVersion += 1
       const currentRequestVersion = requestVersion
 
-      getTxExplorerRequest()
+      getTxExplorerRequest(customExplorerName)
         .then((explorer) => {
           if (currentRequestVersion !== requestVersion) return
           if (isMounted) {
@@ -94,7 +101,7 @@ export function useTxExplorer(): TxExplorerOption {
       isMounted = false
       window.removeEventListener(TX_EXPLORER_CHANGED_EVENT, refreshTxExplorer)
     }
-  }, [])
+  }, [customExplorerName])
 
   return txExplorer
 }

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -5,7 +5,15 @@ import { api } from "@/lib/api"
 import { getStoredLocale, setStoredLocale } from "@/lib/locale"
 import type { Locale } from "@/i18n/config"
 import { invalidateTxExplorerCache } from "@/hooks/useTxExplorer"
-import { buildTxExplorerOptions, resolveSelectedTxExplorer, type TxExplorerOption } from "@/lib/tx-explorers"
+import {
+  CUSTOM_TX_EXPLORER_ID,
+  buildTxExplorerOptions,
+  decodeCustomTxExplorerPreference,
+  encodeCustomTxExplorerPreference,
+  isValidCustomTxExplorerTemplate,
+  resolveSelectedTxExplorer,
+  type TxExplorerOption,
+} from "@/lib/tx-explorers"
 import {
   PUBLIC_NTFY_SERVER_URL,
   PUBLIC_NTFY_SERVER_ID,
@@ -32,6 +40,7 @@ interface UseUserPreferencesOptions {
 export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOptions) {
   const router = useRouter()
   const t = useTranslations("settings")
+  const customTxExplorerName = t("txExplorer.custom.title")
 
   // Regional settings state
   const [selectedCurrency, setSelectedCurrency] = useState<string>("USD")
@@ -43,6 +52,10 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   const [availableTxExplorers, setAvailableTxExplorers] = useState<TxExplorerOption[]>([])
   const [defaultTxExplorerId, setDefaultTxExplorerId] = useState<string>("mempool-space")
   const [selectedTxExplorerId, setSelectedTxExplorerId] = useState<string>("mempool-space")
+  const [savedTxExplorerId, setSavedTxExplorerId] = useState<string>("mempool-space")
+  const [customTxExplorerUrl, setCustomTxExplorerUrl] = useState<string>("")
+  const [savedCustomTxExplorerUrl, setSavedCustomTxExplorerUrl] = useState<string>("")
+  const [txExplorerSettingsError, setTxExplorerSettingsError] = useState<string | null>(null)
   const [isUpdatingTxExplorer, setIsUpdatingTxExplorer] = useState(false)
 
   // ntfy server state
@@ -142,10 +155,20 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     const selectedExplorer = resolveSelectedTxExplorer(
       availableTxExplorers,
       userPreferences?.preferred_tx_explorer_id ?? null,
-      defaultTxExplorerId
+      defaultTxExplorerId,
+      customTxExplorerName
     )
     setSelectedTxExplorerId(selectedExplorer.id)
-  }, [availableTxExplorers, userPreferences?.preferred_tx_explorer_id, defaultTxExplorerId])
+    setSavedTxExplorerId(selectedExplorer.id)
+    const customTemplate = decodeCustomTxExplorerPreference(userPreferences?.preferred_tx_explorer_id ?? null)
+    if (customTemplate) {
+      setCustomTxExplorerUrl(customTemplate)
+      setSavedCustomTxExplorerUrl(customTemplate)
+    } else {
+      setCustomTxExplorerUrl("")
+      setSavedCustomTxExplorerUrl("")
+    }
+  }, [availableTxExplorers, userPreferences?.preferred_tx_explorer_id, defaultTxExplorerId, customTxExplorerName])
 
   useEffect(() => {
     const hasLoadedPreferences = !isAuthenticated || userPreferences !== null
@@ -347,6 +370,12 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
   }, [availableNtfyServers, clearNtfySettingsErrors, lastPublicNtfyUrl, ntfyServerUrl, selectedNtfyServerId])
 
   const handleTxExplorerChange = useCallback(async (explorerId: string) => {
+    setTxExplorerSettingsError(null)
+    if (explorerId === CUSTOM_TX_EXPLORER_ID) {
+      setSelectedTxExplorerId(CUSTOM_TX_EXPLORER_ID)
+      return
+    }
+
     const previousExplorerId = selectedTxExplorerId
     setSelectedTxExplorerId(explorerId)
     setIsUpdatingTxExplorer(true)
@@ -359,9 +388,13 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
       const selectedExplorer = resolveSelectedTxExplorer(
         availableTxExplorers,
         result.preferred_tx_explorer_id,
-        defaultTxExplorerId
+        defaultTxExplorerId,
+        customTxExplorerName
       )
       setSelectedTxExplorerId(selectedExplorer.id)
+      setSavedTxExplorerId(selectedExplorer.id)
+      setCustomTxExplorerUrl("")
+      setSavedCustomTxExplorerUrl("")
       invalidateTxExplorerCache()
     } catch (error) {
       console.error("Failed to update tx explorer preference:", error)
@@ -369,7 +402,40 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     } finally {
       setIsUpdatingTxExplorer(false)
     }
-  }, [availableTxExplorers, defaultTxExplorerId, selectedTxExplorerId])
+  }, [availableTxExplorers, defaultTxExplorerId, selectedTxExplorerId, customTxExplorerName])
+
+  const handleCustomTxExplorerSave = useCallback(async () => {
+    const previousExplorerId = selectedTxExplorerId
+    const normalizedCustomUrl = customTxExplorerUrl.trim()
+    setTxExplorerSettingsError(null)
+
+    if (!isValidCustomTxExplorerTemplate(normalizedCustomUrl)) {
+      setTxExplorerSettingsError(t("txExplorer.custom.validation"))
+      return false
+    }
+
+    setSelectedTxExplorerId(CUSTOM_TX_EXPLORER_ID)
+    setIsUpdatingTxExplorer(true)
+
+    try {
+      const result = await api.updateUserPreferences({
+        preferred_tx_explorer_id: encodeCustomTxExplorerPreference(normalizedCustomUrl),
+      })
+      setUserPreferences(result)
+      setCustomTxExplorerUrl(normalizedCustomUrl)
+      setSavedCustomTxExplorerUrl(normalizedCustomUrl)
+      setSavedTxExplorerId(CUSTOM_TX_EXPLORER_ID)
+      invalidateTxExplorerCache()
+      return true
+    } catch (error) {
+      console.error("Failed to update custom tx explorer preference:", error)
+      setTxExplorerSettingsError(t("txExplorer.custom.saveFailed"))
+      setSelectedTxExplorerId(previousExplorerId)
+      return false
+    } finally {
+      setIsUpdatingTxExplorer(false)
+    }
+  }, [customTxExplorerUrl, selectedTxExplorerId, t])
 
   return {
     // Regional settings
@@ -396,8 +462,14 @@ export function useUserPreferences({ isAuthenticated }: UseUserPreferencesOption
     userPreferences,
     availableTxExplorers,
     selectedTxExplorerId,
+    savedTxExplorerId,
+    customTxExplorerUrl,
+    setCustomTxExplorerUrl,
+    savedCustomTxExplorerUrl,
+    txExplorerSettingsError,
     isUpdatingTxExplorer,
     handleTxExplorerChange,
+    handleCustomTxExplorerSave,
     ntfyAuthType,
     setNtfyAuthType,
     ntfyAccessToken,

--- a/frontend/src/lib/__tests__/tx-explorers.test.ts
+++ b/frontend/src/lib/__tests__/tx-explorers.test.ts
@@ -3,6 +3,7 @@ import {
   PUBLIC_TX_EXPLORERS,
   buildTransactionExplorerUrl,
   buildTxExplorerOptions,
+  encodeCustomTxExplorerPreference,
   resolveExplorerBaseUrl,
   resolveSelectedTxExplorer,
 } from "../tx-explorers"
@@ -295,6 +296,25 @@ describe("tx explorer helpers", () => {
   it("builds transaction URLs with a shared /tx path", () => {
     expect(buildTransactionExplorerUrl("http://umbrel.local:3006/", "abc123")).toBe(
       "http://umbrel.local:3006/tx/abc123"
+    )
+  })
+
+  it("resolves and builds custom transaction explorer URL templates", () => {
+    const selected = resolveSelectedTxExplorer(
+      PUBLIC_TX_EXPLORERS,
+      encodeCustomTxExplorerPreference("https://example.com/transaction/{txid}"),
+      "mempool-space",
+      "Localized custom explorer"
+    )
+
+    expect(selected).toMatchObject({
+      id: "custom",
+      name: "Localized custom explorer",
+      baseUrl: "https://example.com/transaction/{txid}",
+      isCustom: true,
+    })
+    expect(buildTransactionExplorerUrl(selected.baseUrl, "abc123")).toBe(
+      "https://example.com/transaction/abc123"
     )
   })
 })

--- a/frontend/src/lib/tx-explorers.ts
+++ b/frontend/src/lib/tx-explorers.ts
@@ -6,7 +6,11 @@ export interface TxExplorerOption {
   baseUrl: string
   isLocal: boolean
   platform?: string
+  isCustom?: boolean
 }
+
+export const CUSTOM_TX_EXPLORER_ID = "custom"
+export const CUSTOM_TX_EXPLORER_PREFIX = "custom:"
 
 export const PUBLIC_TX_EXPLORERS: TxExplorerOption[] = [
   {
@@ -38,6 +42,38 @@ interface LocationLike {
 
 function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.trim().replace(/\/+$/, "")
+}
+
+function normalizeCustomTxExplorerTemplate(template: string): string {
+  return template.trim()
+}
+
+export function encodeCustomTxExplorerPreference(template: string): string {
+  return `${CUSTOM_TX_EXPLORER_PREFIX}${normalizeCustomTxExplorerTemplate(template)}`
+}
+
+export function decodeCustomTxExplorerPreference(
+  preferredExplorerId: string | null | undefined
+): string | null {
+  if (!preferredExplorerId?.startsWith(CUSTOM_TX_EXPLORER_PREFIX)) {
+    return null
+  }
+
+  return preferredExplorerId.slice(CUSTOM_TX_EXPLORER_PREFIX.length).trim() || null
+}
+
+export function isValidCustomTxExplorerTemplate(template: string): boolean {
+  const normalizedTemplate = normalizeCustomTxExplorerTemplate(template)
+  if (!normalizedTemplate.includes("{txid}")) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(normalizedTemplate.replaceAll("{txid}", "txid"))
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 function isBrowserSafeUrl(baseUrl: string): boolean {
@@ -140,8 +176,20 @@ export function buildTxExplorerOptions(
 export function resolveSelectedTxExplorer(
   options: TxExplorerOption[],
   preferredExplorerId: string | null | undefined,
-  defaultExplorerId: string | null | undefined
+  defaultExplorerId: string | null | undefined,
+  customExplorerName = CUSTOM_TX_EXPLORER_ID
 ): TxExplorerOption {
+  const customTemplate = decodeCustomTxExplorerPreference(preferredExplorerId)
+  if (customTemplate && isValidCustomTxExplorerTemplate(customTemplate)) {
+    return {
+      id: CUSTOM_TX_EXPLORER_ID,
+      name: customExplorerName,
+      baseUrl: customTemplate,
+      isLocal: false,
+      isCustom: true,
+    }
+  }
+
   const preferredExplorer = options.find((explorer) => explorer.id === preferredExplorerId)
   if (preferredExplorer) {
     return preferredExplorer
@@ -161,5 +209,9 @@ export function resolveSelectedTxExplorer(
 }
 
 export function buildTransactionExplorerUrl(baseUrl: string, txid: string): string {
+  if (baseUrl.includes("{txid}")) {
+    return baseUrl.replaceAll("{txid}", txid)
+  }
+
   return `${normalizeBaseUrl(baseUrl)}/tx/${txid}`
 }


### PR DESCRIPTION
## Summary
- Redesign transaction explorer and ntfy settings around provider cards with endpoint-level radio choices
- Add a custom transaction explorer URL template option using {txid}
- Add an ntfy SVG asset and localize the new labels across message files
- Validate custom transaction explorer preferences server-side

Closes #407

## Verification
- pnpm test -- --runTestsByPath src/components/settings/__tests__/tx-explorer-settings.test.tsx src/components/settings/__tests__/ntfy-server-settings.test.tsx src/lib/__tests__/tx-explorers.test.ts src/hooks/__tests__/useUserPreferences.test.tsx
- pnpm lint
- pnpm build
- cargo fmt --check
- cargo test --test config_endpoint_tests tx_explorer -- --nocapture