### PR TITLE
Add Canary agent loop adapter

### DIFF
--- a/.agent-loop/canary-issue-pr-loop.md
+++ b/.agent-loop/canary-issue-pr-loop.md
@@ -1,0 +1,37 @@
+# Canary Issue PR Loop Prompt
+
+Use this prompt for ordinary Canary GitHub issues when the desired outcome is a
+PR that is green and ready for human final review.
+
+```text
+Use the agent-loop-engineering skill.
+
+/goal Work on GitHub issue #ISSUE_NUMBER in Canary through PR review.
+
+Follow AGENTS.md, CLAUDE.md, backend/CLAUDE.md, and frontend/CLAUDE.md as
+relevant.
+
+Create a normal feature/fix branch from master.
+Do not use canary-next-version in the main Canary repo.
+
+Implement the issue, run the relevant narrow checks, then run
+.agent-loop/checks.sh quick before opening the PR.
+
+Open the GitHub PR when the branch is locally ready.
+After opening the PR, monitor CI and the Codex, Claude, and Gemini bot reviews.
+Read all review comments.
+Fix feedback that is relevant to this PR.
+Push follow-up commits as needed.
+Rerun relevant checks after fixes.
+
+Never merge.
+Stop when CI is green, relevant bot feedback is handled or clearly explained as
+not applicable, and the PR is ready for my final review.
+```
+
+For local-only work, add:
+
+```text
+Do not open a PR. Stop with branch name, commit hash, checks run, remaining
+risks, and proposed PR title/body.
+```

--- a/.agent-loop/checks.sh
+++ b/.agent-loop/checks.sh
@@ -2,19 +2,32 @@
 set -euo pipefail
 
 mode="${1:-quick}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+check_requirements() {
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "Error: required command '$cmd' is not installed or not on PATH." >&2
+      exit 1
+    fi
+  done
+}
 
 run_backend() {
+  check_requirements cargo
   (
-    cd "backend"
+    cd "$REPO_ROOT/backend"
     cargo fmt --check
     cargo clippy --all-targets -- -D warnings
+    # Keep tests single-threaded to avoid shared database and port contention.
     cargo test -- --test-threads=1
   )
 }
 
 run_frontend() {
+  check_requirements pnpm
   (
-    cd "frontend"
+    cd "$REPO_ROOT/frontend"
     pnpm run lint
     pnpm test
     pnpm run build
@@ -23,16 +36,18 @@ run_frontend() {
 
 run_system() {
   echo "Warning: system mode runs Docker-backed system tests and may affect local services." >&2
+  check_requirements bash
   (
-    cd backend
+    cd "$REPO_ROOT/backend"
     ./run-system-tests.sh
   )
 }
 
 run_upgrade() {
   echo "Warning: upgrade mode may start/stop services and create temporary upgrade worktrees." >&2
+  check_requirements bash
   (
-    cd scripts
+    cd "$REPO_ROOT/scripts"
     ./test-upgrade.sh
   )
 }

--- a/.agent-loop/checks.sh
+++ b/.agent-loop/checks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-quick}"
+
+run_backend() {
+  cd "backend"
+  cargo fmt --check
+  cargo clippy -- -D warnings
+  cargo test -- --test-threads=1
+  cd - >/dev/null
+}
+
+run_frontend() {
+  cd "frontend"
+  pnpm run lint
+  pnpm test
+  pnpm run build
+  cd - >/dev/null
+}
+
+run_system() {
+  cd backend
+  ./run-system-tests.sh
+  cd - >/dev/null
+}
+
+run_upgrade() {
+  cd scripts
+  ./test-upgrade.sh
+  cd - >/dev/null
+}
+
+case "$mode" in
+  quick)
+    run_backend
+    run_frontend
+    ;;
+  backend) run_backend ;;
+  frontend) run_frontend ;;
+  system) run_system ;;
+  upgrade) run_upgrade ;;
+  ci)
+    run_backend
+    run_frontend
+    ;;
+  full)
+    run_backend
+    run_frontend
+    run_system
+    run_upgrade
+    ;;
+  *)
+    echo "Usage: $0 [quick|backend|frontend|system|upgrade|ci|full]" >&2
+    exit 2
+    ;;
+esac

--- a/.agent-loop/checks.sh
+++ b/.agent-loop/checks.sh
@@ -4,31 +4,37 @@ set -euo pipefail
 mode="${1:-quick}"
 
 run_backend() {
-  cd "backend"
-  cargo fmt --check
-  cargo clippy -- -D warnings
-  cargo test -- --test-threads=1
-  cd - >/dev/null
+  (
+    cd "backend"
+    cargo fmt --check
+    cargo clippy --all-targets -- -D warnings
+    cargo test -- --test-threads=1
+  )
 }
 
 run_frontend() {
-  cd "frontend"
-  pnpm run lint
-  pnpm test
-  pnpm run build
-  cd - >/dev/null
+  (
+    cd "frontend"
+    pnpm run lint
+    pnpm test
+    pnpm run build
+  )
 }
 
 run_system() {
-  cd backend
-  ./run-system-tests.sh
-  cd - >/dev/null
+  echo "Warning: system mode runs Docker-backed system tests and may affect local services." >&2
+  (
+    cd backend
+    ./run-system-tests.sh
+  )
 }
 
 run_upgrade() {
-  cd scripts
-  ./test-upgrade.sh
-  cd - >/dev/null
+  echo "Warning: upgrade mode may start/stop services and create temporary upgrade worktrees." >&2
+  (
+    cd scripts
+    ./test-upgrade.sh
+  )
 }
 
 case "$mode" in
@@ -41,6 +47,7 @@ case "$mode" in
   system) run_system ;;
   upgrade) run_upgrade ;;
   ci)
+    # Alias for quick until CI-specific gates diverge.
     run_backend
     run_frontend
     ;;

--- a/.agent-loop/state.example.md
+++ b/.agent-loop/state.example.md
@@ -1,0 +1,22 @@
+# Agent Loop State
+
+## Goal
+- TBD
+
+## Acceptance Criteria
+- TBD
+
+## Current Status
+- Not started
+
+## Attempts
+- TBD
+
+## Checks Run
+- TBD
+
+## Open Risks
+- TBD
+
+## Handoff
+- TBD

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Temporary Items
 
 .claude/*
 .pnpm-store/
+
+# Agent loop live state
+.agent-loop/state.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,24 @@
 # Canary Agent Notes
 
+## Canary issue loop
+
+For ordinary Canary GitHub issues, the useful default is a full PR-readiness
+loop, not a local-only loop:
+
+1. create a normal feature/fix branch from `master`
+2. implement the issue
+3. run the relevant `.agent-loop/checks.sh` gates
+4. open the GitHub PR
+5. watch CI and the Codex, Claude, and Gemini PR review bots
+6. fix review feedback that is relevant to the PR
+7. push follow-up commits until CI is green and relevant bot feedback is handled
+
+Never merge the PR. Stop when the PR is ready for human final review.
+
+If the user explicitly asks for "local only", "PR-ready only", or "do not open
+a PR", stop before creating the PR and provide the proposed PR title/body
+instead.
+
 ## Node distro packaging work
 
 Keep Umbrel, StartOS, myNode, and similar node distro packaging changes batched


### PR DESCRIPTION
## Summary
- add a repo-local `.agent-loop/checks.sh` adapter with quick/backend/frontend/system/upgrade modes
- add a reusable Canary issue PR loop prompt
- document the default Canary PR-readiness loop in AGENTS.md
- ignore live `.agent-loop/state.md` run memory

## Checks
- `bash -n .agent-loop/checks.sh`
- `node /Users/schjonhaug/.codex/skills/agent-loop-engineering/scripts/loop-doctor.mjs .`
- `git diff --check origin/master...HEAD`

Full backend/frontend gates were not run because this PR only adds loop docs and a shell adapter; the adapter defines those heavier gates for future issue loops.