### PR TITLE
Clean up migrated balance alerts

### DIFF
--- a/backend/migrations/032_cleanup_migrated_balance_alerts.sql
+++ b/backend/migrations/032_cleanup_migrated_balance_alerts.sql
@@ -1,0 +1,48 @@
+BEGIN;
+
+CREATE TEMP TABLE migrated_balance_alert_cleanup_ids (
+    id TEXT PRIMARY KEY
+);
+
+INSERT INTO migrated_balance_alert_cleanup_ids (id)
+SELECT ba.id
+FROM balance_alerts ba
+WHERE ba.contact_id IS NULL
+  AND ba.is_active = 0
+  AND EXISTS (
+      SELECT 1
+      FROM balance_alerts contact_ba
+      WHERE contact_ba.wallet_checksum = ba.wallet_checksum
+        AND contact_ba.contact_id IS NOT NULL
+        AND contact_ba.threshold_sats = ba.threshold_sats
+        AND contact_ba.alert_type = ba.alert_type
+        -- Migration 031 copied ba.created_at verbatim into each per-contact row.
+        AND contact_ba.created_at = ba.created_at
+        AND (
+            contact_ba.threshold_currency = ba.threshold_currency
+            OR (contact_ba.threshold_currency IS NULL AND ba.threshold_currency IS NULL)
+        )
+        AND (
+            contact_ba.threshold_fiat_amount = ba.threshold_fiat_amount
+            OR (contact_ba.threshold_fiat_amount IS NULL AND ba.threshold_fiat_amount IS NULL)
+        )
+  );
+
+DELETE FROM balance_alert_notification_logs
+WHERE balance_alert_id IN (
+    SELECT id FROM migrated_balance_alert_cleanup_ids
+);
+
+DELETE FROM balance_alert_notifications
+WHERE balance_alert_id IN (
+    SELECT id FROM migrated_balance_alert_cleanup_ids
+);
+
+DELETE FROM balance_alerts
+WHERE id IN (
+    SELECT id FROM migrated_balance_alert_cleanup_ids
+);
+
+DROP TABLE migrated_balance_alert_cleanup_ids;
+
+COMMIT;

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -488,6 +488,70 @@ describe('WalletNotificationsPage', () => {
     await waitFor(() => expect(mockApi.deleteBalanceAlert).toHaveBeenCalledWith('alert-1'))
   })
 
+  it('hides inactive migrated wallet-level balance thresholds', async () => {
+    mockNotificationsResponse(
+      [makeContact()],
+      [
+        makeAlert({
+          id: 'legacy-alert',
+          contact_id: undefined,
+          threshold_sats: 0,
+          alert_type: 'equals',
+          is_active: false,
+        }),
+        makeAlert({
+          id: 'contact-alert',
+          contact_id: 'contact-1',
+          threshold_sats: 0,
+          alert_type: 'equals',
+        }),
+      ]
+    )
+
+    await renderLoadedPage()
+
+    expect(screen.queryByText('Legacy wallet balance thresholds')).not.toBeInTheDocument()
+    expect(screen.getByText('equals 0 BTC')).toBeInTheDocument()
+  })
+
+  it('keeps inactive standalone wallet-level balance thresholds visible', async () => {
+    mockNotificationsResponse(
+      [],
+      [
+        makeAlert({
+          contact_id: undefined,
+          threshold_sats: 0,
+          alert_type: 'equals',
+          is_active: false,
+        }),
+      ]
+    )
+
+    await renderLoadedPage()
+
+    expect(screen.getByText('Legacy wallet balance thresholds')).toBeInTheDocument()
+    expect(screen.getByText('equals 0 BTC')).toBeInTheDocument()
+  })
+
+  it('keeps inactive contact-level balance thresholds visible', async () => {
+    mockNotificationsResponse(
+      [makeContact()],
+      [
+        makeAlert({
+          contact_id: 'contact-1',
+          threshold_sats: 0,
+          alert_type: 'equals',
+          is_active: false,
+        }),
+      ]
+    )
+
+    await renderLoadedPage()
+
+    expect(screen.queryByText('Legacy wallet balance thresholds')).not.toBeInTheDocument()
+    expect(screen.getByText('equals 0 BTC')).toBeInTheDocument()
+  })
+
   it('uses the preferred fiat currency for threshold notifications', async () => {
     const user = userEvent.setup()
     mockNotificationsResponse([makeContact()])

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -219,6 +219,35 @@ function txSettingsFromDraft(draft: ContactDraft) {
   }
 }
 
+function nullableThresholdFieldMatches<T>(
+  left: T | null | undefined,
+  right: T | null | undefined
+) {
+  return left == null ? right == null : left === right
+}
+
+function isMigratedWalletLevelAlert(
+  walletLevelAlert: BalanceAlert,
+  candidate: BalanceAlert
+) {
+  return (
+    !walletLevelAlert.contact_id &&
+    Boolean(candidate.contact_id) &&
+    candidate.wallet_checksum === walletLevelAlert.wallet_checksum &&
+    candidate.threshold_sats === walletLevelAlert.threshold_sats &&
+    candidate.alert_type === walletLevelAlert.alert_type &&
+    candidate.created_at === walletLevelAlert.created_at &&
+    nullableThresholdFieldMatches(
+      candidate.threshold_currency,
+      walletLevelAlert.threshold_currency
+    ) &&
+    nullableThresholdFieldMatches(
+      candidate.threshold_fiat_amount,
+      walletLevelAlert.threshold_fiat_amount
+    )
+  )
+}
+
 function TransactionEventGroups({
   groups,
   draft,
@@ -1203,7 +1232,15 @@ export default function WalletNotificationsPage() {
     }, {})
   }, [alerts])
   const walletLevelAlerts = useMemo(
-    () => alerts.filter((alert) => !alert.contact_id),
+    () =>
+      alerts.filter(
+        (alert) =>
+          !alert.contact_id &&
+          (alert.is_active ||
+            !alerts.some((candidate) =>
+              isMigratedWalletLevelAlert(alert, candidate)
+            ))
+      ),
     [alerts]
   )
 


### PR DESCRIPTION
## Summary
- add migration 032 to delete inactive wallet-level balance alert source rows once matching active contact-level alerts exist
- explicitly remove dependent internal balance-alert notification records for those migrated source rows
- filter the notifications settings UI to render only active balance alerts
- add regression coverage for inactive migrated wallet-level alerts

## Safety
- cleanup only targets inactive wallet-level alerts with active matching contact-level replacements
- production dry-run query matched 5 cleanup candidates and does not touch active contact-specific alerts

## Tests
- npm test -- --runTestsByPath 'src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx' --runInBand
- applied the full backend/migrations/*.sql chain to a temporary SQLite database