### PR TITLE
Fix v1.5.1 version metadata

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "canary"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canary"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 
 [lib]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canary",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "mkdir -p logs && next dev --port 3001 2>&1 | tee logs/frontend.log",


### PR DESCRIPTION
## Summary
- Align backend and frontend package metadata with the already-published v1.5.1 release tag
- Update the root canary entry in Cargo.lock

## Test plan
- [x] ./release.sh 1.5.2 --dry-run reaches prerequisites and reports 1.5.1 -> 1.5.2