### PR TITLE
Bump version to v1.5.2

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "canary"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canary"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 
 [lib]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canary",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "scripts": {
     "dev": "mkdir -p logs && next dev --port 3001 2>&1 | tee logs/frontend.log",


### PR DESCRIPTION
## Summary
Bump Canary package metadata to v1.5.2 before tagging the release.

## Test plan
- [x] Node distro smoke testing completed before release tagging
