### PR TITLE
Reject non-derivable xpub descriptors

### DIFF
--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -430,16 +430,15 @@ pub async fn create_wallet_non_blocking(
                         StatusCode::BAD_REQUEST,
                         ErrorResponse::coded(
                             "invalid_descriptor_hardened_derivation",
-                            descriptor_error.to_string(),
+                            "Invalid descriptor: hardened account paths must be before the xpub, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
                         ),
                     ),
-                    DescriptorError::NotMultipath
-                    | DescriptorError::SplitMultipath(_)
-                    | DescriptorError::InvalidMultipathCount => (
+                    DescriptorError::NotMultipath | DescriptorError::InvalidMultipathCount => (
                         StatusCode::BAD_REQUEST,
                         ErrorResponse::coded("invalid_descriptor", descriptor_error.to_string()),
                     ),
-                    DescriptorError::InvalidDescriptor(_)
+                    DescriptorError::SplitMultipath(_)
+                    | DescriptorError::InvalidDescriptor(_)
                     | DescriptorError::InvalidStrippedDescriptor(_) => (
                         StatusCode::BAD_REQUEST,
                         ErrorResponse::coded(

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -428,9 +428,10 @@ pub async fn create_wallet_non_blocking(
                     StatusCode::BAD_REQUEST,
                     ErrorResponse::coded("invalid_descriptor_hardened_derivation", error_msg),
                 )
-            } else if error_msg.contains("Invalid stripped descriptor")
-                || error_msg.contains("Invalid descriptor")
-                || error_msg.contains("multipath descriptor")
+            } else if !error_msg.contains("hardened derivation")
+                && (error_msg.contains("Invalid stripped descriptor")
+                    || error_msg.contains("Invalid descriptor")
+                    || error_msg.contains("multipath descriptor"))
             {
                 (
                     StatusCode::BAD_REQUEST,

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -16,6 +16,7 @@ use crate::models::{
     CreateWalletRequest, CreateWalletResponse, ErrorResponse, UpdateWalletRequest,
 };
 use crate::stripe_billing::StripeBilling;
+use crate::utils::DescriptorError;
 use crate::xpub_converter::XpubConverter;
 use axum::{
     extract::{Path, Query, State},
@@ -423,23 +424,23 @@ pub async fn create_wallet_non_blocking(
                     StatusCode::CONFLICT,
                     ErrorResponse::coded("address_already_watched", error_msg),
                 )
-            } else if error_msg.contains("hardened derivation steps cannot appear after an xpub") {
-                (
-                    StatusCode::BAD_REQUEST,
-                    ErrorResponse::coded("invalid_descriptor_hardened_derivation", error_msg),
-                )
-            } else if !error_msg.contains("hardened derivation")
-                && (error_msg.contains("Invalid stripped descriptor")
-                    || error_msg.contains("Invalid descriptor")
-                    || error_msg.contains("multipath descriptor"))
-            {
-                (
-                    StatusCode::BAD_REQUEST,
-                    ErrorResponse::coded(
-                        "invalid_descriptor",
-                        "Invalid descriptor. Please check the format and try again.",
+            } else if let Some(descriptor_error) = e.downcast_ref::<DescriptorError>() {
+                match descriptor_error {
+                    DescriptorError::HardenedDerivationAfterXpub => (
+                        StatusCode::BAD_REQUEST,
+                        ErrorResponse::coded(
+                            "invalid_descriptor_hardened_derivation",
+                            descriptor_error.to_string(),
+                        ),
                     ),
-                )
+                    _ => (
+                        StatusCode::BAD_REQUEST,
+                        ErrorResponse::coded(
+                            "invalid_descriptor",
+                            "Invalid descriptor. Please check the format and try again.",
+                        ),
+                    ),
+                }
             } else {
                 (StatusCode::BAD_REQUEST, ErrorResponse::new(error_msg))
             };

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -433,7 +433,14 @@ pub async fn create_wallet_non_blocking(
                             descriptor_error.to_string(),
                         ),
                     ),
-                    _ => (
+                    DescriptorError::NotMultipath
+                    | DescriptorError::SplitMultipath(_)
+                    | DescriptorError::InvalidMultipathCount => (
+                        StatusCode::BAD_REQUEST,
+                        ErrorResponse::coded("invalid_descriptor", descriptor_error.to_string()),
+                    ),
+                    DescriptorError::InvalidDescriptor(_)
+                    | DescriptorError::InvalidStrippedDescriptor(_) => (
                         StatusCode::BAD_REQUEST,
                         ErrorResponse::coded(
                             "invalid_descriptor",

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -433,11 +433,9 @@ pub async fn create_wallet_non_blocking(
                             "Invalid descriptor: hardened account paths must be before the xpub, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
                         ),
                     ),
-                    DescriptorError::NotMultipath | DescriptorError::InvalidMultipathCount => (
-                        StatusCode::BAD_REQUEST,
-                        ErrorResponse::coded("invalid_descriptor", descriptor_error.to_string()),
-                    ),
-                    DescriptorError::SplitMultipath(_)
+                    DescriptorError::NotMultipath
+                    | DescriptorError::InvalidMultipathCount
+                    | DescriptorError::SplitMultipath(_)
                     | DescriptorError::InvalidDescriptor(_)
                     | DescriptorError::InvalidStrippedDescriptor(_) => (
                         StatusCode::BAD_REQUEST,

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -433,8 +433,14 @@ pub async fn create_wallet_non_blocking(
                             "Invalid descriptor: hardened account paths must be before the xpub, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
                         ),
                     ),
-                    DescriptorError::NotMultipath
-                    | DescriptorError::InvalidMultipathCount
+                    DescriptorError::NotMultipath => (
+                        StatusCode::BAD_REQUEST,
+                        ErrorResponse::coded(
+                            "invalid_descriptor_not_multipath",
+                            "Descriptor must include receive and change paths, for example xpub.../<0;1>/*.",
+                        ),
+                    ),
+                    DescriptorError::InvalidMultipathCount
                     | DescriptorError::SplitMultipath(_)
                     | DescriptorError::InvalidDescriptor(_)
                     | DescriptorError::InvalidStrippedDescriptor(_) => (

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -423,6 +423,22 @@ pub async fn create_wallet_non_blocking(
                     StatusCode::CONFLICT,
                     ErrorResponse::coded("address_already_watched", error_msg),
                 )
+            } else if error_msg.contains("hardened derivation steps cannot appear after an xpub") {
+                (
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::coded("invalid_descriptor_hardened_derivation", error_msg),
+                )
+            } else if error_msg.contains("Invalid stripped descriptor")
+                || error_msg.contains("Invalid descriptor")
+                || error_msg.contains("multipath descriptor")
+            {
+                (
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::coded(
+                        "invalid_descriptor",
+                        "Invalid descriptor. Please check the format and try again.",
+                    ),
+                )
             } else {
                 (StatusCode::BAD_REQUEST, ErrorResponse::new(error_msg))
             };

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -6,7 +6,7 @@ use std::{error::Error, fmt, sync::LazyLock};
 use tracing::debug;
 
 static KEY_ORIGIN_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[([0-9a-fA-F]{8})(/\d+[h']?)*\]").unwrap());
+    LazyLock::new(|| Regex::new(r"\[([0-9a-fA-F]{8})(/\d+[h'H]?)*\]").unwrap());
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DescriptorError {
@@ -66,7 +66,7 @@ pub fn strip_key_origin(descriptor_str: &str) -> Result<String, DescriptorError>
     // Strip key origin if present
     let stripped_without_checksum = if KEY_ORIGIN_PATTERN.is_match(without_checksum) {
         let result = KEY_ORIGIN_PATTERN.replace_all(without_checksum, "");
-        debug!(" Stripped key origin: {} -> {}", without_checksum, result);
+        debug!("Stripped key origin: {} -> {}", without_checksum, result);
         result.to_string()
     } else {
         // No key origin found, return without checksum
@@ -82,7 +82,7 @@ pub fn strip_key_origin(descriptor_str: &str) -> Result<String, DescriptorError>
 
     // Convert back to string with new checksum
     let final_descriptor = descriptor.to_string();
-    debug!(" Final normalized descriptor: {}", final_descriptor);
+    debug!("Final normalized descriptor: {}", final_descriptor);
 
     Ok(final_descriptor)
 }
@@ -125,8 +125,8 @@ pub fn parse_multipath_descriptor(
     let receive_descriptor = descriptors[0].to_string();
     let change_descriptor = descriptors[1].to_string();
 
-    debug!(" Receive descriptor: {}", receive_descriptor);
-    debug!(" Change descriptor: {}", change_descriptor);
+    debug!("Receive descriptor: {}", receive_descriptor);
+    debug!("Change descriptor: {}", change_descriptor);
 
     Ok((receive_descriptor, change_descriptor))
 }
@@ -255,6 +255,16 @@ mod tests {
     #[test]
     fn test_parse_multipath_descriptor_accepts_key_origin_hardened_path() {
         let descriptor = format!("wpkh([805c684b/84h/1h/0h]{VALID_TPUB}/<0;1>/*)");
+        let normalized = strip_key_origin(&descriptor).unwrap();
+
+        let result = parse_multipath_descriptor(&normalized);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_strip_key_origin_accepts_uppercase_h_hardened_path() {
+        let descriptor = format!("wpkh([805c684b/84H/1H/0H]{VALID_TPUB}/<0;1>/*)");
         let normalized = strip_key_origin(&descriptor).unwrap();
 
         let result = parse_multipath_descriptor(&normalized);

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -1,6 +1,6 @@
 //! Descriptor utility functions for parsing and normalizing Bitcoin descriptors
 
-use miniscript::{descriptor::Wildcard, Descriptor, DescriptorPublicKey, ForEachKey};
+use miniscript::{descriptor::Wildcard, Descriptor, DescriptorPublicKey, ForEachKey}; // ForEachKey enables .for_any_key().
 use regex::Regex;
 use std::{error::Error, fmt, sync::LazyLock};
 use tracing::debug;

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -1,9 +1,42 @@
 //! Descriptor utility functions for parsing and normalizing Bitcoin descriptors
 
-use anyhow::{anyhow, Result};
 use miniscript::{descriptor::Wildcard, Descriptor, DescriptorPublicKey, ForEachKey};
 use regex::Regex;
+use std::{error::Error, fmt};
 use tracing::debug;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DescriptorError {
+    InvalidStrippedDescriptor(String),
+    InvalidDescriptor(String),
+    NotMultipath,
+    SplitMultipath(String),
+    InvalidMultipathCount,
+    HardenedDerivationAfterXpub,
+}
+
+impl fmt::Display for DescriptorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DescriptorError::InvalidStrippedDescriptor(error) => {
+                write!(f, "Invalid stripped descriptor: {}", error)
+            }
+            DescriptorError::InvalidDescriptor(error) => write!(f, "Invalid descriptor: {}", error),
+            DescriptorError::NotMultipath => f.write_str("Descriptor is not a multipath descriptor"),
+            DescriptorError::SplitMultipath(error) => {
+                write!(f, "Failed to split multipath descriptor: {}", error)
+            }
+            DescriptorError::InvalidMultipathCount => {
+                f.write_str("Multipath descriptor must have exactly 2 paths (receive and change)")
+            }
+            DescriptorError::HardenedDerivationAfterXpub => f.write_str(
+                "Invalid descriptor: hardened derivation steps cannot appear after an xpub. Put the account path in key origin metadata, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
+            ),
+        }
+    }
+}
+
+impl Error for DescriptorError {}
 
 /// Strip key origin information from descriptor to prevent duplicates.
 ///
@@ -16,7 +49,7 @@ use tracing::debug;
 ///
 /// # Returns
 /// A normalized descriptor string with key origin stripped and checksum recalculated
-pub fn strip_key_origin(descriptor_str: &str) -> Result<String> {
+pub fn strip_key_origin(descriptor_str: &str) -> Result<String, DescriptorError> {
     // First strip any existing checksum (everything after #)
     let without_checksum = if let Some(pos) = descriptor_str.find('#') {
         &descriptor_str[..pos]
@@ -41,8 +74,8 @@ pub fn strip_key_origin(descriptor_str: &str) -> Result<String> {
 
     // Parse the stripped descriptor to recalculate checksum
     let descriptor: Descriptor<DescriptorPublicKey> = stripped_without_checksum
-        .parse()
-        .map_err(|e| anyhow!("Invalid stripped descriptor: {}", e))?;
+        .parse::<Descriptor<DescriptorPublicKey>>()
+        .map_err(|e| DescriptorError::InvalidStrippedDescriptor(e.to_string()))?;
 
     // Convert back to string with new checksum
     let final_descriptor = descriptor.to_string();
@@ -62,28 +95,28 @@ pub fn strip_key_origin(descriptor_str: &str) -> Result<String> {
 ///
 /// # Returns
 /// A tuple of `(receive_descriptor, change_descriptor)` strings
-pub fn parse_multipath_descriptor(descriptor_str: &str) -> Result<(String, String)> {
+pub fn parse_multipath_descriptor(
+    descriptor_str: &str,
+) -> Result<(String, String), DescriptorError> {
     // Parse the descriptor
     let descriptor: Descriptor<DescriptorPublicKey> = descriptor_str
-        .parse()
-        .map_err(|e| anyhow!("Invalid descriptor: {}", e))?;
+        .parse::<Descriptor<DescriptorPublicKey>>()
+        .map_err(|e| DescriptorError::InvalidDescriptor(e.to_string()))?;
 
     validate_public_descriptor_derivable(&descriptor)?;
 
     // Check if it's a multipath descriptor
     if !descriptor.is_multipath() {
-        return Err(anyhow!("Descriptor is not a multipath descriptor"));
+        return Err(DescriptorError::NotMultipath);
     }
 
     // Split multipath descriptor into receive and change descriptors
     let descriptors = descriptor
         .into_single_descriptors()
-        .map_err(|e| anyhow!("Failed to split multipath descriptor: {}", e))?;
+        .map_err(|e| DescriptorError::SplitMultipath(e.to_string()))?;
 
     if descriptors.len() != 2 {
-        return Err(anyhow!(
-            "Multipath descriptor must have exactly 2 paths (receive and change)"
-        ));
+        return Err(DescriptorError::InvalidMultipathCount);
     }
 
     let receive_descriptor = descriptors[0].to_string();
@@ -97,11 +130,9 @@ pub fn parse_multipath_descriptor(descriptor_str: &str) -> Result<(String, Strin
 
 fn validate_public_descriptor_derivable(
     descriptor: &Descriptor<DescriptorPublicKey>,
-) -> Result<()> {
+) -> Result<(), DescriptorError> {
     if descriptor.for_any_key(public_key_has_hardened_derivation) {
-        return Err(anyhow!(
-            "Invalid descriptor: hardened derivation steps cannot appear after an xpub. Put the account path in key origin metadata, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*."
-        ));
+        return Err(DescriptorError::HardenedDerivationAfterXpub);
     }
 
     Ok(())
@@ -176,11 +207,10 @@ mod tests {
 
         let result = parse_multipath_descriptor(&descriptor);
 
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("hardened derivation steps cannot appear after an xpub"));
+        assert_eq!(
+            result.unwrap_err(),
+            DescriptorError::HardenedDerivationAfterXpub
+        );
     }
 
     #[test]
@@ -189,11 +219,22 @@ mod tests {
 
         let result = parse_multipath_descriptor(&descriptor);
 
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("hardened derivation steps cannot appear after an xpub"));
+        assert_eq!(
+            result.unwrap_err(),
+            DescriptorError::HardenedDerivationAfterXpub
+        );
+    }
+
+    #[test]
+    fn test_parse_multipath_descriptor_rejects_hardened_wildcard_after_xpub() {
+        let descriptor = format!("wpkh({VALID_TPUB}/<0;1>/*h)");
+
+        let result = parse_multipath_descriptor(&descriptor);
+
+        assert_eq!(
+            result.unwrap_err(),
+            DescriptorError::HardenedDerivationAfterXpub
+        );
     }
 
     #[test]

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -68,6 +68,8 @@ pub fn parse_multipath_descriptor(descriptor_str: &str) -> Result<(String, Strin
         .parse()
         .map_err(|e| anyhow!("Invalid descriptor: {}", e))?;
 
+    validate_public_descriptor_derivable(&descriptor)?;
+
     // Check if it's a multipath descriptor
     if !descriptor.is_multipath() {
         return Err(anyhow!("Descriptor is not a multipath descriptor"));
@@ -87,20 +89,15 @@ pub fn parse_multipath_descriptor(descriptor_str: &str) -> Result<(String, Strin
     let receive_descriptor = descriptors[0].to_string();
     let change_descriptor = descriptors[1].to_string();
 
-    validate_public_descriptor_derivable(&receive_descriptor)?;
-    validate_public_descriptor_derivable(&change_descriptor)?;
-
     debug!(" Receive descriptor: {}", receive_descriptor);
     debug!(" Change descriptor: {}", change_descriptor);
 
     Ok((receive_descriptor, change_descriptor))
 }
 
-fn validate_public_descriptor_derivable(descriptor_str: &str) -> Result<()> {
-    let descriptor: Descriptor<DescriptorPublicKey> = descriptor_str
-        .parse()
-        .map_err(|e| anyhow!("Invalid descriptor: {}", e))?;
-
+fn validate_public_descriptor_derivable(
+    descriptor: &Descriptor<DescriptorPublicKey>,
+) -> Result<()> {
     if descriptor.for_any_key(public_key_has_hardened_derivation) {
         return Err(anyhow!(
             "Invalid descriptor: hardened derivation steps cannot appear after an xpub. Put the account path in key origin metadata, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*."
@@ -117,7 +114,8 @@ fn public_key_has_hardened_derivation(key: &DescriptorPublicKey) -> bool {
             xpub.wildcard == Wildcard::Hardened
                 || xpub
                     .derivation_path
-                    .into_iter()
+                    .as_ref()
+                    .iter()
                     .any(|step| step.is_hardened())
         }
         DescriptorPublicKey::MultiXPub(xpub) => {
@@ -126,7 +124,7 @@ fn public_key_has_hardened_derivation(key: &DescriptorPublicKey) -> bool {
                     .derivation_paths
                     .paths()
                     .iter()
-                    .any(|path| path.into_iter().any(|step| step.is_hardened()))
+                    .any(|path| path.as_ref().iter().any(|step| step.is_hardened()))
         }
     }
 }
@@ -175,6 +173,19 @@ mod tests {
     #[test]
     fn test_parse_multipath_descriptor_rejects_hardened_derivation_after_xpub() {
         let descriptor = format!("wpkh({VALID_TPUB}/84h/1h/0h/<0;1>/*)");
+
+        let result = parse_multipath_descriptor(&descriptor);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("hardened derivation steps cannot appear after an xpub"));
+    }
+
+    #[test]
+    fn test_parse_descriptor_rejects_single_path_hardened_derivation_after_xpub() {
+        let descriptor = format!("wpkh({VALID_TPUB}/84h/1h/0h/*)");
 
         let result = parse_multipath_descriptor(&descriptor);
 

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -2,8 +2,11 @@
 
 use miniscript::{descriptor::Wildcard, Descriptor, DescriptorPublicKey, ForEachKey};
 use regex::Regex;
-use std::{error::Error, fmt};
+use std::{error::Error, fmt, sync::LazyLock};
 use tracing::debug;
+
+static KEY_ORIGIN_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[([0-9a-fA-F]{8})(/\d+[h']?)*\]").unwrap());
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DescriptorError {
@@ -60,11 +63,9 @@ pub fn strip_key_origin(descriptor_str: &str) -> Result<String, DescriptorError>
     // Pattern to match [fingerprint/derivation/path] anywhere in the descriptor
     // This handles both bare xpubs and script-wrapped descriptors like wpkh([fingerprint/path]xpub...)
     // Supports both 'h' and '\'' for hardened paths
-    let key_origin_pattern = Regex::new(r"\[([0-9a-fA-F]{8})(/\d+[h']?)*\]").unwrap();
-
     // Strip key origin if present
-    let stripped_without_checksum = if key_origin_pattern.is_match(without_checksum) {
-        let result = key_origin_pattern.replace_all(without_checksum, "");
+    let stripped_without_checksum = if KEY_ORIGIN_PATTERN.is_match(without_checksum) {
+        let result = KEY_ORIGIN_PATTERN.replace_all(without_checksum, "");
         debug!(" Stripped key origin: {} -> {}", without_checksum, result);
         result.to_string()
     } else {

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -77,6 +77,8 @@ pub fn strip_key_origin(descriptor_str: &str) -> Result<String, DescriptorError>
         .parse::<Descriptor<DescriptorPublicKey>>()
         .map_err(|e| DescriptorError::InvalidStrippedDescriptor(e.to_string()))?;
 
+    validate_public_descriptor_derivable(&descriptor)?;
+
     // Convert back to string with new checksum
     let final_descriptor = descriptor.to_string();
     debug!(" Final normalized descriptor: {}", final_descriptor);
@@ -257,6 +259,18 @@ mod tests {
         let result = parse_multipath_descriptor(&normalized);
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_strip_key_origin_rejects_hardened_derivation_after_xpub() {
+        let descriptor = format!("wpkh({VALID_TPUB}/84h/1h/0h/<0;1>/*)");
+
+        let result = strip_key_origin(&descriptor);
+
+        assert_eq!(
+            result.unwrap_err(),
+            DescriptorError::HardenedDerivationAfterXpub
+        );
     }
 
     #[test]

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -1,7 +1,7 @@
 //! Descriptor utility functions for parsing and normalizing Bitcoin descriptors
 
 use anyhow::{anyhow, Result};
-use miniscript::{Descriptor, DescriptorPublicKey};
+use miniscript::{descriptor::Wildcard, Descriptor, DescriptorPublicKey, ForEachKey};
 use regex::Regex;
 use tracing::debug;
 
@@ -87,10 +87,48 @@ pub fn parse_multipath_descriptor(descriptor_str: &str) -> Result<(String, Strin
     let receive_descriptor = descriptors[0].to_string();
     let change_descriptor = descriptors[1].to_string();
 
+    validate_public_descriptor_derivable(&receive_descriptor)?;
+    validate_public_descriptor_derivable(&change_descriptor)?;
+
     debug!(" Receive descriptor: {}", receive_descriptor);
     debug!(" Change descriptor: {}", change_descriptor);
 
     Ok((receive_descriptor, change_descriptor))
+}
+
+fn validate_public_descriptor_derivable(descriptor_str: &str) -> Result<()> {
+    let descriptor: Descriptor<DescriptorPublicKey> = descriptor_str
+        .parse()
+        .map_err(|e| anyhow!("Invalid descriptor: {}", e))?;
+
+    if descriptor.for_any_key(public_key_has_hardened_derivation) {
+        return Err(anyhow!(
+            "Invalid descriptor: hardened derivation steps cannot appear after an xpub. Put the account path in key origin metadata, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*."
+        ));
+    }
+
+    Ok(())
+}
+
+fn public_key_has_hardened_derivation(key: &DescriptorPublicKey) -> bool {
+    match key {
+        DescriptorPublicKey::Single(_) => false,
+        DescriptorPublicKey::XPub(xpub) => {
+            xpub.wildcard == Wildcard::Hardened
+                || xpub
+                    .derivation_path
+                    .into_iter()
+                    .any(|step| step.is_hardened())
+        }
+        DescriptorPublicKey::MultiXPub(xpub) => {
+            xpub.wildcard == Wildcard::Hardened
+                || xpub
+                    .derivation_paths
+                    .paths()
+                    .iter()
+                    .any(|path| path.into_iter().any(|step| step.is_hardened()))
+        }
+    }
 }
 
 /// Extract the address from an `addr()` descriptor string (BIP-385).
@@ -131,6 +169,40 @@ pub fn extract_pubkey_from_descriptor(descriptor_str: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const VALID_TPUB: &str = "tpubDDDa5znrsZrYc3yVHe1iGrmsdrfSELKXK9AkkJL9LNQB2FwTbgtZBdVEunSv5qdLADWyTDXcA5scsjGBjPGsrWmxHuanS6nH5iRh3uZ4Uj5";
+
+    #[test]
+    fn test_parse_multipath_descriptor_rejects_hardened_derivation_after_xpub() {
+        let descriptor = format!("wpkh({VALID_TPUB}/84h/1h/0h/<0;1>/*)");
+
+        let result = parse_multipath_descriptor(&descriptor);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("hardened derivation steps cannot appear after an xpub"));
+    }
+
+    #[test]
+    fn test_parse_multipath_descriptor_accepts_key_origin_hardened_path() {
+        let descriptor = format!("wpkh([805c684b/84h/1h/0h]{VALID_TPUB}/<0;1>/*)");
+        let normalized = strip_key_origin(&descriptor).unwrap();
+
+        let result = parse_multipath_descriptor(&normalized);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_multipath_descriptor_accepts_account_level_xpub() {
+        let descriptor = format!("wpkh({VALID_TPUB}/<0;1>/*)");
+
+        let result = parse_multipath_descriptor(&descriptor);
+
+        assert!(result.is_ok());
+    }
 
     #[test]
     fn test_strip_key_origin_with_origin() {

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -214,6 +214,18 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_multipath_descriptor_rejects_hardened_derivation_in_sh_wpkh() {
+        let descriptor = format!("sh(wpkh({VALID_TPUB}/84h/1h/0h/<0;1>/*))");
+
+        let result = parse_multipath_descriptor(&descriptor);
+
+        assert_eq!(
+            result.unwrap_err(),
+            DescriptorError::HardenedDerivationAfterXpub
+        );
+    }
+
+    #[test]
     fn test_parse_descriptor_rejects_single_path_hardened_derivation_after_xpub() {
         let descriptor = format!("wpkh({VALID_TPUB}/84h/1h/0h/*)");
 

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -5,6 +5,6 @@ pub mod time;
 
 pub use descriptor::{
     extract_address_from_descriptor, extract_pubkey_from_descriptor, parse_multipath_descriptor,
-    strip_key_origin,
+    strip_key_origin, DescriptorError,
 };
 pub use time::current_unix_timestamp;

--- a/backend/tests/wallet_handlers_tests.rs
+++ b/backend/tests/wallet_handlers_tests.rs
@@ -505,7 +505,7 @@ async fn test_create_wallet_rejects_hardened_derivation_after_xpub_before_insert
     assert!(body["error"]
         .as_str()
         .unwrap()
-        .contains("hardened derivation steps cannot appear after an xpub"));
+        .contains("hardened account paths must be before the xpub"));
 
     let wallets = app_services
         .metadata_db

--- a/backend/tests/wallet_handlers_tests.rs
+++ b/backend/tests/wallet_handlers_tests.rs
@@ -472,6 +472,50 @@ async fn test_create_wallet_invalid_descriptor_returns_coded_generic_error() {
 }
 
 #[tokio::test]
+async fn test_create_wallet_non_multipath_descriptor_returns_coded_generic_error() {
+    let (app, _temp_dir, app_services) = create_test_app_with_services().await;
+    let descriptor = format!("wpkh({VALID_TESTNET_XPUB}/0/*)");
+
+    let request = Request::builder()
+        .uri("/api/wallets")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "name": "Single Path Descriptor",
+                "descriptor": descriptor
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.oneshot(authorized_request(request)).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 BAD_REQUEST for non-multipath descriptor"
+    );
+
+    let body = body_to_json(response.into_body()).await;
+    assert_eq!(body["error_code"].as_str().unwrap(), "invalid_descriptor");
+    assert_eq!(
+        body["error"].as_str().unwrap(),
+        "Invalid descriptor. Please check the format and try again."
+    );
+
+    let wallets = app_services
+        .metadata_db
+        .get_wallets_for_user(Some("foss-user"))
+        .await
+        .unwrap();
+    assert!(
+        wallets.is_empty(),
+        "Non-multipath descriptor should be rejected before wallet metadata is inserted"
+    );
+}
+
+#[tokio::test]
 async fn test_create_wallet_rejects_hardened_derivation_after_xpub_before_insert() {
     let (app, _temp_dir, app_services) = create_test_app_with_services().await;
     let descriptor = format!("wpkh({VALID_TESTNET_XPUB}/84h/1h/0h/<0;1>/*)");

--- a/backend/tests/wallet_handlers_tests.rs
+++ b/backend/tests/wallet_handlers_tests.rs
@@ -435,6 +435,90 @@ async fn test_create_wallet_invalid_descriptor() {
 }
 
 #[tokio::test]
+async fn test_create_wallet_invalid_descriptor_returns_coded_generic_error() {
+    let (app, _temp_dir) = create_test_app().await;
+
+    let request = Request::builder()
+        .uri("/api/wallets")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "name": "Invalid Wallet",
+                "descriptor": "xxx"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.oneshot(authorized_request(request)).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 BAD_REQUEST for invalid descriptor"
+    );
+
+    let body = body_to_json(response.into_body()).await;
+    assert_eq!(body["error_code"].as_str().unwrap(), "invalid_descriptor");
+    assert_eq!(
+        body["error"].as_str().unwrap(),
+        "Invalid descriptor. Please check the format and try again."
+    );
+    assert!(
+        !body["error"].as_str().unwrap().contains("Miniscript"),
+        "User-facing error should not leak parser internals"
+    );
+}
+
+#[tokio::test]
+async fn test_create_wallet_rejects_hardened_derivation_after_xpub_before_insert() {
+    let (app, _temp_dir, app_services) = create_test_app_with_services().await;
+    let descriptor = format!("wpkh({VALID_TESTNET_XPUB}/84h/1h/0h/<0;1>/*)");
+
+    let request = Request::builder()
+        .uri("/api/wallets")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "name": "Invalid Hardened Descriptor",
+                "descriptor": descriptor
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.oneshot(authorized_request(request)).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 BAD_REQUEST for hardened derivation after xpub"
+    );
+
+    let body = body_to_json(response.into_body()).await;
+    assert_eq!(
+        body["error_code"].as_str().unwrap(),
+        "invalid_descriptor_hardened_derivation"
+    );
+    assert!(body["error"]
+        .as_str()
+        .unwrap()
+        .contains("hardened derivation steps cannot appear after an xpub"));
+
+    let wallets = app_services
+        .metadata_db
+        .get_wallets_for_user(Some("foss-user"))
+        .await
+        .unwrap();
+    assert!(
+        wallets.is_empty(),
+        "Invalid descriptor should be rejected before wallet metadata is inserted"
+    );
+}
+
+#[tokio::test]
 async fn test_create_wallet_xpub_fresh_no_script_type() {
     let (app, _temp_dir) = create_test_app().await;
 

--- a/backend/tests/wallet_handlers_tests.rs
+++ b/backend/tests/wallet_handlers_tests.rs
@@ -472,7 +472,7 @@ async fn test_create_wallet_invalid_descriptor_returns_coded_generic_error() {
 }
 
 #[tokio::test]
-async fn test_create_wallet_non_multipath_descriptor_returns_coded_generic_error() {
+async fn test_create_wallet_non_multipath_descriptor_returns_specific_error() {
     let (app, _temp_dir, app_services) = create_test_app_with_services().await;
     let descriptor = format!("wpkh({VALID_TESTNET_XPUB}/0/*)");
 
@@ -498,10 +498,13 @@ async fn test_create_wallet_non_multipath_descriptor_returns_coded_generic_error
     );
 
     let body = body_to_json(response.into_body()).await;
-    assert_eq!(body["error_code"].as_str().unwrap(), "invalid_descriptor");
+    assert_eq!(
+        body["error_code"].as_str().unwrap(),
+        "invalid_descriptor_not_multipath"
+    );
     assert_eq!(
         body["error"].as_str().unwrap(),
-        "Invalid descriptor. Please check the format and try again."
+        "Descriptor must include receive and change paths, for example xpub.../<0;1>/*."
     );
 
     let wallets = app_services

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "Nøglen matcher ikke serverens netværk. Brug venligst den korrekte nøgletype.",
       "script_type_required": "Valg af scripttype er påkrævet for denne tegnebogskonfiguration.",
       "invalid_stop_gap": "Ugyldig stop gap-værdi. Tilladte værdier: auto, 250, 500, 750, 1000.",
+      "invalid_descriptor": "Ugyldig descriptor. Kontrollér formatet, og prøv igen.",
+      "invalid_descriptor_hardened_derivation": "Ugyldig descriptor: hærdede kontostier skal stå før xpub, for eksempel [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Du har nået det maksimale antal tegnebøger for dit abonnement. Opgrader for at tilføje flere.",
       "wallet_not_found": "Tegnebog ikke fundet.",
       "wallet_name_required": "Tegnebogens navn kan ikke være tomt.",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "Valg af scripttype er påkrævet for denne tegnebogskonfiguration.",
       "invalid_stop_gap": "Ugyldig stop gap-værdi. Tilladte værdier: auto, 250, 500, 750, 1000.",
       "invalid_descriptor": "Ugyldig descriptor. Kontrollér formatet, og prøv igen.",
+      "invalid_descriptor_not_multipath": "Descriptoren skal indeholde modtage- og vekselstier, for eksempel xpub.../<0;1>/*.",
       "invalid_descriptor_hardened_derivation": "Ugyldig descriptor: hærdede kontostier skal stå før xpub, for eksempel [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Du har nået det maksimale antal tegnebøger for dit abonnement. Opgrader for at tilføje flere.",
       "wallet_not_found": "Tegnebog ikke fundet.",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "Der Schlüssel stimmt nicht mit dem Netzwerk des Servers überein. Bitte verwenden Sie den richtigen Schlüsseltyp.",
       "script_type_required": "Die Auswahl des Skripttyps ist für diese Wallet-Konfiguration erforderlich.",
       "invalid_stop_gap": "Ungültiger Stop-Gap-Wert. Erlaubte Werte: auto, 250, 500, 750, 1000.",
+      "invalid_descriptor": "Ungültiger Descriptor. Bitte prüfen Sie das Format und versuchen Sie es erneut.",
+      "invalid_descriptor_hardened_derivation": "Ungültiger Descriptor: gehärtete Kontopfade müssen vor dem xpub stehen, zum Beispiel [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Sie haben die maximale Anzahl an Wallets für Ihren Plan erreicht. Upgraden Sie, um weitere hinzuzufügen.",
       "wallet_not_found": "Wallet nicht gefunden.",
       "wallet_name_required": "Der Wallet-Name darf nicht leer sein.",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "Die Auswahl des Skripttyps ist für diese Wallet-Konfiguration erforderlich.",
       "invalid_stop_gap": "Ungültiger Stop-Gap-Wert. Erlaubte Werte: auto, 250, 500, 750, 1000.",
       "invalid_descriptor": "Ungültiger Descriptor. Bitte prüfen Sie das Format und versuchen Sie es erneut.",
+      "invalid_descriptor_not_multipath": "Der Descriptor muss Empfangs- und Wechselpfade enthalten, zum Beispiel xpub.../<0;1>/*.",
       "invalid_descriptor_hardened_derivation": "Ungültiger Descriptor: gehärtete Kontopfade müssen vor dem xpub stehen, zum Beispiel [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Sie haben die maximale Anzahl an Wallets für Ihren Plan erreicht. Upgraden Sie, um weitere hinzuzufügen.",
       "wallet_not_found": "Wallet nicht gefunden.",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "Script type selection is required for this wallet configuration.",
       "invalid_stop_gap": "Invalid stop gap value. Allowed values: auto, 250, 500, 750, 1000.",
       "invalid_descriptor": "Invalid descriptor. Please check the format and try again.",
+      "invalid_descriptor_not_multipath": "Descriptor must include receive and change paths, for example xpub.../<0;1>/*.",
       "invalid_descriptor_hardened_derivation": "Invalid descriptor: hardened account paths must be before the xpub, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "You've reached the maximum number of wallets for your plan. Upgrade to add more.",
       "wallet_not_found": "Wallet not found.",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "The key does not match the server's network. Please use the correct key type.",
       "script_type_required": "Script type selection is required for this wallet configuration.",
       "invalid_stop_gap": "Invalid stop gap value. Allowed values: auto, 250, 500, 750, 1000.",
+      "invalid_descriptor": "Invalid descriptor. Please check the format and try again.",
+      "invalid_descriptor_hardened_derivation": "Invalid descriptor: hardened account paths must be before the xpub, for example [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "You've reached the maximum number of wallets for your plan. Upgrade to add more.",
       "wallet_not_found": "Wallet not found.",
       "wallet_name_required": "Wallet name cannot be empty.",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "La clave no coincide con la red del servidor. Por favor, use el tipo de clave correcto.",
       "script_type_required": "Se requiere la selección del tipo de script para esta configuración de billetera.",
       "invalid_stop_gap": "Valor de stop gap no válido. Valores permitidos: auto, 250, 500, 750, 1000.",
+      "invalid_descriptor": "Descriptor no válido. Revise el formato e inténtelo de nuevo.",
+      "invalid_descriptor_hardened_derivation": "Descriptor no válido: las rutas de cuenta endurecidas deben ir antes del xpub, por ejemplo [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Ha alcanzado el número máximo de billeteras para su plan. Actualice para agregar más.",
       "wallet_not_found": "Billetera no encontrada.",
       "wallet_name_required": "El nombre de la billetera no puede estar vacío.",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "Se requiere la selección del tipo de script para esta configuración de billetera.",
       "invalid_stop_gap": "Valor de stop gap no válido. Valores permitidos: auto, 250, 500, 750, 1000.",
       "invalid_descriptor": "Descriptor no válido. Revise el formato e inténtelo de nuevo.",
+      "invalid_descriptor_not_multipath": "El descriptor debe incluir rutas de recepción y cambio, por ejemplo xpub.../<0;1>/*.",
       "invalid_descriptor_hardened_derivation": "Descriptor no válido: las rutas de cuenta endurecidas deben ir antes del xpub, por ejemplo [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Ha alcanzado el número máximo de billeteras para su plan. Actualice para agregar más.",
       "wallet_not_found": "Billetera no encontrada.",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "La sélection du type de script est requise pour cette configuration de portefeuille.",
       "invalid_stop_gap": "Valeur de stop gap invalide. Valeurs autorisées : auto, 250, 500, 750, 1000.",
       "invalid_descriptor": "Descriptor invalide. Vérifiez le format et réessayez.",
+      "invalid_descriptor_not_multipath": "Le descriptor doit inclure les chemins de réception et de monnaie, par exemple xpub.../<0;1>/*.",
       "invalid_descriptor_hardened_derivation": "Descriptor invalide : les chemins de compte renforcés doivent être placés avant le xpub, par exemple [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Vous avez atteint le nombre maximum de portefeuilles pour votre forfait. Passez au niveau supérieur pour en ajouter d'autres.",
       "wallet_not_found": "Portefeuille non trouvé.",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "La clé ne correspond pas au réseau du serveur. Veuillez utiliser le bon type de clé.",
       "script_type_required": "La sélection du type de script est requise pour cette configuration de portefeuille.",
       "invalid_stop_gap": "Valeur de stop gap invalide. Valeurs autorisées : auto, 250, 500, 750, 1000.",
+      "invalid_descriptor": "Descriptor invalide. Vérifiez le format et réessayez.",
+      "invalid_descriptor_hardened_derivation": "Descriptor invalide : les chemins de compte renforcés doivent être placés avant le xpub, par exemple [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Vous avez atteint le nombre maximum de portefeuilles pour votre forfait. Passez au niveau supérieur pour en ajouter d'autres.",
       "wallet_not_found": "Portefeuille non trouvé.",
       "wallet_name_required": "Le nom du portefeuille ne peut pas être vide.",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "このウォレット構成にはスクリプトタイプの選択が必要です。",
       "invalid_stop_gap": "無効なストップギャップ値です。使用可能な値: auto, 250, 500, 750, 1000。",
       "invalid_descriptor": "無効なディスクリプタです。形式を確認してもう一度お試しください。",
+      "invalid_descriptor_not_multipath": "ディスクリプタには受取パスとお釣りパスを含める必要があります。例: xpub.../<0;1>/*。",
       "invalid_descriptor_hardened_derivation": "無効なディスクリプタです。ハード化されたアカウントパスは xpub の前に置く必要があります。例: [fingerprint/84h/0h/0h]xpub.../<0;1>/*。",
       "wallet_limit_reached": "プランのウォレット上限に達しました。追加するにはアップグレードしてください。",
       "wallet_not_found": "ウォレットが見つかりません。",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "キーがサーバーのネットワークと一致しません。正しいキータイプを使用してください。",
       "script_type_required": "このウォレット構成にはスクリプトタイプの選択が必要です。",
       "invalid_stop_gap": "無効なストップギャップ値です。使用可能な値: auto, 250, 500, 750, 1000。",
+      "invalid_descriptor": "無効なディスクリプタです。形式を確認してもう一度お試しください。",
+      "invalid_descriptor_hardened_derivation": "無効なディスクリプタです。ハード化されたアカウントパスは xpub の前に置く必要があります。例: [fingerprint/84h/0h/0h]xpub.../<0;1>/*。",
       "wallet_limit_reached": "プランのウォレット上限に達しました。追加するにはアップグレードしてください。",
       "wallet_not_found": "ウォレットが見つかりません。",
       "wallet_name_required": "ウォレット名を空にすることはできません。",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "Valg av skripttype er påkrevd for denne lommebokkonfigurasjonen.",
       "invalid_stop_gap": "Ugyldig stop gap-verdi. Tillatte verdier: auto, 250, 500, 750, 1000.",
       "invalid_descriptor": "Ugyldig descriptor. Sjekk formatet og prøv igjen.",
+      "invalid_descriptor_not_multipath": "Descriptoren må inneholde mottaks- og vekselstier, for eksempel xpub.../<0;1>/*.",
       "invalid_descriptor_hardened_derivation": "Ugyldig descriptor: herdede kontostier må stå før xpub, for eksempel [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Du har nådd maksimalt antall lommebøker for abonnementet ditt. Oppgrader for å legge til flere.",
       "wallet_not_found": "Lommebok ikke funnet.",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "Nøkkelen samsvarer ikke med serverens nettverk. Vennligst bruk riktig nøkkeltype.",
       "script_type_required": "Valg av skripttype er påkrevd for denne lommebokkonfigurasjonen.",
       "invalid_stop_gap": "Ugyldig stop gap-verdi. Tillatte verdier: auto, 250, 500, 750, 1000.",
+      "invalid_descriptor": "Ugyldig descriptor. Sjekk formatet og prøv igjen.",
+      "invalid_descriptor_hardened_derivation": "Ugyldig descriptor: herdede kontostier må stå før xpub, for eksempel [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Du har nådd maksimalt antall lommebøker for abonnementet ditt. Oppgrader for å legge til flere.",
       "wallet_not_found": "Lommebok ikke funnet.",
       "wallet_name_required": "Lommeboknavn kan ikke være tomt.",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "A seleção do tipo de script é necessária para esta configuração de carteira.",
       "invalid_stop_gap": "Valor de stop gap inválido. Valores permitidos: auto, 250, 500, 750, 1000.",
       "invalid_descriptor": "Descriptor inválido. Verifique o formato e tente novamente.",
+      "invalid_descriptor_not_multipath": "O descriptor deve incluir caminhos de recebimento e troco, por exemplo xpub.../<0;1>/*.",
       "invalid_descriptor_hardened_derivation": "Descriptor inválido: caminhos de conta hardened devem vir antes do xpub, por exemplo [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Você atingiu o número máximo de carteiras para seu plano. Faça upgrade para adicionar mais.",
       "wallet_not_found": "Carteira não encontrada.",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "A chave não corresponde à rede do servidor. Use o tipo de chave correto.",
       "script_type_required": "A seleção do tipo de script é necessária para esta configuração de carteira.",
       "invalid_stop_gap": "Valor de stop gap inválido. Valores permitidos: auto, 250, 500, 750, 1000.",
+      "invalid_descriptor": "Descriptor inválido. Verifique o formato e tente novamente.",
+      "invalid_descriptor_hardened_derivation": "Descriptor inválido: caminhos de conta hardened devem vir antes do xpub, por exemplo [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Você atingiu o número máximo de carteiras para seu plano. Faça upgrade para adicionar mais.",
       "wallet_not_found": "Carteira não encontrada.",
       "wallet_name_required": "O nome da carteira não pode estar vazio.",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -1078,6 +1078,7 @@
       "script_type_required": "Val av skripttyp krävs för denna plånbokskonfiguration.",
       "invalid_stop_gap": "Ogiltigt stop gap-värde. Tillåtna värden: auto, 250, 500, 750, 1000.",
       "invalid_descriptor": "Ogiltig descriptor. Kontrollera formatet och försök igen.",
+      "invalid_descriptor_not_multipath": "Descriptorn måste innehålla mottagnings- och växlingsstigar, till exempel xpub.../<0;1>/*.",
       "invalid_descriptor_hardened_derivation": "Ogiltig descriptor: härdade kontosökvägar måste stå före xpub, till exempel [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Du har nått det maximala antalet plånböcker för din plan. Uppgradera för att lägga till fler.",
       "wallet_not_found": "Plånbok hittades inte.",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -1077,6 +1077,8 @@
       "network_mismatch": "Nyckeln matchar inte serverns nätverk. Använd rätt nyckeltyp.",
       "script_type_required": "Val av skripttyp krävs för denna plånbokskonfiguration.",
       "invalid_stop_gap": "Ogiltigt stop gap-värde. Tillåtna värden: auto, 250, 500, 750, 1000.",
+      "invalid_descriptor": "Ogiltig descriptor. Kontrollera formatet och försök igen.",
+      "invalid_descriptor_hardened_derivation": "Ogiltig descriptor: härdade kontosökvägar måste stå före xpub, till exempel [fingerprint/84h/0h/0h]xpub.../<0;1>/*.",
       "wallet_limit_reached": "Du har nått det maximala antalet plånböcker för din plan. Uppgradera för att lägga till fler.",
       "wallet_not_found": "Plånbok hittades inte.",
       "wallet_name_required": "Plånbokens namn får inte vara tomt.",

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -162,6 +162,42 @@ describe('getTranslatedApiError', () => {
     expect(t).toHaveBeenCalledWith('email_already_exists')
   })
 
+  it('returns the translated hardened descriptor validation message', () => {
+    const error = new ApiError(
+      'Invalid descriptor: hardened derivation steps cannot appear after an xpub.',
+      'validation',
+      400,
+      'invalid_descriptor_hardened_derivation'
+    )
+    const t = jest.fn((key: string) =>
+      key === 'invalid_descriptor_hardened_derivation'
+        ? 'Invalid descriptor: hardened account paths must be before the xpub.'
+        : key
+    )
+
+    expect(getTranslatedApiError(error, t)).toBe(
+      'Invalid descriptor: hardened account paths must be before the xpub.'
+    )
+    expect(t).toHaveBeenCalledWith('invalid_descriptor_hardened_derivation')
+  })
+
+  it('returns the translated generic descriptor validation message', () => {
+    const error = new ApiError(
+      'Invalid descriptor. Please check the format and try again.',
+      'validation',
+      400,
+      'invalid_descriptor'
+    )
+    const t = jest.fn((key: string) =>
+      key === 'invalid_descriptor' ? 'Ugyldig descriptor. Sjekk formatet og prøv igjen.' : key
+    )
+
+    expect(getTranslatedApiError(error, t)).toBe(
+      'Ugyldig descriptor. Sjekk formatet og prøv igjen.'
+    )
+    expect(t).toHaveBeenCalledWith('invalid_descriptor')
+  })
+
   it('falls back to the user-friendly ApiError message when the translation key is missing', () => {
     const error = new ApiError('Invalid email or password', 'authentication', 401, 'invalid_credentials')
     const t = jest.fn((key: string) => `errors.api.${key}`)

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -198,6 +198,25 @@ describe('getTranslatedApiError', () => {
     expect(t).toHaveBeenCalledWith('invalid_descriptor')
   })
 
+  it('returns the translated non-multipath descriptor validation message', () => {
+    const error = new ApiError(
+      'Descriptor must include receive and change paths, for example xpub.../<0;1>/*.',
+      'validation',
+      400,
+      'invalid_descriptor_not_multipath'
+    )
+    const t = jest.fn((key: string) =>
+      key === 'invalid_descriptor_not_multipath'
+        ? 'Descriptoren må inneholde mottaks- og vekselstier.'
+        : key
+    )
+
+    expect(getTranslatedApiError(error, t)).toBe(
+      'Descriptoren må inneholde mottaks- og vekselstier.'
+    )
+    expect(t).toHaveBeenCalledWith('invalid_descriptor_not_multipath')
+  })
+
   it('falls back to the user-friendly ApiError message when the translation key is missing', () => {
     const error = new ApiError('Invalid email or password', 'authentication', 401, 'invalid_credentials')
     const t = jest.fn((key: string) => `errors.api.${key}`)


### PR DESCRIPTION
## Summary
- reject public descriptors that put hardened account derivation after an xpub/tpub before wallet metadata is inserted
- return coded, translated descriptor validation errors without exposing parser internals
- add backend and frontend regression coverage for hardened and generic invalid descriptors

## Tests
- cargo test --manifest-path backend/Cargo.toml test_parse_multipath_descriptor -- --nocapture
- cargo test --manifest-path backend/Cargo.toml --test wallet_handlers_tests test_create_wallet_rejects_hardened_derivation_after_xpub_before_insert -- --nocapture
- cargo test --manifest-path backend/Cargo.toml --test wallet_handlers_tests test_create_wallet_invalid_descriptor_returns_coded_generic_error -- --nocapture
- pnpm test -- --runTestsByPath src/lib/__tests__/utils.test.ts
- node -e "const fs=require('fs'); for (const f of fs.readdirSync('frontend/messages')) JSON.parse(fs.readFileSync('frontend/messages/'+f,'utf8')); console.log('locale json ok')"