### PR TITLE
Fix re-adding deleted delivery methods

### DIFF
--- a/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
+++ b/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
@@ -45,7 +45,6 @@ WHERE ba.contact_id IS NULL
         AND existing_ba.contact_id = c.id
         AND existing_ba.threshold_sats = ba.threshold_sats
         AND existing_ba.alert_type = ba.alert_type
-        AND existing_ba.created_at = ba.created_at
         AND (
             existing_ba.threshold_currency = ba.threshold_currency
             OR (existing_ba.threshold_currency IS NULL AND ba.threshold_currency IS NULL)
@@ -74,7 +73,6 @@ WHERE ba.contact_id IS NULL
         AND contact_ba.contact_id IS NOT NULL
         AND contact_ba.threshold_sats = ba.threshold_sats
         AND contact_ba.alert_type = ba.alert_type
-        AND contact_ba.created_at = ba.created_at
         AND (
             contact_ba.threshold_currency = ba.threshold_currency
             OR (contact_ba.threshold_currency IS NULL AND ba.threshold_currency IS NULL)

--- a/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
+++ b/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
@@ -36,6 +36,8 @@ SELECT
 FROM balance_alerts ba
 JOIN contacts c ON c.wallet_checksum = ba.wallet_checksum
 WHERE ba.contact_id IS NULL
+  -- Inactive alerts are historical fired alerts. Keep them wallet-level so the UI
+  -- can still show legacy standalone history instead of inventing per-contact rows.
   AND ba.is_active = 1
   AND c.is_active = 1
   AND NOT EXISTS (
@@ -59,6 +61,7 @@ INSERT INTO active_wallet_level_balance_alert_cleanup_ids (id)
 SELECT ba.id
 FROM balance_alerts ba
 WHERE ba.contact_id IS NULL
+  -- Match the copy step: only active wallet-level alerts are obsolete after fan-out.
   AND ba.is_active = 1
   AND EXISTS (
       SELECT 1

--- a/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
+++ b/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
@@ -4,6 +4,10 @@ CREATE TEMP TABLE active_wallet_level_balance_alert_cleanup_ids (
     id TEXT PRIMARY KEY
 );
 
+CREATE TEMP TABLE active_wallet_level_balance_alert_history_ids (
+    id TEXT PRIMARY KEY
+);
+
 INSERT INTO balance_alerts (
     id,
     wallet_checksum,
@@ -62,6 +66,8 @@ SELECT ba.id
 FROM balance_alerts ba
 WHERE ba.contact_id IS NULL
   -- Match the copy step: only active wallet-level alerts are obsolete after fan-out.
+  -- Rows with notification history are deactivated below instead of deleted so
+  -- balance alert audit records keep a valid parent row.
   AND ba.is_active = 1
   AND EXISTS (
       SELECT 1
@@ -86,6 +92,31 @@ WHERE ba.contact_id IS NULL
         )
   );
 
+INSERT INTO active_wallet_level_balance_alert_history_ids (id)
+SELECT cleanup.id
+FROM active_wallet_level_balance_alert_cleanup_ids cleanup
+WHERE EXISTS (
+    SELECT 1
+    FROM balance_alert_notifications notification
+    WHERE notification.balance_alert_id = cleanup.id
+)
+OR EXISTS (
+    SELECT 1
+    FROM balance_alert_notification_logs log
+    WHERE log.balance_alert_id = cleanup.id
+);
+
+UPDATE balance_alerts
+SET is_active = 0
+WHERE id IN (
+    SELECT id FROM active_wallet_level_balance_alert_history_ids
+);
+
+DELETE FROM active_wallet_level_balance_alert_cleanup_ids
+WHERE id IN (
+    SELECT id FROM active_wallet_level_balance_alert_history_ids
+);
+
 DELETE FROM balance_alert_notification_logs
 WHERE balance_alert_id IN (
     SELECT id FROM active_wallet_level_balance_alert_cleanup_ids
@@ -101,6 +132,7 @@ WHERE id IN (
     SELECT id FROM active_wallet_level_balance_alert_cleanup_ids
 );
 
+DROP TABLE active_wallet_level_balance_alert_history_ids;
 DROP TABLE active_wallet_level_balance_alert_cleanup_ids;
 
 COMMIT;

--- a/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
+++ b/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
@@ -1,0 +1,105 @@
+BEGIN;
+
+CREATE TEMP TABLE active_wallet_level_balance_alert_cleanup_ids (
+    id TEXT PRIMARY KEY
+);
+
+INSERT INTO balance_alerts (
+    id,
+    wallet_checksum,
+    threshold_sats,
+    alert_type,
+    is_active,
+    last_triggered_at,
+    created_at,
+    threshold_currency,
+    threshold_fiat_amount,
+    last_checked_balance_sats,
+    contact_id
+)
+SELECT
+    lower(hex(randomblob(4))) || '-' ||
+    lower(hex(randomblob(2))) || '-' ||
+    lower(hex(randomblob(2))) || '-' ||
+    lower(hex(randomblob(2))) || '-' ||
+    lower(hex(randomblob(6))),
+    ba.wallet_checksum,
+    ba.threshold_sats,
+    ba.alert_type,
+    ba.is_active,
+    ba.last_triggered_at,
+    ba.created_at,
+    ba.threshold_currency,
+    ba.threshold_fiat_amount,
+    ba.last_checked_balance_sats,
+    c.id
+FROM balance_alerts ba
+JOIN contacts c ON c.wallet_checksum = ba.wallet_checksum
+WHERE ba.contact_id IS NULL
+  AND ba.is_active = 1
+  AND c.is_active = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM balance_alerts existing_ba
+      WHERE existing_ba.wallet_checksum = ba.wallet_checksum
+        AND existing_ba.contact_id = c.id
+        AND existing_ba.threshold_sats = ba.threshold_sats
+        AND existing_ba.alert_type = ba.alert_type
+        AND existing_ba.created_at = ba.created_at
+        AND (
+            existing_ba.threshold_currency = ba.threshold_currency
+            OR (existing_ba.threshold_currency IS NULL AND ba.threshold_currency IS NULL)
+        )
+        AND (
+            existing_ba.threshold_fiat_amount = ba.threshold_fiat_amount
+            OR (existing_ba.threshold_fiat_amount IS NULL AND ba.threshold_fiat_amount IS NULL)
+        )
+  );
+
+INSERT INTO active_wallet_level_balance_alert_cleanup_ids (id)
+SELECT ba.id
+FROM balance_alerts ba
+WHERE ba.contact_id IS NULL
+  AND ba.is_active = 1
+  AND EXISTS (
+      SELECT 1
+      FROM contacts c
+      WHERE c.wallet_checksum = ba.wallet_checksum
+        AND c.is_active = 1
+  )
+  AND EXISTS (
+      SELECT 1
+      FROM balance_alerts contact_ba
+      WHERE contact_ba.wallet_checksum = ba.wallet_checksum
+        AND contact_ba.contact_id IS NOT NULL
+        AND contact_ba.threshold_sats = ba.threshold_sats
+        AND contact_ba.alert_type = ba.alert_type
+        AND contact_ba.created_at = ba.created_at
+        AND (
+            contact_ba.threshold_currency = ba.threshold_currency
+            OR (contact_ba.threshold_currency IS NULL AND ba.threshold_currency IS NULL)
+        )
+        AND (
+            contact_ba.threshold_fiat_amount = ba.threshold_fiat_amount
+            OR (contact_ba.threshold_fiat_amount IS NULL AND ba.threshold_fiat_amount IS NULL)
+        )
+  );
+
+DELETE FROM balance_alert_notification_logs
+WHERE balance_alert_id IN (
+    SELECT id FROM active_wallet_level_balance_alert_cleanup_ids
+);
+
+DELETE FROM balance_alert_notifications
+WHERE balance_alert_id IN (
+    SELECT id FROM active_wallet_level_balance_alert_cleanup_ids
+);
+
+DELETE FROM balance_alerts
+WHERE id IN (
+    SELECT id FROM active_wallet_level_balance_alert_cleanup_ids
+);
+
+DROP TABLE active_wallet_level_balance_alert_cleanup_ids;
+
+COMMIT;

--- a/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
+++ b/backend/migrations/033_cleanup_active_wallet_level_balance_alerts.sql
@@ -80,6 +80,12 @@ WHERE ba.contact_id IS NULL
       FROM balance_alerts contact_ba
       WHERE contact_ba.wallet_checksum = ba.wallet_checksum
         AND contact_ba.contact_id IS NOT NULL
+        AND EXISTS (
+            SELECT 1
+            FROM contacts contact
+            WHERE contact.id = contact_ba.contact_id
+              AND contact.is_active = 1
+        )
         AND contact_ba.threshold_sats = ba.threshold_sats
         AND contact_ba.alert_type = ba.alert_type
         AND (

--- a/backend/migrations/034_remove_wallet_level_balance_alerts.sql
+++ b/backend/migrations/034_remove_wallet_level_balance_alerts.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+CREATE TEMP TABLE wallet_level_balance_alert_cleanup_ids (
+    id TEXT PRIMARY KEY
+);
+
+INSERT INTO wallet_level_balance_alert_cleanup_ids (id)
+SELECT id
+FROM balance_alerts
+WHERE contact_id IS NULL;
+
+DELETE FROM balance_alert_notification_logs
+WHERE balance_alert_id IN (
+    SELECT id FROM wallet_level_balance_alert_cleanup_ids
+);
+
+DELETE FROM balance_alert_notifications
+WHERE balance_alert_id IN (
+    SELECT id FROM wallet_level_balance_alert_cleanup_ids
+);
+
+DELETE FROM balance_alerts
+WHERE id IN (
+    SELECT id FROM wallet_level_balance_alert_cleanup_ids
+);
+
+DROP TABLE wallet_level_balance_alert_cleanup_ids;
+
+COMMIT;

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -10,7 +10,8 @@ use crate::handlers::{
     get_wallet_contacts, get_wallet_detail, get_wallet_notifications, get_wallets_list,
     handle_stripe_webhook, login, logout, me, register, reset_password, run_integrity_check,
     send_contact_verification, send_test_ntfy_notification, submit_contact_form, update_user,
-    update_user_preferences, update_wallet, update_wallet_contact, verify_contact, verify_email,
+    update_user_preferences, update_wallet, update_wallet_contact, validate_wallet_balance_alert,
+    verify_contact, verify_email,
 };
 use crate::metadata::{MetadataDb, WalletsListResponse};
 use crate::notifications::NotificationManager;
@@ -382,6 +383,10 @@ pub fn create_router_with_services(
         .route(
             "/wallets/{checksum}/balance-alerts",
             get(get_wallet_balance_alerts).post(create_wallet_balance_alert),
+        )
+        .route(
+            "/wallets/{checksum}/balance-alerts/validate",
+            post(validate_wallet_balance_alert),
         )
         .route(
             "/balance-alerts/{alert_id}",

--- a/backend/src/handlers/balance_alerts.rs
+++ b/backend/src/handlers/balance_alerts.rs
@@ -12,6 +12,12 @@ use axum::{
     response::{IntoResponse, Json, Response},
 };
 
+struct ValidatedBalanceAlert {
+    threshold_sats: i64,
+    threshold_currency: Option<String>,
+    threshold_fiat_amount: Option<f64>,
+}
+
 /// Get all balance alerts for a wallet
 pub async fn get_wallet_balance_alerts(
     AuthenticatedUser(user): AuthenticatedUser,
@@ -49,19 +55,17 @@ pub async fn get_wallet_balance_alerts(
     }
 }
 
-/// Create a new balance alert for a wallet
-pub async fn create_wallet_balance_alert(
+/// Validate a balance alert for a wallet without creating it.
+pub async fn validate_wallet_balance_alert(
     AuthenticatedUser(user): AuthenticatedUser,
     Path(checksum): Path<String>,
     State(app_services): State<AppServicesState>,
     Json(request): Json<CreateBalanceAlertRequest>,
 ) -> Response {
-    // Reject demo users from creating balance alerts
     if let Err(response) = require_non_demo(&user) {
         return response;
     }
 
-    // Check if wallet exists and user has access
     let wallet = match verify_wallet_access(
         &app_services,
         &user,
@@ -74,57 +78,38 @@ pub async fn create_wallet_balance_alert(
         Err(response) => return response,
     };
 
-    if let Some(contact_id) = request.contact_id.as_deref() {
-        match app_services
-            .metadata_db
-            .get_single_contact_with_methods(contact_id, &checksum)
-            .await
-        {
-            Ok(Some(contact)) if contact.is_active => {}
-            Ok(Some(_)) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse::coded(
-                        "contact_inactive",
-                        "Cannot create a balance alert for an inactive contact",
-                    )),
-                )
-                    .into_response();
-            }
-            Ok(None) => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(ErrorResponse::coded(
-                        "contact_not_found",
-                        "Contact not found",
-                    )),
-                )
-                    .into_response();
-            }
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new(format!(
-                        "Failed to verify contact: {}",
-                        e
-                    ))),
-                )
-                    .into_response();
-            }
-        }
+    match validate_balance_alert_request(
+        &app_services,
+        &checksum,
+        wallet.balance_total,
+        &request,
+        false,
+    )
+    .await
+    {
+        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Err(response) => response,
     }
+}
 
+async fn validate_balance_alert_request(
+    app_services: &AppServicesState,
+    checksum: &str,
+    current_balance_sats: Option<i64>,
+    request: &CreateBalanceAlertRequest,
+    check_duplicate: bool,
+) -> Result<ValidatedBalanceAlert, Response> {
     // Validate threshold type: exactly one must be provided (BTC OR fiat, not both or neither)
     let is_btc_threshold = request.threshold_sats.is_some();
     let is_fiat_threshold =
         request.threshold_currency.is_some() && request.threshold_fiat_amount.is_some();
 
     if is_btc_threshold == is_fiat_threshold {
-        return (
+        return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::coded("invalid_threshold_config", "Exactly one threshold type must be provided: either threshold_sats (BTC) OR threshold_currency + threshold_fiat_amount (fiat)")),
         )
-            .into_response();
+            .into_response());
     }
 
     // Determine threshold_sats based on threshold type
@@ -134,49 +119,49 @@ pub async fn create_wallet_balance_alert(
 
         // Validate BTC threshold
         if sats < 0 {
-            return (
+            return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::coded(
                     "negative_btc_threshold",
                     "BTC threshold must be non-negative",
                 )),
             )
-                .into_response();
+                .into_response());
         }
 
         // Validate "below 0" alert (logically impossible)
         if request.alert_type == BalanceAlertType::Below && sats == 0 {
-            return (
+            return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::coded(
                     "below_zero_alert",
                     "Cannot create alert for 'below 0' - balance cannot go below zero",
                 )),
             )
-                .into_response();
+                .into_response());
         }
 
         (sats, None, None)
     } else {
         // Fiat threshold
-        let currency = request.threshold_currency.unwrap();
+        let currency = request.threshold_currency.clone().unwrap();
         let fiat_amount = request.threshold_fiat_amount.unwrap();
 
         // Validate fiat amount
         if fiat_amount <= 0.0 {
-            return (
+            return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::coded(
                     "negative_fiat_threshold",
                     "Fiat threshold amount must be positive",
                 )),
             )
-                .into_response();
+                .into_response());
         }
 
         // Validate currency is supported
         if !exchange_rates::SUPPORTED_CURRENCIES.contains(&currency.as_str()) {
-            return (
+            return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::coded(
                     "unsupported_currency",
@@ -187,35 +172,35 @@ pub async fn create_wallet_balance_alert(
                     ),
                 )),
             )
-                .into_response();
+                .into_response());
         }
 
         // Get current exchange rate
         let exchange_rates_map = match app_services.metadata_db.get_exchange_rates().await {
             Ok(rates) => rates,
             Err(e) => {
-                return (
+                return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ErrorResponse::new(format!(
                         "Failed to fetch exchange rates: {}",
                         e
                     ))),
                 )
-                    .into_response();
+                    .into_response());
             }
         };
 
         let rate = match exchange_rates_map.get(&currency) {
             Some(rate) => rate.rate_per_btc,
             None => {
-                return (
+                return Err((
                     StatusCode::SERVICE_UNAVAILABLE,
                     Json(ErrorResponse::new(format!(
                         "Exchange rate for {} is currently unavailable",
                         currency
                     ))),
                 )
-                    .into_response();
+                    .into_response());
             }
         };
 
@@ -224,7 +209,7 @@ pub async fn create_wallet_balance_alert(
         let threshold_sats = (btc_amount * 100_000_000.0) as i64;
 
         if threshold_sats <= 0 {
-            return (
+            return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::coded(
                     "fiat_amount_too_small",
@@ -234,50 +219,52 @@ pub async fn create_wallet_balance_alert(
                     ),
                 )),
             )
-                .into_response();
+                .into_response());
         }
 
         (threshold_sats, Some(currency), Some(fiat_amount))
     };
 
     // Check for duplicate balance alert
-    match app_services
-        .metadata_db
-        .check_duplicate_balance_alert_for_contact(
-            &checksum,
-            request.contact_id.as_deref(),
-            threshold_sats,
-            request.alert_type,
-        )
-        .await
-    {
-        Ok(Some(_existing_alert)) => {
-            return (
-                StatusCode::CONFLICT,
-                Json(ErrorResponse::coded(
-                    "duplicate_alert",
-                    "An alert with this type and threshold already exists",
-                )),
+    if check_duplicate {
+        match app_services
+            .metadata_db
+            .check_duplicate_balance_alert_for_contact(
+                checksum,
+                request.contact_id.as_deref(),
+                threshold_sats,
+                request.alert_type,
             )
-                .into_response();
-        }
-        Ok(None) => {
-            // No duplicate, continue with creation
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new(format!(
-                    "Failed to check for duplicate alert: {}",
-                    e
-                ))),
-            )
-                .into_response();
+            .await
+        {
+            Ok(Some(_existing_alert)) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse::coded(
+                        "duplicate_alert",
+                        "An alert with this type and threshold already exists",
+                    )),
+                )
+                    .into_response());
+            }
+            Ok(None) => {
+                // No duplicate, continue with creation
+            }
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(format!(
+                        "Failed to check for duplicate alert: {}",
+                        e
+                    ))),
+                )
+                    .into_response());
+            }
         }
     }
 
     // Check if alert would trigger immediately based on current balance
-    if let Some(current_balance_sats) = wallet.balance_total {
+    if let Some(current_balance_sats) = current_balance_sats {
         // Determine if alert would trigger
         let would_trigger = if is_fiat_threshold {
             // For fiat alerts, convert current balance to fiat and compare
@@ -343,16 +330,110 @@ pub async fn create_wallet_balance_alert(
                 )
             };
 
-            return (
+            return Err((
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::coded(
                     "alert_would_trigger_immediately",
                     error_msg,
                 )),
             )
+                .into_response());
+        }
+    }
+
+    Ok(ValidatedBalanceAlert {
+        threshold_sats,
+        threshold_currency,
+        threshold_fiat_amount,
+    })
+}
+
+/// Create a new balance alert for a wallet
+pub async fn create_wallet_balance_alert(
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(checksum): Path<String>,
+    State(app_services): State<AppServicesState>,
+    Json(request): Json<CreateBalanceAlertRequest>,
+) -> Response {
+    // Reject demo users from creating balance alerts
+    if let Err(response) = require_non_demo(&user) {
+        return response;
+    }
+
+    // Check if wallet exists and user has access
+    let wallet = match verify_wallet_access(
+        &app_services,
+        &user,
+        &checksum,
+        DatabaseErrorMessage::Prefix("Database error"),
+    )
+    .await
+    {
+        Ok(wallet) => wallet,
+        Err(response) => return response,
+    };
+
+    let Some(contact_id) = request.contact_id.as_deref() else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::coded(
+                "contact_required",
+                "Balance alerts must belong to a contact",
+            )),
+        )
+            .into_response();
+    };
+
+    match app_services
+        .metadata_db
+        .get_single_contact_with_methods(contact_id, &checksum)
+        .await
+    {
+        Ok(Some(contact)) if contact.is_active => {}
+        Ok(Some(_)) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::coded(
+                    "contact_inactive",
+                    "Cannot create a balance alert for an inactive contact",
+                )),
+            )
+                .into_response();
+        }
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::coded(
+                    "contact_not_found",
+                    "Contact not found",
+                )),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(format!(
+                    "Failed to verify contact: {}",
+                    e
+                ))),
+            )
                 .into_response();
         }
     }
+
+    let validated = match validate_balance_alert_request(
+        &app_services,
+        &checksum,
+        wallet.balance_total,
+        &request,
+        true,
+    )
+    .await
+    {
+        Ok(validated) => validated,
+        Err(response) => return response,
+    };
 
     // Create the balance alert with current balance for threshold crossing detection
     match app_services
@@ -360,10 +441,10 @@ pub async fn create_wallet_balance_alert(
         .create_balance_alert_with_contact(CreateBalanceAlertInput {
             wallet_checksum: &checksum,
             contact_id: request.contact_id.as_deref(),
-            threshold_sats,
+            threshold_sats: validated.threshold_sats,
             alert_type: request.alert_type,
-            threshold_currency,
-            threshold_fiat_amount,
+            threshold_currency: validated.threshold_currency,
+            threshold_fiat_amount: validated.threshold_fiat_amount,
             current_balance_sats: wallet.balance_total,
         })
         .await

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -21,6 +21,7 @@ pub use auth::{
 };
 pub use balance_alerts::{
     create_wallet_balance_alert, delete_balance_alert, get_wallet_balance_alerts,
+    validate_wallet_balance_alert,
 };
 pub use billing::{
     create_stripe_checkout_session, create_stripe_customer_portal, get_billing_pricing,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -349,7 +349,7 @@ async fn main() -> anyhow::Result<()> {
 
                             // Add "Canary" contact with email notification
                             use metadata::ProviderType;
-                            match app_services
+                            let canary_contact_id = match app_services
                                 .metadata_db
                                 .insert_contact_with_notification_methods(
                                     &wallet_metadata.checksum,
@@ -361,22 +361,29 @@ async fn main() -> anyhow::Result<()> {
                                 )
                                 .await
                             {
-                                Ok(_) => println!("✅ Added Canary contact to Bacon wallet"),
-                                Err(e) => println!("❌ Failed to add Canary contact: {}", e),
-                            }
+                                Ok(contact_id) => {
+                                    println!("✅ Added Canary contact to Bacon wallet");
+                                    Some(contact_id)
+                                }
+                                Err(e) => {
+                                    println!("❌ Failed to add Canary contact: {}", e);
+                                    None
+                                }
+                            };
 
                             // Create balance alert: when balance equals 0 BTC
-                            use metadata::BalanceAlertType;
+                            use metadata::{BalanceAlertType, CreateBalanceAlertInput};
                             match app_services
                                 .metadata_db
-                                .create_balance_alert(
-                                    &wallet_metadata.checksum,
-                                    0, // 0 sats
-                                    BalanceAlertType::Equals,
-                                    None, // BTC threshold
-                                    None,
-                                    None, // current balance (demo setup)
-                                )
+                                .create_balance_alert_with_contact(CreateBalanceAlertInput {
+                                    wallet_checksum: &wallet_metadata.checksum,
+                                    contact_id: canary_contact_id.as_deref(),
+                                    threshold_sats: 0, // 0 sats
+                                    alert_type: BalanceAlertType::Equals,
+                                    threshold_currency: None, // BTC threshold
+                                    threshold_fiat_amount: None,
+                                    current_balance_sats: None, // demo setup
+                                })
                                 .await
                             {
                                 Ok(_) => println!("✅ Added 0 BTC balance alert to Bacon wallet"),
@@ -386,14 +393,15 @@ async fn main() -> anyhow::Result<()> {
                             // Create balance alert: when balance is above 0.21 BTC (21,000,000 sats)
                             match app_services
                                 .metadata_db
-                                .create_balance_alert(
-                                    &wallet_metadata.checksum,
-                                    21_000_000, // 0.21 BTC in sats
-                                    BalanceAlertType::Above,
-                                    None, // BTC threshold
-                                    None,
-                                    None, // current balance (demo setup)
-                                )
+                                .create_balance_alert_with_contact(CreateBalanceAlertInput {
+                                    wallet_checksum: &wallet_metadata.checksum,
+                                    contact_id: canary_contact_id.as_deref(),
+                                    threshold_sats: 21_000_000, // 0.21 BTC in sats
+                                    alert_type: BalanceAlertType::Above,
+                                    threshold_currency: None, // BTC threshold
+                                    threshold_fiat_amount: None,
+                                    current_balance_sats: None, // demo setup
+                                })
                                 .await
                             {
                                 Ok(_) => {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -371,45 +371,55 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             };
 
-                            // Create balance alert: when balance equals 0 BTC
-                            use metadata::{BalanceAlertType, CreateBalanceAlertInput};
-                            match app_services
-                                .metadata_db
-                                .create_balance_alert_with_contact(CreateBalanceAlertInput {
-                                    wallet_checksum: &wallet_metadata.checksum,
-                                    contact_id: canary_contact_id.as_deref(),
-                                    threshold_sats: 0, // 0 sats
-                                    alert_type: BalanceAlertType::Equals,
-                                    threshold_currency: None, // BTC threshold
-                                    threshold_fiat_amount: None,
-                                    current_balance_sats: None, // demo setup
-                                })
-                                .await
-                            {
-                                Ok(_) => println!("✅ Added 0 BTC balance alert to Bacon wallet"),
-                                Err(e) => println!("❌ Failed to add 0 BTC balance alert: {}", e),
-                            }
+                            if let Some(canary_contact_id) = canary_contact_id.as_deref() {
+                                // Create balance alert: when balance equals 0 BTC
+                                use metadata::{BalanceAlertType, CreateBalanceAlertInput};
+                                match app_services
+                                    .metadata_db
+                                    .create_balance_alert_with_contact(CreateBalanceAlertInput {
+                                        wallet_checksum: &wallet_metadata.checksum,
+                                        contact_id: Some(canary_contact_id),
+                                        threshold_sats: 0, // 0 sats
+                                        alert_type: BalanceAlertType::Equals,
+                                        threshold_currency: None, // BTC threshold
+                                        threshold_fiat_amount: None,
+                                        current_balance_sats: None, // demo setup
+                                    })
+                                    .await
+                                {
+                                    Ok(_) => {
+                                        println!("✅ Added 0 BTC balance alert to Bacon wallet")
+                                    }
+                                    Err(e) => {
+                                        println!("❌ Failed to add 0 BTC balance alert: {}", e)
+                                    }
+                                }
 
-                            // Create balance alert: when balance is above 0.21 BTC (21,000,000 sats)
-                            match app_services
-                                .metadata_db
-                                .create_balance_alert_with_contact(CreateBalanceAlertInput {
-                                    wallet_checksum: &wallet_metadata.checksum,
-                                    contact_id: canary_contact_id.as_deref(),
-                                    threshold_sats: 21_000_000, // 0.21 BTC in sats
-                                    alert_type: BalanceAlertType::Above,
-                                    threshold_currency: None, // BTC threshold
-                                    threshold_fiat_amount: None,
-                                    current_balance_sats: None, // demo setup
-                                })
-                                .await
-                            {
-                                Ok(_) => {
-                                    println!("✅ Added >0.21 BTC balance alert to Bacon wallet")
+                                // Create balance alert: when balance is above 0.21 BTC (21,000,000 sats)
+                                match app_services
+                                    .metadata_db
+                                    .create_balance_alert_with_contact(CreateBalanceAlertInput {
+                                        wallet_checksum: &wallet_metadata.checksum,
+                                        contact_id: Some(canary_contact_id),
+                                        threshold_sats: 21_000_000, // 0.21 BTC in sats
+                                        alert_type: BalanceAlertType::Above,
+                                        threshold_currency: None, // BTC threshold
+                                        threshold_fiat_amount: None,
+                                        current_balance_sats: None, // demo setup
+                                    })
+                                    .await
+                                {
+                                    Ok(_) => {
+                                        println!("✅ Added >0.21 BTC balance alert to Bacon wallet")
+                                    }
+                                    Err(e) => {
+                                        println!("❌ Failed to add >0.21 BTC balance alert: {}", e)
+                                    }
                                 }
-                                Err(e) => {
-                                    println!("❌ Failed to add >0.21 BTC balance alert: {}", e)
-                                }
+                            } else {
+                                println!(
+                                    "⚠️ Skipping Bacon wallet balance alerts because Canary contact was not created"
+                                );
                             }
                         }
                         Err(e) => println!("❌ Failed to create Bacon wallet: {}", e),

--- a/backend/src/metadata/pool.rs
+++ b/backend/src/metadata/pool.rs
@@ -14,7 +14,6 @@ impl CustomizeConnection<Connection, bdk_wallet::rusqlite::Error> for SqliteConn
     fn on_acquire(&self, conn: &mut Connection) -> Result<(), bdk_wallet::rusqlite::Error> {
         conn.execute_batch(
             "PRAGMA foreign_keys = ON;
-             PRAGMA journal_mode = WAL;
              PRAGMA synchronous = NORMAL;
              PRAGMA busy_timeout = 5000;",
         )
@@ -59,8 +58,13 @@ impl MetadataDb {
             );
         }
 
-        // Get the connection back from the migration runner and close it
         let conn = migration_runner.get_connection();
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA busy_timeout = 5000;",
+        )
+        .context("Failed to initialize SQLite journal mode")?;
         drop(conn);
 
         // Create connection pool with foreign key enforcement

--- a/backend/src/metadata/pool.rs
+++ b/backend/src/metadata/pool.rs
@@ -59,12 +59,8 @@ impl MetadataDb {
         }
 
         let conn = migration_runner.get_connection();
-        conn.execute_batch(
-            "PRAGMA journal_mode = WAL;
-             PRAGMA synchronous = NORMAL;
-             PRAGMA busy_timeout = 5000;",
-        )
-        .context("Failed to initialize SQLite journal mode")?;
+        conn.execute_batch("PRAGMA journal_mode = WAL;")
+            .context("Failed to initialize SQLite journal mode")?;
         drop(conn);
 
         // Create connection pool with foreign key enforcement

--- a/backend/src/metadata/wallet.rs
+++ b/backend/src/metadata/wallet.rs
@@ -459,7 +459,13 @@ impl MetadataDb {
                  FROM wallets w
                  JOIN users u ON w.user_id = u.id
                  -- Failed wallets are terminal until users delete and recreate them.
-                 WHERE w.is_active = 1 AND w.status IN ('ready', 'pending')
+                 -- Descriptor wallets are synced by their creation task while pending; only
+                 -- address watches can safely enter tier sync before they are ready.
+                 WHERE w.is_active = 1
+                   AND (
+                    w.status = 'ready'
+                    OR (w.status = 'pending' AND w.wallet_type = 'address')
+                 )
                    AND u.subscription_tier = ?1
                    AND (
                     -- Admin users bypass all subscription checks

--- a/backend/src/models/requests.rs
+++ b/backend/src/models/requests.rs
@@ -113,7 +113,7 @@ pub struct VerifyContactRequest {
 
 #[derive(Deserialize, Serialize)]
 pub struct CreateBalanceAlertRequest {
-    /// Contact this threshold belongs to. Omitted for legacy wallet-level alerts.
+    /// Contact this threshold belongs to. Required when creating an alert.
     pub contact_id: Option<String>,
     /// Balance threshold in satoshis (Option 1: BTC threshold)
     pub threshold_sats: Option<i64>,

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -1791,9 +1791,15 @@ async fn test_get_wallets_for_tier_sync_uses_transaction_last_activity() {
         .insert_wallet("Empty Sync Wallet", "descriptor_sync_empty", "foss-user")
         .await
         .unwrap();
+    db.update_wallet_status(&empty_wallet_checksum, "ready")
+        .await
+        .unwrap();
 
     let wallet_checksum = db
         .insert_wallet("Sync Wallet", "descriptor_sync", "foss-user")
+        .await
+        .unwrap();
+    db.update_wallet_status(&wallet_checksum, "ready")
         .await
         .unwrap();
 
@@ -1841,6 +1847,66 @@ async fn test_get_wallets_for_tier_sync_uses_transaction_last_activity() {
         wallet.last_activity.as_deref(),
         Some("1740000123"),
         "sync query should derive last_activity from transactions instead of the stale wallets column"
+    );
+}
+
+#[tokio::test]
+async fn test_get_wallets_for_tier_sync_excludes_pending_descriptor_wallets() {
+    let (db, _temp_dir) = create_test_db().await;
+
+    let pending_descriptor_checksum = db
+        .insert_wallet(
+            "Pending Descriptor",
+            "descriptor_pending_tier_sync",
+            "foss-user",
+        )
+        .await
+        .unwrap();
+    let ready_descriptor_checksum = db
+        .insert_wallet(
+            "Ready Descriptor",
+            "descriptor_ready_tier_sync",
+            "foss-user",
+        )
+        .await
+        .unwrap();
+    let pending_address_checksum = db
+        .insert_wallet_with_type(
+            "Pending Address",
+            "addr(bcrt1qpendingaddresssync)",
+            "foss-user",
+            "address",
+        )
+        .await
+        .unwrap();
+
+    db.update_wallet_status(&ready_descriptor_checksum, "ready")
+        .await
+        .unwrap();
+
+    let wallets = db
+        .get_wallets_for_tier_sync(
+            &crate::subscription::SubscriptionTier::Team,
+            &NetworkConfig::Regtest,
+        )
+        .await
+        .unwrap();
+    let checksums = wallets
+        .iter()
+        .map(|wallet| wallet.checksum.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        !checksums.contains(&pending_descriptor_checksum.as_str()),
+        "pending descriptor wallets should wait for the creation task"
+    );
+    assert!(
+        checksums.contains(&ready_descriptor_checksum.as_str()),
+        "ready descriptor wallets should sync normally"
+    );
+    assert!(
+        checksums.contains(&pending_address_checksum.as_str()),
+        "pending address watches should remain eligible for initial sync"
     );
 }
 

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -458,3 +458,153 @@ fn migration_031_handles_clean_first_run_and_wallets_without_contacts() {
     let conn = bdk_wallet::rusqlite::Connection::open(&db_path).expect("open db");
     assert_migration_031_032_state(&conn);
 }
+
+#[test]
+fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let migrations_dir = temp_dir.path().join("migrations");
+    fs::create_dir(&migrations_dir).expect("create migrations dir");
+    let db_path = temp_dir.path().join("metadata.sqlite");
+
+    copy_migrations_through(&migrations_dir, 32);
+    MigrationRunner::new(db_path.to_str().expect("db path"))
+        .expect("create migration runner")
+        .run_migrations(migrations_dir.to_str().expect("migrations path"))
+        .expect("run migrations through 032");
+
+    let conn = Connection::open(&db_path).expect("open db");
+    conn.execute(
+        "INSERT INTO users (id, email, password_hash, name) VALUES (?1, ?2, ?3, ?4)",
+        params!["user-1", "user@example.com", "hash", "User"],
+    )
+    .expect("insert user");
+    conn.execute(
+        "INSERT INTO wallets (checksum, name, descriptor, hex_color, status, user_id, wallet_type)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            "wallet-1",
+            "Wallet",
+            "addr(bc1qexample000000000000000000000000000000000)",
+            "#000000",
+            "ready",
+            "user-1",
+            "address"
+        ],
+    )
+    .expect("insert wallet");
+    conn.execute(
+        "INSERT INTO wallets (checksum, name, descriptor, hex_color, status, user_id, wallet_type)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            "wallet-no-contacts",
+            "Wallet Without Contacts",
+            "addr(bc1qexample111111111111111111111111111111111)",
+            "#111111",
+            "ready",
+            "user-1",
+            "address"
+        ],
+    )
+    .expect("insert wallet without contacts");
+    conn.execute(
+        "INSERT INTO contacts (id, wallet_checksum, name, is_active)
+         VALUES (?1, ?2, ?3, ?4)",
+        params!["contact-1", "wallet-1", "Contact", 1],
+    )
+    .expect("insert contact");
+    conn.execute(
+        "INSERT INTO balance_alerts (
+            id,
+            wallet_checksum,
+            threshold_sats,
+            alert_type,
+            is_active,
+            created_at,
+            last_checked_balance_sats
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            "post-032-wallet-alert",
+            "wallet-1",
+            21_000_000,
+            "above",
+            1,
+            "2026-06-11T06:41:33.907501+00:00",
+            16_999_436
+        ],
+    )
+    .expect("insert post-032 wallet-level alert");
+    conn.execute(
+        "INSERT INTO balance_alerts (
+            id,
+            wallet_checksum,
+            threshold_sats,
+            alert_type,
+            is_active,
+            created_at,
+            last_checked_balance_sats
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            "post-032-no-contact-alert",
+            "wallet-no-contacts",
+            0,
+            "equals",
+            1,
+            "2026-06-11T06:41:33.907104+00:00",
+            16_999_436
+        ],
+    )
+    .expect("insert no-contact wallet-level alert");
+    drop(conn);
+
+    copy_migrations_through(&migrations_dir, 33);
+    MigrationRunner::new(db_path.to_str().expect("db path"))
+        .expect("create migration runner")
+        .run_migrations(migrations_dir.to_str().expect("migrations path"))
+        .expect("run migrations through 033");
+
+    let conn = Connection::open(&db_path).expect("open db");
+    let latest_version: String = conn
+        .query_row("SELECT MAX(version) FROM schema_migrations", [], |row| {
+            row.get(0)
+        })
+        .expect("latest migration version");
+    assert_eq!(latest_version, "033");
+
+    let original_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts WHERE id = 'post-032-wallet-alert'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("original alert count");
+    assert_eq!(original_alert_count, 0);
+
+    let contact_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts
+             WHERE wallet_checksum = 'wallet-1'
+               AND contact_id = 'contact-1'
+               AND threshold_sats = 21000000
+               AND alert_type = 'above'
+               AND is_active = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("contact alert count");
+    assert_eq!(contact_alert_count, 1);
+
+    let no_contact_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts
+             WHERE id = 'post-032-no-contact-alert'
+               AND wallet_checksum = 'wallet-no-contacts'
+               AND contact_id IS NULL
+               AND is_active = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("no-contact alert count");
+    assert_eq!(no_contact_alert_count, 1);
+}

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -620,6 +620,48 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
          )
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
+            "post-032-wallet-alert-with-log-history",
+            "wallet-1",
+            84_000_000,
+            "above",
+            1,
+            "2026-06-11T07:02:00.000000+00:00",
+            85_000_000
+        ],
+    )
+    .expect("insert post-032 wallet-level alert with log history");
+    conn.execute(
+        "INSERT INTO balance_alert_notification_logs (
+            id,
+            balance_alert_id,
+            wallet_checksum,
+            provider_name,
+            status,
+            message_content
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            "history-log-1",
+            "post-032-wallet-alert-with-log-history",
+            "wallet-1",
+            "email",
+            "sent",
+            "Balance alert sent"
+        ],
+    )
+    .expect("insert balance alert notification log history");
+    conn.execute(
+        "INSERT INTO balance_alerts (
+            id,
+            wallet_checksum,
+            threshold_sats,
+            alert_type,
+            is_active,
+            created_at,
+            last_checked_balance_sats
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
             "post-032-no-contact-alert",
             "wallet-no-contacts",
             0,
@@ -718,6 +760,41 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
         )
         .expect("preserved notification count");
     assert_eq!(preserved_notification_count, 1);
+
+    let log_history_original_is_active: i64 = conn
+        .query_row(
+            "SELECT is_active FROM balance_alerts
+             WHERE id = 'post-032-wallet-alert-with-log-history'
+               AND contact_id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("log history original active state");
+    assert_eq!(log_history_original_is_active, 0);
+
+    let log_history_contact_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts
+             WHERE wallet_checksum = 'wallet-1'
+               AND contact_id IN ('contact-1', 'contact-2')
+               AND threshold_sats = 84000000
+               AND alert_type = 'above'
+               AND is_active = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("log history contact alert count");
+    assert_eq!(log_history_contact_alert_count, 2);
+
+    let preserved_log_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alert_notification_logs
+             WHERE balance_alert_id = 'post-032-wallet-alert-with-log-history'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("preserved log count");
+    assert_eq!(preserved_log_count, 1);
 
     let no_contact_alert_count: i64 = conn
         .query_row(

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -878,4 +878,63 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
         )
         .expect("no-contact alert count");
     assert_eq!(no_contact_alert_count, 1);
+    drop(conn);
+
+    copy_migrations_through(&migrations_dir, 34);
+    MigrationRunner::new(db_path.to_str().expect("db path"))
+        .expect("create migration runner")
+        .run_migrations(migrations_dir.to_str().expect("migrations path"))
+        .expect("run migrations through 034");
+
+    let conn = Connection::open(&db_path).expect("open db");
+    let latest_version: String = conn
+        .query_row("SELECT MAX(version) FROM schema_migrations", [], |row| {
+            row.get(0)
+        })
+        .expect("latest migration version");
+    assert_eq!(latest_version, "034");
+
+    let remaining_wallet_level_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts WHERE contact_id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("remaining wallet-level alert count");
+    assert_eq!(remaining_wallet_level_alert_count, 0);
+
+    let remaining_wallet_level_notification_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alert_notifications
+             WHERE balance_alert_id IN (
+                 'post-032-wallet-alert-with-history',
+                 'post-032-wallet-alert-with-log-history'
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .expect("remaining wallet-level notification count");
+    assert_eq!(remaining_wallet_level_notification_count, 0);
+
+    let remaining_wallet_level_log_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alert_notification_logs
+             WHERE balance_alert_id IN (
+                 'post-032-wallet-alert-with-history',
+                 'post-032-wallet-alert-with-log-history'
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .expect("remaining wallet-level log count");
+    assert_eq!(remaining_wallet_level_log_count, 0);
+
+    let remaining_contact_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts WHERE contact_id IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("remaining contact alert count");
+    assert_eq!(remaining_contact_alert_count, 7);
 }

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -576,6 +576,50 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
          )
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
+            "post-032-wallet-alert-with-history",
+            "wallet-1",
+            42_000_000,
+            "below",
+            1,
+            "2026-06-11T07:01:00.000000+00:00",
+            50_000_000
+        ],
+    )
+    .expect("insert post-032 wallet-level alert with history");
+    conn.execute(
+        "INSERT INTO balance_alert_notifications (
+            id,
+            balance_alert_id,
+            wallet_checksum,
+            threshold_sats,
+            current_balance_sats,
+            alert_type,
+            notification_sent_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            "history-notification-1",
+            "post-032-wallet-alert-with-history",
+            "wallet-1",
+            42_000_000,
+            41_000_000,
+            "below",
+            1_782_000_000_i64
+        ],
+    )
+    .expect("insert balance alert notification history");
+    conn.execute(
+        "INSERT INTO balance_alerts (
+            id,
+            wallet_checksum,
+            threshold_sats,
+            alert_type,
+            is_active,
+            created_at,
+            last_checked_balance_sats
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
             "post-032-no-contact-alert",
             "wallet-no-contacts",
             0,
@@ -639,6 +683,41 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
         )
         .expect("existing contact alert count");
     assert_eq!(existing_contact_alert_count, 1);
+
+    let historical_original_is_active: i64 = conn
+        .query_row(
+            "SELECT is_active FROM balance_alerts
+             WHERE id = 'post-032-wallet-alert-with-history'
+               AND contact_id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("historical original active state");
+    assert_eq!(historical_original_is_active, 0);
+
+    let historical_contact_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts
+             WHERE wallet_checksum = 'wallet-1'
+               AND contact_id IN ('contact-1', 'contact-2')
+               AND threshold_sats = 42000000
+               AND alert_type = 'below'
+               AND is_active = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("historical contact alert count");
+    assert_eq!(historical_contact_alert_count, 2);
+
+    let preserved_notification_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alert_notifications
+             WHERE balance_alert_id = 'post-032-wallet-alert-with-history'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("preserved notification count");
+    assert_eq!(preserved_notification_count, 1);
 
     let no_contact_alert_count: i64 = conn
         .query_row(

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -513,6 +513,12 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
     )
     .expect("insert contact");
     conn.execute(
+        "INSERT INTO contacts (id, wallet_checksum, name, is_active)
+         VALUES (?1, ?2, ?3, ?4)",
+        params!["contact-2", "wallet-1", "Second Contact", 1],
+    )
+    .expect("insert second contact");
+    conn.execute(
         "INSERT INTO balance_alerts (
             id,
             wallet_checksum,
@@ -534,6 +540,30 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
         ],
     )
     .expect("insert post-032 wallet-level alert");
+    conn.execute(
+        "INSERT INTO balance_alerts (
+            id,
+            wallet_checksum,
+            threshold_sats,
+            alert_type,
+            is_active,
+            created_at,
+            last_checked_balance_sats,
+            contact_id
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            "manually-recreated-contact-alert",
+            "wallet-1",
+            21_000_000,
+            "above",
+            1,
+            "2026-06-11T07:00:00.000000+00:00",
+            16_999_436,
+            "contact-2"
+        ],
+    )
+    .expect("insert manually recreated contact-level alert");
     conn.execute(
         "INSERT INTO balance_alerts (
             id,
@@ -585,7 +615,7 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
         .query_row(
             "SELECT COUNT(*) FROM balance_alerts
              WHERE wallet_checksum = 'wallet-1'
-               AND contact_id = 'contact-1'
+               AND contact_id IN ('contact-1', 'contact-2')
                AND threshold_sats = 21000000
                AND alert_type = 'above'
                AND is_active = 1",
@@ -593,7 +623,22 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
             |row| row.get(0),
         )
         .expect("contact alert count");
-    assert_eq!(contact_alert_count, 1);
+    assert_eq!(contact_alert_count, 2);
+
+    let existing_contact_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts
+             WHERE id = 'manually-recreated-contact-alert'
+               AND wallet_checksum = 'wallet-1'
+               AND contact_id = 'contact-2'
+               AND threshold_sats = 21000000
+               AND alert_type = 'above'
+               AND is_active = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("existing contact alert count");
+    assert_eq!(existing_contact_alert_count, 1);
 
     let no_contact_alert_count: i64 = conn
         .query_row(

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -519,6 +519,17 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
     )
     .expect("insert second contact");
     conn.execute(
+        "INSERT INTO contacts (id, wallet_checksum, name, is_active)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            "inactive-contact-1",
+            "wallet-no-contacts",
+            "Inactive Contact",
+            0
+        ],
+    )
+    .expect("insert inactive contact");
+    conn.execute(
         "INSERT INTO balance_alerts (
             id,
             wallet_checksum,
@@ -650,6 +661,52 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
         ],
     )
     .expect("insert balance alert notification log history");
+    conn.execute(
+        "INSERT INTO balance_alerts (
+            id,
+            wallet_checksum,
+            threshold_sats,
+            alert_type,
+            is_active,
+            created_at,
+            last_checked_balance_sats
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            "wallet-alert-with-inactive-contact-match",
+            "wallet-no-contacts",
+            1_234_567,
+            "equals",
+            1,
+            "2026-06-11T07:03:00.000000+00:00",
+            1_234_567
+        ],
+    )
+    .expect("insert wallet alert with inactive contact match");
+    conn.execute(
+        "INSERT INTO balance_alerts (
+            id,
+            wallet_checksum,
+            threshold_sats,
+            alert_type,
+            is_active,
+            created_at,
+            last_checked_balance_sats,
+            contact_id
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            "inactive-contact-matching-alert",
+            "wallet-no-contacts",
+            1_234_567,
+            "equals",
+            1,
+            "2026-06-11T07:03:30.000000+00:00",
+            1_234_567,
+            "inactive-contact-1"
+        ],
+    )
+    .expect("insert inactive contact matching alert");
     conn.execute(
         "INSERT INTO balance_alerts (
             id,
@@ -795,6 +852,19 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
         )
         .expect("preserved log count");
     assert_eq!(preserved_log_count, 1);
+
+    let inactive_contact_wallet_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts
+             WHERE id = 'wallet-alert-with-inactive-contact-match'
+               AND wallet_checksum = 'wallet-no-contacts'
+               AND contact_id IS NULL
+               AND is_active = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("inactive contact wallet alert count");
+    assert_eq!(inactive_contact_wallet_alert_count, 1);
 
     let no_contact_alert_count: i64 = conn
         .query_row(

--- a/backend/tests/wallet_handlers_tests.rs
+++ b/backend/tests/wallet_handlers_tests.rs
@@ -274,6 +274,129 @@ async fn test_create_wallet_duplicate_descriptor() {
 }
 
 #[tokio::test]
+async fn test_validate_balance_alert_success_does_not_create_alert() {
+    let (app, _temp_dir, app_services) = create_test_app_with_services().await;
+    let wallet_checksum = app_services
+        .metadata_db
+        .insert_wallet("Alert Wallet", "descriptor-alert-success", "foss-user")
+        .await
+        .unwrap();
+    app_services
+        .metadata_db
+        .update_wallet_balance_by_checksum(&wallet_checksum, 50_000_000)
+        .await
+        .unwrap();
+
+    let request = Request::builder()
+        .uri(format!(
+            "/api/wallets/{wallet_checksum}/balance-alerts/validate"
+        ))
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "threshold_sats": 10_000_000,
+                "alert_type": "below"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.oneshot(authorized_request(request)).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let alerts = app_services
+        .metadata_db
+        .get_all_balance_alerts_for_wallet(&wallet_checksum)
+        .await
+        .unwrap();
+    assert!(alerts.is_empty(), "Validation must not create an alert");
+}
+
+#[tokio::test]
+async fn test_validate_balance_alert_rejects_immediate_trigger() {
+    let (app, _temp_dir, app_services) = create_test_app_with_services().await;
+    let wallet_checksum = app_services
+        .metadata_db
+        .insert_wallet("Alert Wallet", "descriptor-alert-immediate", "foss-user")
+        .await
+        .unwrap();
+    app_services
+        .metadata_db
+        .update_wallet_balance_by_checksum(&wallet_checksum, 50_000_000)
+        .await
+        .unwrap();
+
+    let request = Request::builder()
+        .uri(format!(
+            "/api/wallets/{wallet_checksum}/balance-alerts/validate"
+        ))
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "threshold_sats": 100_000_000,
+                "alert_type": "below"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.oneshot(authorized_request(request)).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(response.into_body()).await;
+    assert_eq!(body["error_code"], "alert_would_trigger_immediately");
+    let alerts = app_services
+        .metadata_db
+        .get_all_balance_alerts_for_wallet(&wallet_checksum)
+        .await
+        .unwrap();
+    assert!(
+        alerts.is_empty(),
+        "Rejected validation must not create an alert"
+    );
+}
+
+#[tokio::test]
+async fn test_create_balance_alert_rejects_missing_contact_id() {
+    let (app, _temp_dir, app_services) = create_test_app_with_services().await;
+    let wallet_checksum = app_services
+        .metadata_db
+        .insert_wallet("Alert Wallet", "descriptor-alert-no-contact", "foss-user")
+        .await
+        .unwrap();
+
+    let request = Request::builder()
+        .uri(format!("/api/wallets/{wallet_checksum}/balance-alerts"))
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "threshold_sats": 10_000_000,
+                "alert_type": "below"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.oneshot(authorized_request(request)).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = body_to_json(response.into_body()).await;
+    assert_eq!(body["error_code"], "contact_required");
+    let alerts = app_services
+        .metadata_db
+        .get_all_balance_alerts_for_wallet(&wallet_checksum)
+        .await
+        .unwrap();
+    assert!(
+        alerts.is_empty(),
+        "Missing contact_id must not create an alert"
+    );
+}
+
+#[tokio::test]
 async fn test_create_wallet_network_mismatch() {
     let (app, _temp_dir) = create_test_app().await;
 

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -1198,5 +1198,70 @@
       },
       "closeTab": "Du kan lukke denne fane for at vende tilbage til Canary."
     }
+  },
+  "walletNotifications": {
+    "title": "Notifications",
+    "description": "Choose who gets notified, how, and for which wallet events.",
+    "addContact": "Add contact",
+    "delivery": {
+      "noMethods": "No delivery methods",
+      "notSet": "not set",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaction notifications",
+      "includeBalance": "Include wallet balance in transaction notifications",
+      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
+      "selectTypeFirst": "Select at least one transaction notification type first."
+    },
+    "saveState": {
+      "saved": "Saved",
+      "error": "Could not save",
+      "savedOnChange": "Saved on change"
+    },
+    "eventGroups": {
+      "activity": "Activity",
+      "firstConfirmation": "First confirmation",
+      "replacements": "Replacements / fee bumps"
+    },
+    "events": {
+      "sending": {
+        "label": "Sending",
+        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+      },
+      "receiving": {
+        "label": "Receiving",
+        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+      },
+      "sent": {
+        "label": "Sent",
+        "description": "An outgoing transaction receives its first confirmation."
+      },
+      "received": {
+        "label": "Received",
+        "description": "An incoming transaction receives its first confirmation."
+      },
+      "rbf": {
+        "label": "RBF replacement",
+        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+      },
+      "cpfp": {
+        "label": "CPFP fee bump",
+        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+      }
+    },
+    "balance": {
+      "title": "Balance threshold notifications"
+    },
+    "thresholdTypes": {
+      "above": "Above",
+      "equals": "Equal",
+      "below": "Below"
+    },
+    "alertTypes": {
+      "above": "above",
+      "equals": "equals",
+      "below": "below"
+    }
   }
 }

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "Kontaktnavn er påkrævet",
-      "ntfyTopicRequired": "ntfy-emne er påkrævet"
+      "ntfyTopicRequired": "ntfy-emne er påkrævet",
+      "phoneRequired": "Telefonnummer er påkrævet",
+      "emailRequired": "E-mailadresse er påkrævet"
     },
     "wizard": {
       "nameStep": "Kontaktnavn",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -1200,72 +1200,72 @@
     }
   },
   "walletNotifications": {
-    "title": "Notifications",
-    "description": "Choose who gets notified, how, and for which wallet events.",
-    "addContact": "Add contact",
+    "title": "Notifikationer",
+    "description": "Vælg hvem der får besked, hvordan og for hvilke wallet-hændelser.",
+    "addContact": "Tilføj kontakt",
     "contactActions": {
-      "edit": "Edit contact",
-      "delete": "Delete contact"
+      "edit": "Rediger kontakt",
+      "delete": "Slet kontakt"
     },
     "delivery": {
-      "noMethods": "No delivery methods",
-      "notSet": "not set",
+      "noMethods": "Ingen leveringsmetoder",
+      "notSet": "ikke angivet",
       "summary": "{provider}: {target}"
     },
     "transaction": {
-      "title": "Transaction notifications",
-      "includeBalance": "Include wallet balance in transaction notifications",
-      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
-      "selectTypeFirst": "Select at least one transaction notification type first."
+      "title": "Transaktionsnotifikationer",
+      "includeBalance": "Inkluder wallet-saldo i transaktionsnotifikationer",
+      "includeBalanceDescription": "Gælder alle valgte transaktionsnotifikationstyper nedenfor.",
+      "selectTypeFirst": "Vælg mindst én type transaktionsnotifikation først."
     },
     "saveState": {
-      "saved": "Saved",
-      "error": "Could not save",
-      "savedOnChange": "Saved on change"
+      "saved": "Gemt",
+      "error": "Kunne ikke gemme",
+      "savedOnChange": "Gemmes ved ændring"
     },
     "eventGroups": {
-      "activity": "Activity",
-      "firstConfirmation": "First confirmation",
-      "replacements": "Replacements / fee bumps"
+      "activity": "Aktivitet",
+      "firstConfirmation": "Første bekræftelse",
+      "replacements": "Erstatninger / gebyrforhøjelser"
     },
     "events": {
       "sending": {
-        "label": "Sending",
-        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+        "label": "Sender",
+        "description": "En udgående transaktion ses i mempoolen og er stadig ubekræftet."
       },
       "receiving": {
-        "label": "Receiving",
-        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+        "label": "Modtager",
+        "description": "En indgående transaktion ses i mempoolen og er stadig ubekræftet."
       },
       "sent": {
-        "label": "Sent",
-        "description": "An outgoing transaction receives its first confirmation."
+        "label": "Sendt",
+        "description": "En udgående transaktion får sin første bekræftelse."
       },
       "received": {
-        "label": "Received",
-        "description": "An incoming transaction receives its first confirmation."
+        "label": "Modtaget",
+        "description": "En indgående transaktion får sin første bekræftelse."
       },
       "rbf": {
-        "label": "RBF replacement",
-        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+        "label": "RBF-erstatning",
+        "description": "Replace-By-Fee: en ubekræftet transaktion erstattes af en nyere version."
       },
       "cpfp": {
-        "label": "CPFP fee bump",
-        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+        "label": "CPFP-gebyrforhøjelse",
+        "description": "Child Pays For Parent: en barnetransaktion bruges til at hjælpe med at bekræfte sin forælder."
       }
     },
     "balance": {
-      "title": "Balance threshold notifications"
+      "title": "Saldotærskelnotifikationer"
     },
     "thresholdTypes": {
-      "above": "Above",
-      "equals": "Equal",
-      "below": "Below"
+      "above": "Over",
+      "equals": "Lig med",
+      "below": "Under"
     },
     "alertTypes": {
-      "above": "above",
-      "equals": "equals",
-      "below": "below"
+      "above": "over",
+      "equals": "lig med",
+      "below": "under"
     }
   }
 }

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -1203,6 +1203,10 @@
     "title": "Notifications",
     "description": "Choose who gets notified, how, and for which wallet events.",
     "addContact": "Add contact",
+    "contactActions": {
+      "edit": "Edit contact",
+      "delete": "Delete contact"
+    },
     "delivery": {
       "noMethods": "No delivery methods",
       "notSet": "not set",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -1200,72 +1200,72 @@
     }
   },
   "walletNotifications": {
-    "title": "Notifications",
-    "description": "Choose who gets notified, how, and for which wallet events.",
-    "addContact": "Add contact",
+    "title": "Benachrichtigungen",
+    "description": "Wählen Sie, wer wie und bei welchen Wallet-Ereignissen benachrichtigt wird.",
+    "addContact": "Kontakt hinzufügen",
     "contactActions": {
-      "edit": "Edit contact",
-      "delete": "Delete contact"
+      "edit": "Kontakt bearbeiten",
+      "delete": "Kontakt löschen"
     },
     "delivery": {
-      "noMethods": "No delivery methods",
-      "notSet": "not set",
+      "noMethods": "Keine Zustellmethoden",
+      "notSet": "nicht festgelegt",
       "summary": "{provider}: {target}"
     },
     "transaction": {
-      "title": "Transaction notifications",
-      "includeBalance": "Include wallet balance in transaction notifications",
-      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
-      "selectTypeFirst": "Select at least one transaction notification type first."
+      "title": "Transaktionsbenachrichtigungen",
+      "includeBalance": "Wallet-Saldo in Transaktionsbenachrichtigungen einschließen",
+      "includeBalanceDescription": "Gilt für alle unten ausgewählten Transaktionsbenachrichtigungstypen.",
+      "selectTypeFirst": "Wählen Sie zuerst mindestens einen Transaktionsbenachrichtigungstyp aus."
     },
     "saveState": {
-      "saved": "Saved",
-      "error": "Could not save",
-      "savedOnChange": "Saved on change"
+      "saved": "Gespeichert",
+      "error": "Konnte nicht gespeichert werden",
+      "savedOnChange": "Wird bei Änderung gespeichert"
     },
     "eventGroups": {
-      "activity": "Activity",
-      "firstConfirmation": "First confirmation",
-      "replacements": "Replacements / fee bumps"
+      "activity": "Aktivität",
+      "firstConfirmation": "Erste Bestätigung",
+      "replacements": "Ersetzungen / Gebührenerhöhungen"
     },
     "events": {
       "sending": {
-        "label": "Sending",
-        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+        "label": "Senden",
+        "description": "Eine ausgehende Transaktion ist im Mempool sichtbar und noch unbestätigt."
       },
       "receiving": {
-        "label": "Receiving",
-        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+        "label": "Empfangen",
+        "description": "Eine eingehende Transaktion ist im Mempool sichtbar und noch unbestätigt."
       },
       "sent": {
-        "label": "Sent",
-        "description": "An outgoing transaction receives its first confirmation."
+        "label": "Gesendet",
+        "description": "Eine ausgehende Transaktion erhält ihre erste Bestätigung."
       },
       "received": {
-        "label": "Received",
-        "description": "An incoming transaction receives its first confirmation."
+        "label": "Empfangen",
+        "description": "Eine eingehende Transaktion erhält ihre erste Bestätigung."
       },
       "rbf": {
-        "label": "RBF replacement",
-        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+        "label": "RBF-Ersetzung",
+        "description": "Replace-By-Fee: Eine unbestätigte Transaktion wird durch eine neuere Version ersetzt."
       },
       "cpfp": {
-        "label": "CPFP fee bump",
-        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+        "label": "CPFP-Gebührenerhöhung",
+        "description": "Child Pays For Parent: Eine Child-Transaktion hilft dabei, ihre Parent-Transaktion zu bestätigen."
       }
     },
     "balance": {
-      "title": "Balance threshold notifications"
+      "title": "Saldoschwellen-Benachrichtigungen"
     },
     "thresholdTypes": {
-      "above": "Above",
-      "equals": "Equal",
-      "below": "Below"
+      "above": "Über",
+      "equals": "Gleich",
+      "below": "Unter"
     },
     "alertTypes": {
-      "above": "above",
-      "equals": "equals",
-      "below": "below"
+      "above": "über",
+      "equals": "gleich",
+      "below": "unter"
     }
   }
 }

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "Kontaktname ist erforderlich",
-      "ntfyTopicRequired": "ntfy-Thema ist erforderlich"
+      "ntfyTopicRequired": "ntfy-Thema ist erforderlich",
+      "phoneRequired": "Telefonnummer ist erforderlich",
+      "emailRequired": "E-Mail-Adresse ist erforderlich"
     },
     "wizard": {
       "nameStep": "Kontaktname",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -1198,5 +1198,70 @@
       },
       "closeTab": "Du kannst diesen Tab schließen, um zu Canary zurückzukehren."
     }
+  },
+  "walletNotifications": {
+    "title": "Notifications",
+    "description": "Choose who gets notified, how, and for which wallet events.",
+    "addContact": "Add contact",
+    "delivery": {
+      "noMethods": "No delivery methods",
+      "notSet": "not set",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaction notifications",
+      "includeBalance": "Include wallet balance in transaction notifications",
+      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
+      "selectTypeFirst": "Select at least one transaction notification type first."
+    },
+    "saveState": {
+      "saved": "Saved",
+      "error": "Could not save",
+      "savedOnChange": "Saved on change"
+    },
+    "eventGroups": {
+      "activity": "Activity",
+      "firstConfirmation": "First confirmation",
+      "replacements": "Replacements / fee bumps"
+    },
+    "events": {
+      "sending": {
+        "label": "Sending",
+        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+      },
+      "receiving": {
+        "label": "Receiving",
+        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+      },
+      "sent": {
+        "label": "Sent",
+        "description": "An outgoing transaction receives its first confirmation."
+      },
+      "received": {
+        "label": "Received",
+        "description": "An incoming transaction receives its first confirmation."
+      },
+      "rbf": {
+        "label": "RBF replacement",
+        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+      },
+      "cpfp": {
+        "label": "CPFP fee bump",
+        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+      }
+    },
+    "balance": {
+      "title": "Balance threshold notifications"
+    },
+    "thresholdTypes": {
+      "above": "Above",
+      "equals": "Equal",
+      "below": "Below"
+    },
+    "alertTypes": {
+      "above": "above",
+      "equals": "equals",
+      "below": "below"
+    }
   }
 }

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -1234,7 +1234,7 @@
         "description": "Eine ausgehende Transaktion ist im Mempool sichtbar und noch unbestätigt."
       },
       "receiving": {
-        "label": "Empfangen",
+        "label": "Eingehend",
         "description": "Eine eingehende Transaktion ist im Mempool sichtbar und noch unbestätigt."
       },
       "sent": {

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -1203,6 +1203,10 @@
     "title": "Notifications",
     "description": "Choose who gets notified, how, and for which wallet events.",
     "addContact": "Add contact",
+    "contactActions": {
+      "edit": "Edit contact",
+      "delete": "Delete contact"
+    },
     "delivery": {
       "noMethods": "No delivery methods",
       "notSet": "not set",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -1198,5 +1198,70 @@
       },
       "closeTab": "You can close this tab to return to Canary."
     }
+  },
+  "walletNotifications": {
+    "title": "Notifications",
+    "description": "Choose who gets notified, how, and for which wallet events.",
+    "addContact": "Add contact",
+    "delivery": {
+      "noMethods": "No delivery methods",
+      "notSet": "not set",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaction notifications",
+      "includeBalance": "Include wallet balance in transaction notifications",
+      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
+      "selectTypeFirst": "Select at least one transaction notification type first."
+    },
+    "saveState": {
+      "saved": "Saved",
+      "error": "Could not save",
+      "savedOnChange": "Saved on change"
+    },
+    "eventGroups": {
+      "activity": "Activity",
+      "firstConfirmation": "First confirmation",
+      "replacements": "Replacements / fee bumps"
+    },
+    "events": {
+      "sending": {
+        "label": "Sending",
+        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+      },
+      "receiving": {
+        "label": "Receiving",
+        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+      },
+      "sent": {
+        "label": "Sent",
+        "description": "An outgoing transaction receives its first confirmation."
+      },
+      "received": {
+        "label": "Received",
+        "description": "An incoming transaction receives its first confirmation."
+      },
+      "rbf": {
+        "label": "RBF replacement",
+        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+      },
+      "cpfp": {
+        "label": "CPFP fee bump",
+        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+      }
+    },
+    "balance": {
+      "title": "Balance threshold notifications"
+    },
+    "thresholdTypes": {
+      "above": "Above",
+      "equals": "Equal",
+      "below": "Below"
+    },
+    "alertTypes": {
+      "above": "above",
+      "equals": "equals",
+      "below": "below"
+    }
   }
 }

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "Contact name is required",
-      "ntfyTopicRequired": "ntfy topic is required"
+      "ntfyTopicRequired": "ntfy topic is required",
+      "phoneRequired": "Phone number is required",
+      "emailRequired": "Email address is required"
     },
     "wizard": {
       "nameStep": "Contact Name",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -1203,6 +1203,10 @@
     "title": "Notifications",
     "description": "Choose who gets notified, how, and for which wallet events.",
     "addContact": "Add contact",
+    "contactActions": {
+      "edit": "Edit contact",
+      "delete": "Delete contact"
+    },
     "delivery": {
       "noMethods": "No delivery methods",
       "notSet": "not set",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -1200,72 +1200,72 @@
     }
   },
   "walletNotifications": {
-    "title": "Notifications",
-    "description": "Choose who gets notified, how, and for which wallet events.",
-    "addContact": "Add contact",
+    "title": "Notificaciones",
+    "description": "Elige quién recibe notificaciones, cómo y para qué eventos de la billetera.",
+    "addContact": "Agregar contacto",
     "contactActions": {
-      "edit": "Edit contact",
-      "delete": "Delete contact"
+      "edit": "Editar contacto",
+      "delete": "Eliminar contacto"
     },
     "delivery": {
-      "noMethods": "No delivery methods",
-      "notSet": "not set",
+      "noMethods": "Sin métodos de entrega",
+      "notSet": "sin configurar",
       "summary": "{provider}: {target}"
     },
     "transaction": {
-      "title": "Transaction notifications",
-      "includeBalance": "Include wallet balance in transaction notifications",
-      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
-      "selectTypeFirst": "Select at least one transaction notification type first."
+      "title": "Notificaciones de transacciones",
+      "includeBalance": "Incluir saldo de la billetera en las notificaciones de transacciones",
+      "includeBalanceDescription": "Se aplica a todos los tipos de notificación de transacción seleccionados abajo.",
+      "selectTypeFirst": "Selecciona primero al menos un tipo de notificación de transacción."
     },
     "saveState": {
-      "saved": "Saved",
-      "error": "Could not save",
-      "savedOnChange": "Saved on change"
+      "saved": "Guardado",
+      "error": "No se pudo guardar",
+      "savedOnChange": "Se guarda al cambiar"
     },
     "eventGroups": {
-      "activity": "Activity",
-      "firstConfirmation": "First confirmation",
-      "replacements": "Replacements / fee bumps"
+      "activity": "Actividad",
+      "firstConfirmation": "Primera confirmación",
+      "replacements": "Reemplazos / aumentos de comisión"
     },
     "events": {
       "sending": {
-        "label": "Sending",
-        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+        "label": "Enviando",
+        "description": "Una transacción saliente aparece en el mempool y aún no está confirmada."
       },
       "receiving": {
-        "label": "Receiving",
-        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+        "label": "Recibiendo",
+        "description": "Una transacción entrante aparece en el mempool y aún no está confirmada."
       },
       "sent": {
-        "label": "Sent",
-        "description": "An outgoing transaction receives its first confirmation."
+        "label": "Enviada",
+        "description": "Una transacción saliente recibe su primera confirmación."
       },
       "received": {
-        "label": "Received",
-        "description": "An incoming transaction receives its first confirmation."
+        "label": "Recibida",
+        "description": "Una transacción entrante recibe su primera confirmación."
       },
       "rbf": {
-        "label": "RBF replacement",
-        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+        "label": "Reemplazo RBF",
+        "description": "Replace-By-Fee: una transacción sin confirmar se reemplaza por una versión nueva."
       },
       "cpfp": {
-        "label": "CPFP fee bump",
-        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+        "label": "Aumento de comisión CPFP",
+        "description": "Child Pays For Parent: una transacción hija se usa para ayudar a confirmar su transacción padre."
       }
     },
     "balance": {
-      "title": "Balance threshold notifications"
+      "title": "Notificaciones de umbrales de saldo"
     },
     "thresholdTypes": {
-      "above": "Above",
-      "equals": "Equal",
-      "below": "Below"
+      "above": "Por encima de",
+      "equals": "Igual a",
+      "below": "Por debajo de"
     },
     "alertTypes": {
-      "above": "above",
-      "equals": "equals",
-      "below": "below"
+      "above": "por encima de",
+      "equals": "igual a",
+      "below": "por debajo de"
     }
   }
 }

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "El nombre del contacto es obligatorio",
-      "ntfyTopicRequired": "El tema de ntfy es obligatorio"
+      "ntfyTopicRequired": "El tema de ntfy es obligatorio",
+      "phoneRequired": "El número de teléfono es obligatorio",
+      "emailRequired": "La dirección de email es obligatoria"
     },
     "wizard": {
       "nameStep": "Nombre del contacto",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -1203,6 +1203,10 @@
     "title": "Notifications",
     "description": "Choose who gets notified, how, and for which wallet events.",
     "addContact": "Add contact",
+    "contactActions": {
+      "edit": "Edit contact",
+      "delete": "Delete contact"
+    },
     "delivery": {
       "noMethods": "No delivery methods",
       "notSet": "not set",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -1198,5 +1198,70 @@
       },
       "closeTab": "Puedes cerrar esta pestaña para volver a Canary."
     }
+  },
+  "walletNotifications": {
+    "title": "Notifications",
+    "description": "Choose who gets notified, how, and for which wallet events.",
+    "addContact": "Add contact",
+    "delivery": {
+      "noMethods": "No delivery methods",
+      "notSet": "not set",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaction notifications",
+      "includeBalance": "Include wallet balance in transaction notifications",
+      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
+      "selectTypeFirst": "Select at least one transaction notification type first."
+    },
+    "saveState": {
+      "saved": "Saved",
+      "error": "Could not save",
+      "savedOnChange": "Saved on change"
+    },
+    "eventGroups": {
+      "activity": "Activity",
+      "firstConfirmation": "First confirmation",
+      "replacements": "Replacements / fee bumps"
+    },
+    "events": {
+      "sending": {
+        "label": "Sending",
+        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+      },
+      "receiving": {
+        "label": "Receiving",
+        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+      },
+      "sent": {
+        "label": "Sent",
+        "description": "An outgoing transaction receives its first confirmation."
+      },
+      "received": {
+        "label": "Received",
+        "description": "An incoming transaction receives its first confirmation."
+      },
+      "rbf": {
+        "label": "RBF replacement",
+        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+      },
+      "cpfp": {
+        "label": "CPFP fee bump",
+        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+      }
+    },
+    "balance": {
+      "title": "Balance threshold notifications"
+    },
+    "thresholdTypes": {
+      "above": "Above",
+      "equals": "Equal",
+      "below": "Below"
+    },
+    "alertTypes": {
+      "above": "above",
+      "equals": "equals",
+      "below": "below"
+    }
   }
 }

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -1201,71 +1201,71 @@
   },
   "walletNotifications": {
     "title": "Notifications",
-    "description": "Choose who gets notified, how, and for which wallet events.",
-    "addContact": "Add contact",
+    "description": "Choisissez qui est averti, comment, et pour quels événements du portefeuille.",
+    "addContact": "Ajouter un contact",
     "contactActions": {
-      "edit": "Edit contact",
-      "delete": "Delete contact"
+      "edit": "Modifier le contact",
+      "delete": "Supprimer le contact"
     },
     "delivery": {
-      "noMethods": "No delivery methods",
-      "notSet": "not set",
+      "noMethods": "Aucune méthode de livraison",
+      "notSet": "non défini",
       "summary": "{provider}: {target}"
     },
     "transaction": {
-      "title": "Transaction notifications",
-      "includeBalance": "Include wallet balance in transaction notifications",
-      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
-      "selectTypeFirst": "Select at least one transaction notification type first."
+      "title": "Notifications de transaction",
+      "includeBalance": "Inclure le solde du portefeuille dans les notifications de transaction",
+      "includeBalanceDescription": "S’applique à tous les types de notifications de transaction sélectionnés ci-dessous.",
+      "selectTypeFirst": "Sélectionnez d’abord au moins un type de notification de transaction."
     },
     "saveState": {
-      "saved": "Saved",
-      "error": "Could not save",
-      "savedOnChange": "Saved on change"
+      "saved": "Enregistré",
+      "error": "Impossible d’enregistrer",
+      "savedOnChange": "Enregistré lors du changement"
     },
     "eventGroups": {
-      "activity": "Activity",
-      "firstConfirmation": "First confirmation",
-      "replacements": "Replacements / fee bumps"
+      "activity": "Activité",
+      "firstConfirmation": "Première confirmation",
+      "replacements": "Remplacements / hausses de frais"
     },
     "events": {
       "sending": {
-        "label": "Sending",
-        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+        "label": "Envoi",
+        "description": "Une transaction sortante est vue dans le mempool et n’est pas encore confirmée."
       },
       "receiving": {
-        "label": "Receiving",
-        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+        "label": "Réception",
+        "description": "Une transaction entrante est vue dans le mempool et n’est pas encore confirmée."
       },
       "sent": {
-        "label": "Sent",
-        "description": "An outgoing transaction receives its first confirmation."
+        "label": "Envoyée",
+        "description": "Une transaction sortante reçoit sa première confirmation."
       },
       "received": {
-        "label": "Received",
-        "description": "An incoming transaction receives its first confirmation."
+        "label": "Reçue",
+        "description": "Une transaction entrante reçoit sa première confirmation."
       },
       "rbf": {
-        "label": "RBF replacement",
-        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+        "label": "Remplacement RBF",
+        "description": "Replace-By-Fee : une transaction non confirmée est remplacée par une version plus récente."
       },
       "cpfp": {
-        "label": "CPFP fee bump",
-        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+        "label": "Hausse de frais CPFP",
+        "description": "Child Pays For Parent : une transaction enfant est utilisée pour aider à confirmer sa transaction parente."
       }
     },
     "balance": {
-      "title": "Balance threshold notifications"
+      "title": "Notifications de seuil de solde"
     },
     "thresholdTypes": {
-      "above": "Above",
-      "equals": "Equal",
-      "below": "Below"
+      "above": "Au-dessus de",
+      "equals": "Égal à",
+      "below": "En dessous de"
     },
     "alertTypes": {
-      "above": "above",
-      "equals": "equals",
-      "below": "below"
+      "above": "au-dessus de",
+      "equals": "égal à",
+      "below": "en dessous de"
     }
   }
 }

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -1198,5 +1198,70 @@
       },
       "closeTab": "Vous pouvez fermer cet onglet pour revenir à Canary."
     }
+  },
+  "walletNotifications": {
+    "title": "Notifications",
+    "description": "Choose who gets notified, how, and for which wallet events.",
+    "addContact": "Add contact",
+    "delivery": {
+      "noMethods": "No delivery methods",
+      "notSet": "not set",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaction notifications",
+      "includeBalance": "Include wallet balance in transaction notifications",
+      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
+      "selectTypeFirst": "Select at least one transaction notification type first."
+    },
+    "saveState": {
+      "saved": "Saved",
+      "error": "Could not save",
+      "savedOnChange": "Saved on change"
+    },
+    "eventGroups": {
+      "activity": "Activity",
+      "firstConfirmation": "First confirmation",
+      "replacements": "Replacements / fee bumps"
+    },
+    "events": {
+      "sending": {
+        "label": "Sending",
+        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+      },
+      "receiving": {
+        "label": "Receiving",
+        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+      },
+      "sent": {
+        "label": "Sent",
+        "description": "An outgoing transaction receives its first confirmation."
+      },
+      "received": {
+        "label": "Received",
+        "description": "An incoming transaction receives its first confirmation."
+      },
+      "rbf": {
+        "label": "RBF replacement",
+        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+      },
+      "cpfp": {
+        "label": "CPFP fee bump",
+        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+      }
+    },
+    "balance": {
+      "title": "Balance threshold notifications"
+    },
+    "thresholdTypes": {
+      "above": "Above",
+      "equals": "Equal",
+      "below": "Below"
+    },
+    "alertTypes": {
+      "above": "above",
+      "equals": "equals",
+      "below": "below"
+    }
   }
 }

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "Le nom du contact est obligatoire",
-      "ntfyTopicRequired": "Le sujet ntfy est requis"
+      "ntfyTopicRequired": "Le sujet ntfy est requis",
+      "phoneRequired": "Le numéro de téléphone est obligatoire",
+      "emailRequired": "L'adresse email est obligatoire"
     },
     "wizard": {
       "nameStep": "Nom du contact",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -1203,6 +1203,10 @@
     "title": "Notifications",
     "description": "Choose who gets notified, how, and for which wallet events.",
     "addContact": "Add contact",
+    "contactActions": {
+      "edit": "Edit contact",
+      "delete": "Delete contact"
+    },
     "delivery": {
       "noMethods": "No delivery methods",
       "notSet": "not set",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1198,5 +1198,70 @@
       },
       "closeTab": "このタブを閉じてCanaryに戻ることができます。"
     }
+  },
+  "walletNotifications": {
+    "title": "Notifications",
+    "description": "Choose who gets notified, how, and for which wallet events.",
+    "addContact": "Add contact",
+    "delivery": {
+      "noMethods": "No delivery methods",
+      "notSet": "not set",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaction notifications",
+      "includeBalance": "Include wallet balance in transaction notifications",
+      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
+      "selectTypeFirst": "Select at least one transaction notification type first."
+    },
+    "saveState": {
+      "saved": "Saved",
+      "error": "Could not save",
+      "savedOnChange": "Saved on change"
+    },
+    "eventGroups": {
+      "activity": "Activity",
+      "firstConfirmation": "First confirmation",
+      "replacements": "Replacements / fee bumps"
+    },
+    "events": {
+      "sending": {
+        "label": "Sending",
+        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+      },
+      "receiving": {
+        "label": "Receiving",
+        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+      },
+      "sent": {
+        "label": "Sent",
+        "description": "An outgoing transaction receives its first confirmation."
+      },
+      "received": {
+        "label": "Received",
+        "description": "An incoming transaction receives its first confirmation."
+      },
+      "rbf": {
+        "label": "RBF replacement",
+        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+      },
+      "cpfp": {
+        "label": "CPFP fee bump",
+        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+      }
+    },
+    "balance": {
+      "title": "Balance threshold notifications"
+    },
+    "thresholdTypes": {
+      "above": "Above",
+      "equals": "Equal",
+      "below": "Below"
+    },
+    "alertTypes": {
+      "above": "above",
+      "equals": "equals",
+      "below": "below"
+    }
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1200,72 +1200,72 @@
     }
   },
   "walletNotifications": {
-    "title": "Notifications",
-    "description": "Choose who gets notified, how, and for which wallet events.",
-    "addContact": "Add contact",
+    "title": "通知",
+    "description": "誰に、どの方法で、どのウォレットイベントを通知するかを選択します。",
+    "addContact": "連絡先を追加",
     "contactActions": {
-      "edit": "Edit contact",
-      "delete": "Delete contact"
+      "edit": "連絡先を編集",
+      "delete": "連絡先を削除"
     },
     "delivery": {
-      "noMethods": "No delivery methods",
-      "notSet": "not set",
+      "noMethods": "配信方法がありません",
+      "notSet": "未設定",
       "summary": "{provider}: {target}"
     },
     "transaction": {
-      "title": "Transaction notifications",
-      "includeBalance": "Include wallet balance in transaction notifications",
-      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
-      "selectTypeFirst": "Select at least one transaction notification type first."
+      "title": "トランザクション通知",
+      "includeBalance": "トランザクション通知にウォレット残高を含める",
+      "includeBalanceDescription": "下で選択したすべてのトランザクション通知タイプに適用されます。",
+      "selectTypeFirst": "まず少なくとも1つのトランザクション通知タイプを選択してください。"
     },
     "saveState": {
-      "saved": "Saved",
-      "error": "Could not save",
-      "savedOnChange": "Saved on change"
+      "saved": "保存済み",
+      "error": "保存できませんでした",
+      "savedOnChange": "変更時に保存"
     },
     "eventGroups": {
-      "activity": "Activity",
-      "firstConfirmation": "First confirmation",
-      "replacements": "Replacements / fee bumps"
+      "activity": "アクティビティ",
+      "firstConfirmation": "初回承認",
+      "replacements": "置換 / 手数料引き上げ"
     },
     "events": {
       "sending": {
-        "label": "Sending",
-        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+        "label": "送信中",
+        "description": "送信トランザクションがメンプールで確認され、まだ未承認です。"
       },
       "receiving": {
-        "label": "Receiving",
-        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+        "label": "受信中",
+        "description": "受信トランザクションがメンプールで確認され、まだ未承認です。"
       },
       "sent": {
-        "label": "Sent",
-        "description": "An outgoing transaction receives its first confirmation."
+        "label": "送信済み",
+        "description": "送信トランザクションが初回承認を受けました。"
       },
       "received": {
-        "label": "Received",
-        "description": "An incoming transaction receives its first confirmation."
+        "label": "受信済み",
+        "description": "受信トランザクションが初回承認を受けました。"
       },
       "rbf": {
-        "label": "RBF replacement",
-        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+        "label": "RBF置換",
+        "description": "Replace-By-Fee: 未承認トランザクションが新しいバージョンに置き換えられました。"
       },
       "cpfp": {
-        "label": "CPFP fee bump",
-        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+        "label": "CPFP手数料引き上げ",
+        "description": "Child Pays For Parent: 子トランザクションが親トランザクションの承認を助けるために使われます。"
       }
     },
     "balance": {
-      "title": "Balance threshold notifications"
+      "title": "残高しきい値通知"
     },
     "thresholdTypes": {
-      "above": "Above",
-      "equals": "Equal",
-      "below": "Below"
+      "above": "超過",
+      "equals": "等しい",
+      "below": "未満"
     },
     "alertTypes": {
-      "above": "above",
-      "equals": "equals",
-      "below": "below"
+      "above": "超過",
+      "equals": "等しい",
+      "below": "未満"
     }
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "連絡先名は必須です",
-      "ntfyTopicRequired": "ntfyトピックは必須です"
+      "ntfyTopicRequired": "ntfyトピックは必須です",
+      "phoneRequired": "電話番号は必須です",
+      "emailRequired": "メールアドレスは必須です"
     },
     "wizard": {
       "nameStep": "連絡先名",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1203,6 +1203,10 @@
     "title": "Notifications",
     "description": "Choose who gets notified, how, and for which wallet events.",
     "addContact": "Add contact",
+    "contactActions": {
+      "edit": "Edit contact",
+      "delete": "Delete contact"
+    },
     "delivery": {
       "noMethods": "No delivery methods",
       "notSet": "not set",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -608,7 +608,7 @@
     "detail": {
       "balance": "Saldo",
       "transactions": "Transaksjoner",
-      "notifications": "Notifications",
+      "notifications": "Varsler",
       "walletSections": "Wallet sections",
       "contacts": "Kontakter",
       "balanceAlerts": "Saldovarsler",
@@ -1197,6 +1197,71 @@
         "description": "Ditt faste bidrag bidrar til å opprettholde den videre utviklingen av Canary."
       },
       "closeTab": "Du kan lukke denne fanen for å gå tilbake til Canary."
+    }
+  },
+  "walletNotifications": {
+    "title": "Varsler",
+    "description": "Velg hvem som blir varslet, hvordan og for hvilke lommebokhendelser.",
+    "addContact": "Legg til kontakt",
+    "delivery": {
+      "noMethods": "Ingen leveringsmetoder",
+      "notSet": "ikke satt",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaksjonsvarsler",
+      "includeBalance": "Inkluder lommeboksaldo i transaksjonsvarsler",
+      "includeBalanceDescription": "Gjelder alle valgte transaksjonsvarsler nedenfor.",
+      "selectTypeFirst": "Velg minst én type transaksjonsvarsel først."
+    },
+    "saveState": {
+      "saved": "Lagret",
+      "error": "Kunne ikke lagre",
+      "savedOnChange": "Lagres ved endring"
+    },
+    "eventGroups": {
+      "activity": "Aktivitet",
+      "firstConfirmation": "Første bekreftelse",
+      "replacements": "Erstatninger / gebyrøkninger"
+    },
+    "events": {
+      "sending": {
+        "label": "Sender",
+        "description": "En utgående transaksjon er sett i mempoolen og er fortsatt ubekreftet."
+      },
+      "receiving": {
+        "label": "Mottar",
+        "description": "En inngående transaksjon er sett i mempoolen og er fortsatt ubekreftet."
+      },
+      "sent": {
+        "label": "Sendt",
+        "description": "En utgående transaksjon får sin første bekreftelse."
+      },
+      "received": {
+        "label": "Mottatt",
+        "description": "En inngående transaksjon får sin første bekreftelse."
+      },
+      "rbf": {
+        "label": "RBF-erstatning",
+        "description": "Replace-By-Fee: en ubekreftet transaksjon erstattes av en nyere versjon."
+      },
+      "cpfp": {
+        "label": "CPFP-gebyrøkning",
+        "description": "Child Pays For Parent: en barnetransaksjon brukes for å hjelpe forelderen med å bli bekreftet."
+      }
+    },
+    "balance": {
+      "title": "Saldoterskelvarsler"
+    },
+    "thresholdTypes": {
+      "above": "Over",
+      "equals": "Lik",
+      "below": "Under"
+    },
+    "alertTypes": {
+      "above": "over",
+      "equals": "lik",
+      "below": "under"
     }
   }
 }

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "Kontaktnavn er påkrevd",
-      "ntfyTopicRequired": "ntfy-emne er påkrevd"
+      "ntfyTopicRequired": "ntfy-emne er påkrevd",
+      "phoneRequired": "Telefonnummer er påkrevd",
+      "emailRequired": "E-postadresse er påkrevd"
     },
     "wizard": {
       "nameStep": "Kontaktnavn",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -1203,6 +1203,10 @@
     "title": "Varsler",
     "description": "Velg hvem som blir varslet, hvordan og for hvilke lommebokhendelser.",
     "addContact": "Legg til kontakt",
+    "contactActions": {
+      "edit": "Rediger kontakt",
+      "delete": "Slett kontakt"
+    },
     "delivery": {
       "noMethods": "Ingen leveringsmetoder",
       "notSet": "ikke satt",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "O nome do contato é obrigatório",
-      "ntfyTopicRequired": "O tópico do ntfy é obrigatório"
+      "ntfyTopicRequired": "O tópico do ntfy é obrigatório",
+      "phoneRequired": "O número de telefone é obrigatório",
+      "emailRequired": "O endereço de email é obrigatório"
     },
     "wizard": {
       "nameStep": "Nome do contato",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -1200,72 +1200,72 @@
     }
   },
   "walletNotifications": {
-    "title": "Notifications",
-    "description": "Choose who gets notified, how, and for which wallet events.",
-    "addContact": "Add contact",
+    "title": "Notificações",
+    "description": "Escolha quem recebe notificações, como e para quais eventos da carteira.",
+    "addContact": "Adicionar contato",
     "contactActions": {
-      "edit": "Edit contact",
-      "delete": "Delete contact"
+      "edit": "Editar contato",
+      "delete": "Excluir contato"
     },
     "delivery": {
-      "noMethods": "No delivery methods",
-      "notSet": "not set",
+      "noMethods": "Nenhum método de entrega",
+      "notSet": "não definido",
       "summary": "{provider}: {target}"
     },
     "transaction": {
-      "title": "Transaction notifications",
-      "includeBalance": "Include wallet balance in transaction notifications",
-      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
-      "selectTypeFirst": "Select at least one transaction notification type first."
+      "title": "Notificações de transações",
+      "includeBalance": "Incluir saldo da carteira nas notificações de transações",
+      "includeBalanceDescription": "Aplica-se a todos os tipos de notificação de transação selecionados abaixo.",
+      "selectTypeFirst": "Selecione primeiro pelo menos um tipo de notificação de transação."
     },
     "saveState": {
-      "saved": "Saved",
-      "error": "Could not save",
-      "savedOnChange": "Saved on change"
+      "saved": "Salvo",
+      "error": "Não foi possível salvar",
+      "savedOnChange": "Salvo ao alterar"
     },
     "eventGroups": {
-      "activity": "Activity",
-      "firstConfirmation": "First confirmation",
-      "replacements": "Replacements / fee bumps"
+      "activity": "Atividade",
+      "firstConfirmation": "Primeira confirmação",
+      "replacements": "Substituições / aumentos de taxa"
     },
     "events": {
       "sending": {
-        "label": "Sending",
-        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+        "label": "Enviando",
+        "description": "Uma transação de saída aparece no mempool e ainda não foi confirmada."
       },
       "receiving": {
-        "label": "Receiving",
-        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+        "label": "Recebendo",
+        "description": "Uma transação de entrada aparece no mempool e ainda não foi confirmada."
       },
       "sent": {
-        "label": "Sent",
-        "description": "An outgoing transaction receives its first confirmation."
+        "label": "Enviada",
+        "description": "Uma transação de saída recebe sua primeira confirmação."
       },
       "received": {
-        "label": "Received",
-        "description": "An incoming transaction receives its first confirmation."
+        "label": "Recebida",
+        "description": "Uma transação de entrada recebe sua primeira confirmação."
       },
       "rbf": {
-        "label": "RBF replacement",
-        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+        "label": "Substituição RBF",
+        "description": "Replace-By-Fee: uma transação não confirmada é substituída por uma versão mais nova."
       },
       "cpfp": {
-        "label": "CPFP fee bump",
-        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+        "label": "Aumento de taxa CPFP",
+        "description": "Child Pays For Parent: uma transação filha é usada para ajudar a confirmar sua transação pai."
       }
     },
     "balance": {
-      "title": "Balance threshold notifications"
+      "title": "Notificações de limite de saldo"
     },
     "thresholdTypes": {
-      "above": "Above",
-      "equals": "Equal",
-      "below": "Below"
+      "above": "Acima de",
+      "equals": "Igual a",
+      "below": "Abaixo de"
     },
     "alertTypes": {
-      "above": "above",
-      "equals": "equals",
-      "below": "below"
+      "above": "acima de",
+      "equals": "igual a",
+      "below": "abaixo de"
     }
   }
 }

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -1198,5 +1198,70 @@
       },
       "closeTab": "Você pode fechar esta aba para voltar ao Canary."
     }
+  },
+  "walletNotifications": {
+    "title": "Notifications",
+    "description": "Choose who gets notified, how, and for which wallet events.",
+    "addContact": "Add contact",
+    "delivery": {
+      "noMethods": "No delivery methods",
+      "notSet": "not set",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaction notifications",
+      "includeBalance": "Include wallet balance in transaction notifications",
+      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
+      "selectTypeFirst": "Select at least one transaction notification type first."
+    },
+    "saveState": {
+      "saved": "Saved",
+      "error": "Could not save",
+      "savedOnChange": "Saved on change"
+    },
+    "eventGroups": {
+      "activity": "Activity",
+      "firstConfirmation": "First confirmation",
+      "replacements": "Replacements / fee bumps"
+    },
+    "events": {
+      "sending": {
+        "label": "Sending",
+        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+      },
+      "receiving": {
+        "label": "Receiving",
+        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+      },
+      "sent": {
+        "label": "Sent",
+        "description": "An outgoing transaction receives its first confirmation."
+      },
+      "received": {
+        "label": "Received",
+        "description": "An incoming transaction receives its first confirmation."
+      },
+      "rbf": {
+        "label": "RBF replacement",
+        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+      },
+      "cpfp": {
+        "label": "CPFP fee bump",
+        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+      }
+    },
+    "balance": {
+      "title": "Balance threshold notifications"
+    },
+    "thresholdTypes": {
+      "above": "Above",
+      "equals": "Equal",
+      "below": "Below"
+    },
+    "alertTypes": {
+      "above": "above",
+      "equals": "equals",
+      "below": "below"
+    }
   }
 }

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -1203,6 +1203,10 @@
     "title": "Notifications",
     "description": "Choose who gets notified, how, and for which wallet events.",
     "addContact": "Add contact",
+    "contactActions": {
+      "edit": "Edit contact",
+      "delete": "Delete contact"
+    },
     "delivery": {
       "noMethods": "No delivery methods",
       "notSet": "not set",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -1200,72 +1200,72 @@
     }
   },
   "walletNotifications": {
-    "title": "Notifications",
-    "description": "Choose who gets notified, how, and for which wallet events.",
-    "addContact": "Add contact",
+    "title": "Aviseringar",
+    "description": "Välj vem som får aviseringar, hur och för vilka plånbokshändelser.",
+    "addContact": "Lägg till kontakt",
     "contactActions": {
       "edit": "Redigera kontakt",
       "delete": "Ta bort kontakt"
     },
     "delivery": {
-      "noMethods": "No delivery methods",
-      "notSet": "not set",
+      "noMethods": "Inga leveransmetoder",
+      "notSet": "inte angivet",
       "summary": "{provider}: {target}"
     },
     "transaction": {
-      "title": "Transaction notifications",
-      "includeBalance": "Include wallet balance in transaction notifications",
-      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
-      "selectTypeFirst": "Select at least one transaction notification type first."
+      "title": "Transaktionsaviseringar",
+      "includeBalance": "Inkludera plånbokssaldo i transaktionsaviseringar",
+      "includeBalanceDescription": "Gäller alla valda typer av transaktionsaviseringar nedan.",
+      "selectTypeFirst": "Välj minst en typ av transaktionsavisering först."
     },
     "saveState": {
-      "saved": "Saved",
-      "error": "Could not save",
-      "savedOnChange": "Saved on change"
+      "saved": "Sparat",
+      "error": "Kunde inte spara",
+      "savedOnChange": "Sparas vid ändring"
     },
     "eventGroups": {
-      "activity": "Activity",
-      "firstConfirmation": "First confirmation",
-      "replacements": "Replacements / fee bumps"
+      "activity": "Aktivitet",
+      "firstConfirmation": "Första bekräftelsen",
+      "replacements": "Ersättningar / avgiftshöjningar"
     },
     "events": {
       "sending": {
-        "label": "Sending",
-        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+        "label": "Skickar",
+        "description": "En utgående transaktion syns i mempoolen och är fortfarande obekräftad."
       },
       "receiving": {
-        "label": "Receiving",
-        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+        "label": "Tar emot",
+        "description": "En inkommande transaktion syns i mempoolen och är fortfarande obekräftad."
       },
       "sent": {
-        "label": "Sent",
-        "description": "An outgoing transaction receives its first confirmation."
+        "label": "Skickad",
+        "description": "En utgående transaktion får sin första bekräftelse."
       },
       "received": {
-        "label": "Received",
-        "description": "An incoming transaction receives its first confirmation."
+        "label": "Mottagen",
+        "description": "En inkommande transaktion får sin första bekräftelse."
       },
       "rbf": {
-        "label": "RBF replacement",
-        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+        "label": "RBF-ersättning",
+        "description": "Replace-By-Fee: en obekräftad transaktion ersätts av en nyare version."
       },
       "cpfp": {
-        "label": "CPFP fee bump",
-        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+        "label": "CPFP-avgiftshöjning",
+        "description": "Child Pays For Parent: en barntransaktion används för att hjälpa till att bekräfta sin förälder."
       }
     },
     "balance": {
-      "title": "Balance threshold notifications"
+      "title": "Saldotröskelaviseringar"
     },
     "thresholdTypes": {
-      "above": "Above",
-      "equals": "Equal",
-      "below": "Below"
+      "above": "Över",
+      "equals": "Lika med",
+      "below": "Under"
     },
     "alertTypes": {
-      "above": "above",
-      "equals": "equals",
-      "below": "below"
+      "above": "över",
+      "equals": "lika med",
+      "below": "under"
     }
   }
 }

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -747,7 +747,9 @@
     },
     "errors": {
       "nameRequired": "Kontaktnamn krävs",
-      "ntfyTopicRequired": "ntfy-ämne krävs"
+      "ntfyTopicRequired": "ntfy-ämne krävs",
+      "phoneRequired": "Telefonnummer krävs",
+      "emailRequired": "E-postadress krävs"
     },
     "wizard": {
       "nameStep": "Kontaktnamn",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -608,7 +608,7 @@
     "detail": {
       "balance": "Saldo",
       "transactions": "Transaktioner",
-      "notifications": "Notifications",
+      "notifications": "Aviseringar",
       "walletSections": "Wallet sections",
       "contacts": "Kontakter",
       "balanceAlerts": "Saldovarningar",
@@ -1197,6 +1197,71 @@
         "description": "Ditt regelbundna bidrag bidrar till att upprätthålla den fortsatta utvecklingen av Canary."
       },
       "closeTab": "Du kan stänga den här fliken för att återgå till Canary."
+    }
+  },
+  "walletNotifications": {
+    "title": "Notifications",
+    "description": "Choose who gets notified, how, and for which wallet events.",
+    "addContact": "Add contact",
+    "delivery": {
+      "noMethods": "No delivery methods",
+      "notSet": "not set",
+      "summary": "{provider}: {target}"
+    },
+    "transaction": {
+      "title": "Transaction notifications",
+      "includeBalance": "Include wallet balance in transaction notifications",
+      "includeBalanceDescription": "Applies to all selected transaction notification types below.",
+      "selectTypeFirst": "Select at least one transaction notification type first."
+    },
+    "saveState": {
+      "saved": "Saved",
+      "error": "Could not save",
+      "savedOnChange": "Saved on change"
+    },
+    "eventGroups": {
+      "activity": "Activity",
+      "firstConfirmation": "First confirmation",
+      "replacements": "Replacements / fee bumps"
+    },
+    "events": {
+      "sending": {
+        "label": "Sending",
+        "description": "An outgoing transaction is seen in the mempool and is still unconfirmed."
+      },
+      "receiving": {
+        "label": "Receiving",
+        "description": "An incoming transaction is seen in the mempool and is still unconfirmed."
+      },
+      "sent": {
+        "label": "Sent",
+        "description": "An outgoing transaction receives its first confirmation."
+      },
+      "received": {
+        "label": "Received",
+        "description": "An incoming transaction receives its first confirmation."
+      },
+      "rbf": {
+        "label": "RBF replacement",
+        "description": "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version."
+      },
+      "cpfp": {
+        "label": "CPFP fee bump",
+        "description": "Child Pays For Parent: a child transaction is used to help confirm its parent."
+      }
+    },
+    "balance": {
+      "title": "Balance threshold notifications"
+    },
+    "thresholdTypes": {
+      "above": "Above",
+      "equals": "Equal",
+      "below": "Below"
+    },
+    "alertTypes": {
+      "above": "above",
+      "equals": "equals",
+      "below": "below"
     }
   }
 }

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -1203,6 +1203,10 @@
     "title": "Notifications",
     "description": "Choose who gets notified, how, and for which wallet events.",
     "addContact": "Add contact",
+    "contactActions": {
+      "edit": "Redigera kontakt",
+      "delete": "Ta bort kontakt"
+    },
     "delivery": {
       "noMethods": "No delivery methods",
       "notSet": "not set",

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -314,6 +314,34 @@ describe('WalletNotificationsPage', () => {
     expect(screen.getByRole('checkbox', { name: /Sending/i })).toBeDisabled()
   })
 
+  it('uses the provider selector as the only visible method label for new cloud contacts', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 0,
+      },
+    })
+    mockNotificationsResponse([])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Add contact' }))
+    await user.type(screen.getByLabelText('New contact name'), 'Alice')
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(screen.getByRole('combobox', { name: 'Delivery method' })).toHaveTextContent('Email')
+    expect(screen.getAllByText('Email')).toHaveLength(1)
+  })
+
   it('creates an ntfy contact inline with default transaction notification settings', async () => {
     const user = userEvent.setup()
     mockNotificationsResponse([])

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -612,6 +612,185 @@ describe('WalletNotificationsPage', () => {
     expect(screen.getByDisplayValue('alice@example.com')).toBeDisabled()
   })
 
+  it('allows adding email to an existing cloud contact that only has SMS', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 1,
+      },
+    })
+    mockNotificationsResponse([
+      makeContact({
+        notification_methods: [
+          {
+            id: 'contact-1-method-1',
+            contact_id: 'contact-1',
+            provider_type: 'sms',
+            notification_target: '+4799999999',
+            display_target: '+4799999999',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
+    ])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+    await user.click(screen.getByRole('combobox', { name: 'Delivery method type' }))
+    await user.click(await screen.findByText('Email'))
+    await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
+    await user.type(screen.getByPlaceholderText('your@email.com'), 'alice@example.com')
+    await user.click(screen.getByRole('button', { name: /Save contact/ }))
+
+    await waitFor(() => expect(mockApi.updateContact).toHaveBeenCalledTimes(1))
+    expect(mockApi.updateContact).toHaveBeenCalledWith(
+      'sq32h3ch',
+      'contact-1',
+      'Alice',
+      [
+        {
+          provider_type: 'sms',
+          notification_target: '+4799999999',
+          is_enabled: true,
+        },
+        {
+          provider_type: 'email',
+          notification_target: 'alice@example.com',
+          is_enabled: true,
+        },
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('allows adding SMS to an existing cloud contact that only has email', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 1,
+      },
+    })
+    mockNotificationsResponse([
+      makeContact({
+        notification_methods: [
+          {
+            id: 'contact-1-method-1',
+            contact_id: 'contact-1',
+            provider_type: 'email',
+            notification_target: 'alice@example.com',
+            display_target: 'alice@example.com',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
+    ])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+    await user.click(screen.getByRole('combobox', { name: 'Delivery method type' }))
+    await user.click(await screen.findByText('SMS'))
+    await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
+    await user.type(screen.getByPlaceholderText('+47 123 45 678'), '+4799999999')
+    await user.click(screen.getByRole('button', { name: /Save contact/ }))
+
+    await waitFor(() => expect(mockApi.updateContact).toHaveBeenCalledTimes(1))
+    expect(mockApi.updateContact).toHaveBeenCalledWith(
+      'sq32h3ch',
+      'contact-1',
+      'Alice',
+      [
+        {
+          provider_type: 'email',
+          notification_target: 'alice@example.com',
+          is_enabled: true,
+        },
+        {
+          provider_type: 'sms',
+          notification_target: '+4799999999',
+          is_enabled: true,
+        },
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('restores an unsaved deleted delivery method when adding the same provider again', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 1,
+      },
+    })
+    mockNotificationsResponse([
+      makeContact({
+        notification_methods: [
+          {
+            id: 'contact-1-method-1',
+            contact_id: 'contact-1',
+            provider_type: 'email',
+            notification_target: 'alice@example.com',
+            display_target: 'alice@example.com',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+          {
+            id: 'contact-1-method-2',
+            contact_id: 'contact-1',
+            provider_type: 'ntfy',
+            notification_target: 'alice-topic',
+            display_target: 'alice-topic',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
+    ])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+    await user.click(screen.getAllByRole('button', { name: 'Delete delivery method' })[0])
+    await user.click(screen.getByRole('combobox', { name: 'Delivery method type' }))
+    await user.click(await screen.findByText('Email'))
+    await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
+
+    expect(screen.getByDisplayValue('alice@example.com')).toBeDisabled()
+  })
+
   it('opens the upgrade modal instead of the wizard when the cloud contact limit is reached', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -204,6 +204,7 @@ async function renderLoadedPage() {
 describe('WalletNotificationsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    verificationMock.isVerified = true
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -673,6 +674,55 @@ describe('WalletNotificationsPage', () => {
       ],
       expect.any(Object)
     )
+  })
+
+  it('blocks saving a new email delivery method until it is verified', async () => {
+    const user = userEvent.setup()
+    verificationMock.isVerified = false
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 1,
+      },
+    })
+    mockNotificationsResponse([
+      makeContact({
+        notification_methods: [
+          {
+            id: 'contact-1-method-1',
+            contact_id: 'contact-1',
+            provider_type: 'sms',
+            notification_target: '+4799999999',
+            display_target: '+4799999999',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
+    ])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+    await user.click(screen.getByRole('combobox', { name: 'Delivery method type' }))
+    await user.click(await screen.findByText('Email'))
+    await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
+    await user.type(screen.getByPlaceholderText('your@email.com'), 'alice@example.com')
+    await user.click(screen.getByRole('button', { name: /Save contact/ }))
+
+    expect(
+      screen.getByText('Please verify the new email address before saving the contact')
+    ).toBeInTheDocument()
+    expect(mockApi.updateContact).not.toHaveBeenCalled()
   })
 
   it('allows adding SMS to an existing cloud contact that only has email', async () => {

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -628,8 +628,9 @@ describe('WalletNotificationsPage', () => {
     })
   })
 
-  it('does not allow inline editing of email targets without verification', async () => {
+  it('blocks saving a changed email target until it is verified', async () => {
     const user = userEvent.setup()
+    verificationMock.isVerified = false
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -664,8 +665,14 @@ describe('WalletNotificationsPage', () => {
     await renderLoadedPage()
     await user.click(screen.getByRole('button', { name: 'Contact actions' }))
     await user.click(screen.getByText('Edit contact'))
+    await user.clear(screen.getByDisplayValue('alice@example.com'))
+    await user.type(screen.getByPlaceholderText('your@email.com'), 'alice+new@example.com')
+    await user.click(screen.getByRole('button', { name: /Save contact/ }))
 
-    expect(screen.getByDisplayValue('alice@example.com')).toBeDisabled()
+    expect(
+      screen.getByText('Please verify the new email address before saving the contact')
+    ).toBeInTheDocument()
+    expect(mockApi.updateContact).not.toHaveBeenCalled()
   })
 
   it('allows adding email to an existing cloud contact that only has SMS', async () => {
@@ -1078,7 +1085,7 @@ describe('WalletNotificationsPage', () => {
     await user.click(await screen.findByRole('option', { name: 'Email' }))
     await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
 
-    expect(screen.getByDisplayValue('alice@example.com')).toBeDisabled()
+    expect(screen.getByDisplayValue('alice@example.com')).toBeEnabled()
   })
 
   it('opens the upgrade modal instead of the wizard when the cloud contact limit is reached', async () => {

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -225,7 +225,21 @@ describe('WalletNotificationsPage', () => {
     mockNotificationsResponse([
       makeContact({ id: 'contact-2', name: 'Zoe' }),
       makeContact({ id: 'contact-1', name: 'alice' }),
-      makeContact({ id: 'contact-3', name: 'Bob' }),
+      makeContact({
+        id: 'contact-3',
+        name: 'Bob',
+        notification_methods: [
+          {
+            id: 'contact-3-method-1',
+            contact_id: 'contact-3',
+            provider_type: 'sms',
+            notification_target: '+4792050946',
+            display_target: '+4792050946',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
     ])
 
     await renderLoadedPage()
@@ -242,6 +256,7 @@ describe('WalletNotificationsPage', () => {
     expect(screen.getAllByText('Received')).toHaveLength(3)
     expect(screen.getAllByText('RBF replacement')).toHaveLength(3)
     expect(screen.getAllByText('CPFP fee bump')).toHaveLength(3)
+    expect(screen.getByText('SMS: +47 92 05 09 46')).toBeInTheDocument()
   })
 
   it('hides contact creation and locks transaction checkboxes for cloud read-only users', async () => {

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -936,6 +936,52 @@ describe('WalletNotificationsPage', () => {
     expect(screen.getAllByRole('button', { name: 'Delete delivery method' })).toHaveLength(1)
   })
 
+  it('shows the fallback addable provider after deleting another method without saving', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 1,
+      },
+    })
+    mockNotificationsResponse([
+      makeContact({
+        notification_methods: [
+          {
+            id: 'contact-1-method-1',
+            contact_id: 'contact-1',
+            provider_type: 'email',
+            notification_target: 'alice@example.com',
+            display_target: 'alice@example.com',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
+    ])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+    await user.click(screen.getByRole('combobox', { name: 'Delivery method type' }))
+    await user.click(await screen.findByText('SMS'))
+    await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
+    await user.click(screen.getAllByRole('button', { name: 'Delete delivery method' })[0])
+
+    expect(screen.getByRole('combobox', { name: 'Delivery method type' })).toHaveTextContent(
+      'Email'
+    )
+  })
+
   it('restores an unsaved deleted delivery method when adding the same provider again', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({
@@ -983,7 +1029,7 @@ describe('WalletNotificationsPage', () => {
     await user.click(screen.getByText('Edit contact'))
     await user.click(screen.getAllByRole('button', { name: 'Delete delivery method' })[0])
     await user.click(screen.getByRole('combobox', { name: 'Delivery method type' }))
-    await user.click(await screen.findByText('Email'))
+    await user.click(await screen.findByRole('option', { name: 'Email' }))
     await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
 
     expect(screen.getByDisplayValue('alice@example.com')).toBeDisabled()

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -843,6 +843,50 @@ describe('WalletNotificationsPage', () => {
     )
   })
 
+  it('hides the delete action for a new SMS method until it is verified', async () => {
+    const user = userEvent.setup()
+    verificationMock.isVerified = false
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 1,
+      },
+    })
+    mockNotificationsResponse([
+      makeContact({
+        notification_methods: [
+          {
+            id: 'contact-1-method-1',
+            contact_id: 'contact-1',
+            provider_type: 'email',
+            notification_target: 'alice@example.com',
+            display_target: 'alice@example.com',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
+    ])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+    await user.click(screen.getByRole('combobox', { name: 'Delivery method type' }))
+    await user.click(await screen.findByText('SMS'))
+    await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
+
+    expect(screen.getAllByRole('button', { name: 'Delete delivery method' })).toHaveLength(1)
+  })
+
   it('restores an unsaved deleted delivery method when adding the same provider again', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -982,6 +982,52 @@ describe('WalletNotificationsPage', () => {
     )
   })
 
+  it('allows replacing the only cloud delivery method before saving', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 1,
+      },
+    })
+    mockNotificationsResponse([
+      makeContact({
+        notification_methods: [
+          {
+            id: 'contact-1-method-1',
+            contact_id: 'contact-1',
+            provider_type: 'email',
+            notification_target: 'alice@example.com',
+            display_target: 'alice@example.com',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
+    ])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+
+    await user.click(screen.getByRole('button', { name: 'Delete delivery method' }))
+
+    expect(screen.queryByDisplayValue('alice@example.com')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Delivery method type' })).toHaveTextContent(
+      'ntfy'
+    )
+    expect(screen.getByRole('button', { name: /Save contact/ })).toBeDisabled()
+  })
+
   it('restores an unsaved deleted delivery method when adding the same provider again', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import WalletNotificationsPage from '../page'
 import type { BalanceAlert, Contact, Wallet, WalletNotificationsResponse } from '@/types'
-import { api } from '@/lib/api'
+import { ApiError, api } from '@/lib/api'
 
 const mockPush = jest.fn()
 const mockSetCurrentWallet = jest.fn()
@@ -111,13 +111,25 @@ jest.mock('@/hooks/usePhonePlaceholder', () => ({
 }))
 
 jest.mock('@/lib/api', () => ({
-  ApiError: class ApiError extends Error {},
+  ApiError: class ApiError extends Error {
+    errorCode: string | null
+
+    constructor(message: string, _type?: string, _statusCode?: number | null, errorCode?: string | null) {
+      super(message)
+      this.errorCode = errorCode ?? null
+    }
+
+    getUserFriendlyMessage() {
+      return this.message
+    }
+  },
   api: {
     getWalletNotifications: jest.fn(),
     createContact: jest.fn(),
     updateContact: jest.fn(),
     deleteContact: jest.fn(),
     createBalanceAlert: jest.fn(),
+    validateBalanceAlert: jest.fn(),
     deleteBalanceAlert: jest.fn(),
     getUserPreferences: jest.fn(),
   },
@@ -217,6 +229,7 @@ describe('WalletNotificationsPage', () => {
     mockApi.updateContact.mockResolvedValue(makeContact())
     mockApi.deleteContact.mockResolvedValue(undefined)
     mockApi.createBalanceAlert.mockResolvedValue(makeAlert())
+    mockApi.validateBalanceAlert.mockResolvedValue(undefined)
     mockApi.deleteBalanceAlert.mockResolvedValue(undefined)
     mockApi.getUserPreferences.mockResolvedValue({ preferred_fiat_currency: 'NOK' })
   })
@@ -355,7 +368,13 @@ describe('WalletNotificationsPage', () => {
     await user.click(screen.getByText('RBF replacement'))
     await user.type(screen.getByPlaceholderText('0.10'), '0.25')
     await user.click(screen.getByRole('button', { name: 'Add' }))
-    expect(screen.getByText('below 0.25 BTC')).toBeInTheDocument()
+    expect(await screen.findByText('below 0.25 BTC')).toBeInTheDocument()
+    expect(mockApi.validateBalanceAlert).toHaveBeenCalledWith('sq32h3ch', {
+      alert_type: 'below',
+      threshold_sats: 25000000,
+      threshold_currency: undefined,
+      threshold_fiat_amount: undefined,
+    })
     expect(screen.getByLabelText('ntfy Topic')).toHaveValue('nora-sq32h3ch')
     await user.click(screen.getByRole('button', { name: 'Create contact' }))
 
@@ -385,6 +404,40 @@ describe('WalletNotificationsPage', () => {
       contact_id: 'contact-1',
       alert_type: 'below',
       threshold_sats: 25000000,
+      threshold_currency: undefined,
+      threshold_fiat_amount: undefined,
+    })
+  })
+
+  it('validates new contact draft thresholds before adding them', async () => {
+    const user = userEvent.setup()
+    mockNotificationsResponse([])
+    mockApi.validateBalanceAlert.mockRejectedValueOnce(
+      new ApiError(
+        'This alert would trigger immediately based on the current balance. Try a different threshold or alert type.',
+        'validation',
+        400,
+        'alert_would_trigger_immediately'
+      )
+    )
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Add contact' }))
+
+    await user.type(screen.getByPlaceholderText('0.10'), '0.1')
+    await user.click(screen.getByRole('button', { name: 'Add' }))
+
+    const thresholdSection = screen.getByText('Balance threshold notifications').closest('section')
+    expect(thresholdSection).not.toBeNull()
+    expect(
+      await within(thresholdSection!).findByText(
+        'This alert would trigger immediately based on the current balance. Try a different threshold or alert type.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText('below 0.1 BTC')).not.toBeInTheDocument()
+    expect(mockApi.validateBalanceAlert).toHaveBeenCalledWith('sq32h3ch', {
+      alert_type: 'below',
+      threshold_sats: 10000000,
       threshold_currency: undefined,
       threshold_fiat_amount: undefined,
     })
@@ -604,63 +657,14 @@ describe('WalletNotificationsPage', () => {
     await waitFor(() => expect(mockApi.deleteBalanceAlert).toHaveBeenCalledWith('alert-1'))
   })
 
-  it('shows legacy wallet-level balance thresholds when they have no contact', async () => {
-    const user = userEvent.setup()
+  it('ignores wallet-level balance thresholds without a contact', async () => {
     mockNotificationsResponse([], [makeAlert({ contact_id: undefined })])
 
     await renderLoadedPage()
 
-    expect(screen.getByText('Legacy wallet balance thresholds')).toBeInTheDocument()
-    expect(screen.getByText('above 1 BTC')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: 'Delete wallet-level threshold' }))
-
-    await waitFor(() => expect(mockApi.deleteBalanceAlert).toHaveBeenCalledWith('alert-1'))
-  })
-
-  it('hides inactive migrated wallet-level balance thresholds', async () => {
-    mockNotificationsResponse(
-      [makeContact()],
-      [
-        makeAlert({
-          id: 'legacy-alert',
-          contact_id: undefined,
-          threshold_sats: 0,
-          alert_type: 'equals',
-          is_active: false,
-        }),
-        makeAlert({
-          id: 'contact-alert',
-          contact_id: 'contact-1',
-          threshold_sats: 0,
-          alert_type: 'equals',
-        }),
-      ]
-    )
-
-    await renderLoadedPage()
-
     expect(screen.queryByText('Legacy wallet balance thresholds')).not.toBeInTheDocument()
-    expect(screen.getByText('equals 0 BTC')).toBeInTheDocument()
-  })
-
-  it('keeps inactive standalone wallet-level balance thresholds visible', async () => {
-    mockNotificationsResponse(
-      [],
-      [
-        makeAlert({
-          contact_id: undefined,
-          threshold_sats: 0,
-          alert_type: 'equals',
-          is_active: false,
-        }),
-      ]
-    )
-
-    await renderLoadedPage()
-
-    expect(screen.getByText('Legacy wallet balance thresholds')).toBeInTheDocument()
-    expect(screen.getByText('equals 0 BTC')).toBeInTheDocument()
+    expect(screen.queryByText('above 1 BTC')).not.toBeInTheDocument()
+    expect(mockApi.deleteBalanceAlert).not.toHaveBeenCalled()
   })
 
   it('keeps inactive contact-level balance thresholds visible', async () => {

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -780,6 +780,55 @@ describe('WalletNotificationsPage', () => {
     expect(mockApi.updateContact).not.toHaveBeenCalled()
   })
 
+  it('blocks saving a new SMS delivery method until it is verified', async () => {
+    const user = userEvent.setup()
+    verificationMock.isVerified = false
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: { id: 1, email: 'test@example.com', subscription_tier: 'team' },
+      billingStatus: {
+        subscription_tier: 'team',
+        subscription_status: 'active',
+        stripe_customer_id: 'cus_123',
+        limits: { max_wallets: 5, max_contacts_per_wallet: 5, sync_interval_seconds: 60 },
+        wallet_count: 1,
+        contact_count: 1,
+      },
+    })
+    mockNotificationsResponse([
+      makeContact({
+        notification_methods: [
+          {
+            id: 'contact-1-method-1',
+            contact_id: 'contact-1',
+            provider_type: 'email',
+            notification_target: 'alice@example.com',
+            display_target: 'alice@example.com',
+            created_at: '2024-01-01T00:00:00Z',
+            is_enabled: true,
+          },
+        ],
+      }),
+    ])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+    await user.click(screen.getByRole('combobox', { name: 'Delivery method type' }))
+    await user.click(await screen.findByText('SMS'))
+    await user.click(screen.getByRole('button', { name: 'Add delivery method' }))
+    await user.type(screen.getByPlaceholderText('+47 123 45 678'), '+4799999999')
+    await user.click(screen.getByRole('button', { name: /Save contact/ }))
+
+    expect(
+      screen.getByText('Please verify the new SMS phone number before saving the contact')
+    ).toBeInTheDocument()
+    expect(mockApi.updateContact).not.toHaveBeenCalled()
+  })
+
   it('allows adding SMS to an existing cloud contact that only has email', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -244,6 +244,61 @@ describe('WalletNotificationsPage', () => {
     expect(screen.getAllByText('CPFP fee bump')).toHaveLength(3)
   })
 
+  it('hides contact creation and locks transaction checkboxes for cloud read-only users', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: {
+        id: 1,
+        email: 'demo@canarybitcoin.com',
+        is_admin: false,
+        is_demo: true,
+        email_verified: true,
+      },
+      billingStatus: null,
+    })
+    mockNotificationsResponse([makeContact({ notify_rbf: true })])
+
+    await renderLoadedPage()
+
+    expect(screen.queryByRole('button', { name: 'Add contact' })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Contact actions')).not.toBeInTheDocument()
+
+    const rbfCheckbox = screen.getByRole('checkbox', { name: /RBF replacement/i })
+    expect(rbfCheckbox).toBeDisabled()
+    expect(rbfCheckbox).toHaveClass('cursor-not-allowed')
+
+    await user.click(screen.getByText('RBF replacement'))
+    expect(mockApi.updateContact).not.toHaveBeenCalled()
+  })
+
+  it('hides contact creation for cloud admins', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isCloudMode: true,
+      isSelfHostedMode: false,
+      user: {
+        id: 1,
+        email: 'admin@example.com',
+        is_admin: true,
+        is_demo: false,
+        email_verified: true,
+      },
+      billingStatus: null,
+    })
+    mockNotificationsResponse([makeContact()])
+
+    await renderLoadedPage()
+
+    expect(screen.queryByRole('button', { name: 'Add contact' })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Contact actions')).not.toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /Sending/i })).toBeDisabled()
+  })
+
   it('creates an ntfy contact inline with default transaction notification settings', async () => {
     const user = userEvent.setup()
     mockNotificationsResponse([])

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -336,13 +336,12 @@ describe('WalletNotificationsPage', () => {
     await renderLoadedPage()
     await user.click(screen.getByRole('button', { name: 'Add contact' }))
     await user.type(screen.getByLabelText('New contact name'), 'Alice')
-    await user.click(screen.getByRole('button', { name: 'Next' }))
 
     expect(screen.getByRole('combobox', { name: 'Delivery method' })).toHaveTextContent('Email')
     expect(screen.getAllByText('Email')).toHaveLength(1)
   })
 
-  it('creates an ntfy contact inline with default transaction notification settings', async () => {
+  it('creates an ntfy contact inline with selected notification settings', async () => {
     const user = userEvent.setup()
     mockNotificationsResponse([])
 
@@ -350,11 +349,14 @@ describe('WalletNotificationsPage', () => {
     await user.click(screen.getByRole('button', { name: 'Add contact' }))
 
     expect(screen.getByRole('heading', { name: 'New contact' })).toBeInTheDocument()
-    expect(screen.queryByText('Transaction notifications')).not.toBeInTheDocument()
 
     await user.type(screen.getByLabelText('New contact name'), 'Nora')
-    await user.click(screen.getByRole('button', { name: 'Next' }))
-    await screen.findByLabelText('ntfy Topic')
+    expect(screen.getByText('Include wallet balance in transaction notifications')).toBeInTheDocument()
+    await user.click(screen.getByText('RBF replacement'))
+    await user.type(screen.getByPlaceholderText('0.10'), '0.25')
+    await user.click(screen.getByRole('button', { name: 'Add' }))
+    expect(screen.getByText('below 0.25 BTC')).toBeInTheDocument()
+    expect(screen.getByLabelText('ntfy Topic')).toHaveValue('nora-sq32h3ch')
     await user.click(screen.getByRole('button', { name: 'Create contact' }))
 
     await waitFor(() => expect(mockApi.createContact).toHaveBeenCalledTimes(1))
@@ -364,7 +366,7 @@ describe('WalletNotificationsPage', () => {
       [
         {
           provider_type: 'ntfy',
-          notification_target: 'canary-dev-topic',
+          notification_target: 'nora-sq32h3ch',
           is_enabled: true,
         },
       ],
@@ -374,10 +376,39 @@ describe('WalletNotificationsPage', () => {
         notify_receiving: true,
         notify_received: true,
         notify_cpfp: false,
-        notify_rbf: false,
+        notify_rbf: true,
         include_wallet_balance_in_tx_notifications: false,
       }
     )
+    await waitFor(() => expect(mockApi.createBalanceAlert).toHaveBeenCalledTimes(1))
+    expect(mockApi.createBalanceAlert).toHaveBeenCalledWith('sq32h3ch', {
+      contact_id: 'contact-1',
+      alert_type: 'below',
+      threshold_sats: 25000000,
+      threshold_currency: undefined,
+      threshold_fiat_amount: undefined,
+    })
+  })
+
+  it('keeps a manually edited ntfy topic when the new contact name changes', async () => {
+    const user = userEvent.setup()
+    mockNotificationsResponse([])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Add contact' }))
+
+    const nameInput = screen.getByLabelText('New contact name')
+    const topicInput = screen.getByLabelText('ntfy Topic')
+
+    await user.type(nameInput, 'Nora')
+    expect(topicInput).toHaveValue('nora-sq32h3ch')
+
+    await user.clear(topicInput)
+    await user.type(topicInput, 'custom-topic')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'New Nora')
+
+    expect(topicInput).toHaveValue('custom-topic')
   })
 
   it('autosaves transaction notification checkbox changes', async () => {

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -517,10 +517,16 @@ function NewContactWizardCard({
           <section className="space-y-3">
             <h3 className="text-sm font-medium">Delivery method</h3>
             <div className="rounded-md border p-3">
-              <div className="mb-3 flex flex-wrap items-center gap-3">
+              <div
+                className={
+                  providerType === "ntfy"
+                    ? "mb-3 flex flex-wrap items-center gap-3"
+                    : "flex flex-col gap-3 sm:flex-row sm:items-start"
+                }
+              >
                 {availableProviders.length > 1 && (
                   <Select value={providerType} onValueChange={handleProviderChange}>
-                    <SelectTrigger className="w-40" aria-label="Delivery method">
+                    <SelectTrigger className="w-full sm:w-40" aria-label="Delivery method">
                       <div className="flex items-center gap-2">
                         <SelectedProviderIcon className="h-4 w-4" />
                         <SelectValue />
@@ -541,6 +547,88 @@ function NewContactWizardCard({
                     {selectedProvider.label}
                   </div>
                 )}
+                <div className={providerType === "ntfy" ? "hidden" : "min-w-0 flex-1"}>
+                  {providerType === "sms" && (
+                    <SmsProviderFields
+                      phoneNumber={target}
+                      onPhoneNumberChange={(value) => {
+                        setTarget(value)
+                        setError(null)
+                        smsVerification.clearPhoneError()
+                        if (
+                          smsVerification.isVerified ||
+                          (smsVerification.verificationPhone &&
+                            value.trim() !== smsVerification.verificationPhone)
+                        ) {
+                          smsVerification.reset()
+                        }
+                      }}
+                      phonePlaceholder={phonePlaceholder}
+                      phoneError={smsVerification.phoneError}
+                      disabled={isCreating}
+                      containerClassName="space-y-3"
+                      verificationButtonLayout="inline"
+                      verificationRequired
+                      verificationSent={smsVerification.verificationSent}
+                      verificationCode={smsVerification.verificationCode}
+                      onVerificationCodeChange={(code) => {
+                        smsVerification.setVerificationCode(code)
+                        smsVerification.clearVerificationError()
+                      }}
+                      verificationPhone={smsVerification.verificationPhone}
+                      verificationError={smsVerification.verificationError}
+                      isVerified={smsVerification.isVerified}
+                      showSuccess={smsVerification.showSuccess}
+                      isSending={smsVerification.isSending}
+                      isVerifying={smsVerification.isVerifying}
+                      timeRemaining={smsVerification.timeRemaining}
+                      formatTime={smsVerification.formatTime}
+                      onSendVerification={() => smsVerification.sendVerification(target.trim())}
+                      onVerifyCode={() => smsVerification.verifyCode()}
+                      onResendCode={() => smsVerification.resendCode()}
+                    />
+                  )}
+                  {providerType === "email" && (
+                    <EmailProviderFields
+                      emailAddress={target}
+                      onEmailAddressChange={(value) => {
+                        setTarget(value)
+                        setError(null)
+                        emailVerification.clearEmailError()
+                        if (
+                          emailVerification.isVerified ||
+                          (emailVerification.verificationAddress &&
+                            value.trim() !== emailVerification.verificationAddress)
+                        ) {
+                          emailVerification.reset()
+                        }
+                      }}
+                      emailPlaceholder={tCommon("emailPlaceholder")}
+                      emailError={emailVerification.emailError}
+                      disabled={isCreating}
+                      containerClassName="space-y-3"
+                      verificationButtonLayout="inline"
+                      verificationRequired
+                      verificationSent={emailVerification.verificationSent}
+                      verificationCode={emailVerification.verificationCode}
+                      onVerificationCodeChange={(code) => {
+                        emailVerification.setVerificationCode(code)
+                        emailVerification.clearVerificationError()
+                      }}
+                      verificationAddress={emailVerification.verificationAddress}
+                      verificationError={emailVerification.verificationError}
+                      isVerified={emailVerification.isVerified}
+                      showSuccess={emailVerification.showSuccess}
+                      isSending={emailVerification.isSending}
+                      isVerifying={emailVerification.isVerifying}
+                      timeRemaining={emailVerification.timeRemaining}
+                      formatTime={emailVerification.formatTime}
+                      onSendVerification={() => emailVerification.sendVerification(target.trim())}
+                      onVerifyCode={() => emailVerification.verifyCode()}
+                      onResendCode={() => emailVerification.resendCode()}
+                    />
+                  )}
+                </div>
               </div>
               {providerType === "ntfy" && (
                 <NtfyProviderFields
@@ -556,82 +644,6 @@ function NewContactWizardCard({
                   disabled={isCreating}
                   ntfyServerUrl={ntfyServerTarget.url}
                   ntfyServerIsBrowserSafe={ntfyServerTarget.isBrowserSafe}
-                />
-              )}
-              {providerType === "sms" && (
-                <SmsProviderFields
-                  phoneNumber={target}
-                  onPhoneNumberChange={(value) => {
-                    setTarget(value)
-                    setError(null)
-                    smsVerification.clearPhoneError()
-                    if (
-                      smsVerification.isVerified ||
-                      (smsVerification.verificationPhone &&
-                        value.trim() !== smsVerification.verificationPhone)
-                    ) {
-                      smsVerification.reset()
-                    }
-                  }}
-                  phonePlaceholder={phonePlaceholder}
-                  phoneError={smsVerification.phoneError}
-                  disabled={isCreating}
-                  verificationRequired
-                  verificationSent={smsVerification.verificationSent}
-                  verificationCode={smsVerification.verificationCode}
-                  onVerificationCodeChange={(code) => {
-                    smsVerification.setVerificationCode(code)
-                    smsVerification.clearVerificationError()
-                  }}
-                  verificationPhone={smsVerification.verificationPhone}
-                  verificationError={smsVerification.verificationError}
-                  isVerified={smsVerification.isVerified}
-                  showSuccess={smsVerification.showSuccess}
-                  isSending={smsVerification.isSending}
-                  isVerifying={smsVerification.isVerifying}
-                  timeRemaining={smsVerification.timeRemaining}
-                  formatTime={smsVerification.formatTime}
-                  onSendVerification={() => smsVerification.sendVerification(target.trim())}
-                  onVerifyCode={() => smsVerification.verifyCode()}
-                  onResendCode={() => smsVerification.resendCode()}
-                />
-              )}
-              {providerType === "email" && (
-                <EmailProviderFields
-                  emailAddress={target}
-                  onEmailAddressChange={(value) => {
-                    setTarget(value)
-                    setError(null)
-                    emailVerification.clearEmailError()
-                    if (
-                      emailVerification.isVerified ||
-                      (emailVerification.verificationAddress &&
-                        value.trim() !== emailVerification.verificationAddress)
-                    ) {
-                      emailVerification.reset()
-                    }
-                  }}
-                  emailPlaceholder={tCommon("emailPlaceholder")}
-                  emailError={emailVerification.emailError}
-                  disabled={isCreating}
-                  verificationRequired
-                  verificationSent={emailVerification.verificationSent}
-                  verificationCode={emailVerification.verificationCode}
-                  onVerificationCodeChange={(code) => {
-                    emailVerification.setVerificationCode(code)
-                    emailVerification.clearVerificationError()
-                  }}
-                  verificationAddress={emailVerification.verificationAddress}
-                  verificationError={emailVerification.verificationError}
-                  isVerified={emailVerification.isVerified}
-                  showSuccess={emailVerification.showSuccess}
-                  isSending={emailVerification.isSending}
-                  isVerifying={emailVerification.isVerifying}
-                  timeRemaining={emailVerification.timeRemaining}
-                  formatTime={emailVerification.formatTime}
-                  onSendVerification={() => emailVerification.sendVerification(target.trim())}
-                  onVerifyCode={() => emailVerification.verifyCode()}
-                  onResendCode={() => emailVerification.resendCode()}
                 />
               )}
             </div>

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -61,6 +61,7 @@ import {
   satsToBtc,
 } from "@/lib/utils"
 import { useTranslations } from "next-intl"
+import { parsePhoneNumberFromString } from "libphonenumber-js"
 import type { BalanceAlert, Contact, Wallet } from "@/types"
 
 type MethodDraft = {
@@ -96,6 +97,14 @@ const PROVIDERS = [
   { value: "sms", label: "SMS", icon: MessageCircle },
   { value: "ntfy", label: "ntfy", icon: Bell },
 ] as const
+
+function formatDeliveryTarget(method: MethodDraft) {
+  const target = method.notification_target.trim()
+  if (method.provider_type !== "sms" || !target) {
+    return target
+  }
+  return parsePhoneNumberFromString(target)?.formatInternational() ?? target
+}
 
 const THRESHOLD_TYPES = [
   { value: "above", labelKey: "thresholdTypes.above", icon: TrendingUp },
@@ -747,7 +756,7 @@ function ContactNotificationCard({
       : draft.methods
           .map((method) => {
             const provider = PROVIDERS.find((item) => item.value === method.provider_type)
-            const target = method.notification_target.trim()
+            const target = formatDeliveryTarget(method)
             return tNotifications("delivery.summary", {
               provider: provider?.label ?? method.provider_type,
               target: target || tNotifications("delivery.notSet"),

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -1016,7 +1016,7 @@ function ContactNotificationCard({
                       : "grid gap-2 sm:grid-cols-[120px_1fr_auto]"
                   }
                 >
-                  <div className="flex items-center gap-2 text-sm">
+                  <div className="flex h-9 items-center gap-2 self-start text-sm">
                     {!hasSingleEditableDeliveryMethod && (
                       <Checkbox
                         checked={method.is_enabled}

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -518,14 +518,13 @@ function NewContactWizardCard({
             <h3 className="text-sm font-medium">Delivery method</h3>
             <div className="rounded-md border p-3">
               <div className="mb-3 flex flex-wrap items-center gap-3">
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <SelectedProviderIcon className="h-4 w-4" />
-                  {selectedProvider.label}
-                </div>
                 {availableProviders.length > 1 && (
                   <Select value={providerType} onValueChange={handleProviderChange}>
                     <SelectTrigger className="w-40" aria-label="Delivery method">
-                      <SelectValue />
+                      <div className="flex items-center gap-2">
+                        <SelectedProviderIcon className="h-4 w-4" />
+                        <SelectValue />
+                      </div>
                     </SelectTrigger>
                     <SelectContent>
                       {availableProviders.map((provider) => (
@@ -535,6 +534,12 @@ function NewContactWizardCard({
                       ))}
                     </SelectContent>
                   </Select>
+                )}
+                {availableProviders.length === 1 && (
+                  <div className="flex h-9 items-center gap-2 text-sm font-medium">
+                    <SelectedProviderIcon className="h-4 w-4" />
+                    {selectedProvider.label}
+                  </div>
                 )}
               </div>
               {providerType === "ntfy" && (

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -476,6 +476,30 @@ function NewContactWizardCard({
     }
   }
 
+  const deliveryMethodControl =
+    availableProviders.length > 1 ? (
+      <Select value={providerType} onValueChange={handleProviderChange}>
+        <SelectTrigger className="w-40 shrink-0" aria-label="Delivery method">
+          <div className="flex items-center gap-2">
+            <SelectedProviderIcon className="h-4 w-4" />
+            <SelectValue />
+          </div>
+        </SelectTrigger>
+        <SelectContent>
+          {availableProviders.map((provider) => (
+            <SelectItem key={provider.value} value={provider.value}>
+              {provider.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    ) : (
+      <div className="flex h-9 w-40 shrink-0 items-center gap-2 text-sm font-medium">
+        <SelectedProviderIcon className="h-4 w-4" />
+        {selectedProvider.label}
+      </div>
+    )
+
   return (
     <Card>
       <CardHeader>
@@ -517,119 +541,6 @@ function NewContactWizardCard({
           <section className="space-y-3">
             <h3 className="text-sm font-medium">Delivery method</h3>
             <div className="rounded-md border p-3">
-              <div
-                className={
-                  providerType === "ntfy"
-                    ? "mb-3 flex flex-wrap items-center gap-3"
-                    : "grid gap-3 sm:grid-cols-[10rem_minmax(0,1fr)] sm:items-start"
-                }
-              >
-                {availableProviders.length > 1 && (
-                  <Select value={providerType} onValueChange={handleProviderChange}>
-                    <SelectTrigger className="w-full" aria-label="Delivery method">
-                      <div className="flex items-center gap-2">
-                        <SelectedProviderIcon className="h-4 w-4" />
-                        <SelectValue />
-                      </div>
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableProviders.map((provider) => (
-                        <SelectItem key={provider.value} value={provider.value}>
-                          {provider.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-                {availableProviders.length === 1 && (
-                  <div className="flex h-9 items-center gap-2 text-sm font-medium">
-                    <SelectedProviderIcon className="h-4 w-4" />
-                    {selectedProvider.label}
-                  </div>
-                )}
-                <div className={providerType === "ntfy" ? "hidden" : "min-w-0 flex-1"}>
-                  {providerType === "sms" && (
-                    <SmsProviderFields
-                      phoneNumber={target}
-                      onPhoneNumberChange={(value) => {
-                        setTarget(value)
-                        setError(null)
-                        smsVerification.clearPhoneError()
-                        if (
-                          smsVerification.isVerified ||
-                          (smsVerification.verificationPhone &&
-                            value.trim() !== smsVerification.verificationPhone)
-                        ) {
-                          smsVerification.reset()
-                        }
-                      }}
-                      phonePlaceholder={phonePlaceholder}
-                      phoneError={smsVerification.phoneError}
-                      disabled={isCreating}
-                      containerClassName="space-y-3"
-                      verificationButtonLayout="inline"
-                      verificationRequired
-                      verificationSent={smsVerification.verificationSent}
-                      verificationCode={smsVerification.verificationCode}
-                      onVerificationCodeChange={(code) => {
-                        smsVerification.setVerificationCode(code)
-                        smsVerification.clearVerificationError()
-                      }}
-                      verificationPhone={smsVerification.verificationPhone}
-                      verificationError={smsVerification.verificationError}
-                      isVerified={smsVerification.isVerified}
-                      showSuccess={smsVerification.showSuccess}
-                      isSending={smsVerification.isSending}
-                      isVerifying={smsVerification.isVerifying}
-                      timeRemaining={smsVerification.timeRemaining}
-                      formatTime={smsVerification.formatTime}
-                      onSendVerification={() => smsVerification.sendVerification(target.trim())}
-                      onVerifyCode={() => smsVerification.verifyCode()}
-                      onResendCode={() => smsVerification.resendCode()}
-                    />
-                  )}
-                  {providerType === "email" && (
-                    <EmailProviderFields
-                      emailAddress={target}
-                      onEmailAddressChange={(value) => {
-                        setTarget(value)
-                        setError(null)
-                        emailVerification.clearEmailError()
-                        if (
-                          emailVerification.isVerified ||
-                          (emailVerification.verificationAddress &&
-                            value.trim() !== emailVerification.verificationAddress)
-                        ) {
-                          emailVerification.reset()
-                        }
-                      }}
-                      emailPlaceholder={tCommon("emailPlaceholder")}
-                      emailError={emailVerification.emailError}
-                      disabled={isCreating}
-                      containerClassName="space-y-3"
-                      verificationButtonLayout="inline"
-                      verificationRequired
-                      verificationSent={emailVerification.verificationSent}
-                      verificationCode={emailVerification.verificationCode}
-                      onVerificationCodeChange={(code) => {
-                        emailVerification.setVerificationCode(code)
-                        emailVerification.clearVerificationError()
-                      }}
-                      verificationAddress={emailVerification.verificationAddress}
-                      verificationError={emailVerification.verificationError}
-                      isVerified={emailVerification.isVerified}
-                      showSuccess={emailVerification.showSuccess}
-                      isSending={emailVerification.isSending}
-                      isVerifying={emailVerification.isVerifying}
-                      timeRemaining={emailVerification.timeRemaining}
-                      formatTime={emailVerification.formatTime}
-                      onSendVerification={() => emailVerification.sendVerification(target.trim())}
-                      onVerifyCode={() => emailVerification.verifyCode()}
-                      onResendCode={() => emailVerification.resendCode()}
-                    />
-                  )}
-                </div>
-              </div>
               {providerType === "ntfy" && (
                 <NtfyProviderFields
                   topic={ntfyTopic}
@@ -644,6 +555,91 @@ function NewContactWizardCard({
                   disabled={isCreating}
                   ntfyServerUrl={ntfyServerTarget.url}
                   ntfyServerIsBrowserSafe={ntfyServerTarget.isBrowserSafe}
+                  containerClassName="space-y-2"
+                  leadingControl={deliveryMethodControl}
+                  inline
+                />
+              )}
+              {providerType === "sms" && (
+                <SmsProviderFields
+                  phoneNumber={target}
+                  onPhoneNumberChange={(value) => {
+                    setTarget(value)
+                    setError(null)
+                    smsVerification.clearPhoneError()
+                    if (
+                      smsVerification.isVerified ||
+                      (smsVerification.verificationPhone &&
+                        value.trim() !== smsVerification.verificationPhone)
+                    ) {
+                      smsVerification.reset()
+                    }
+                  }}
+                  phonePlaceholder={phonePlaceholder}
+                  phoneError={smsVerification.phoneError}
+                  disabled={isCreating}
+                  containerClassName="space-y-3"
+                  verificationButtonLayout="inline"
+                  leadingControl={deliveryMethodControl}
+                  verificationRequired
+                  verificationSent={smsVerification.verificationSent}
+                  verificationCode={smsVerification.verificationCode}
+                  onVerificationCodeChange={(code) => {
+                    smsVerification.setVerificationCode(code)
+                    smsVerification.clearVerificationError()
+                  }}
+                  verificationPhone={smsVerification.verificationPhone}
+                  verificationError={smsVerification.verificationError}
+                  isVerified={smsVerification.isVerified}
+                  showSuccess={smsVerification.showSuccess}
+                  isSending={smsVerification.isSending}
+                  isVerifying={smsVerification.isVerifying}
+                  timeRemaining={smsVerification.timeRemaining}
+                  formatTime={smsVerification.formatTime}
+                  onSendVerification={() => smsVerification.sendVerification(target.trim())}
+                  onVerifyCode={() => smsVerification.verifyCode()}
+                  onResendCode={() => smsVerification.resendCode()}
+                />
+              )}
+              {providerType === "email" && (
+                <EmailProviderFields
+                  emailAddress={target}
+                  onEmailAddressChange={(value) => {
+                    setTarget(value)
+                    setError(null)
+                    emailVerification.clearEmailError()
+                    if (
+                      emailVerification.isVerified ||
+                      (emailVerification.verificationAddress &&
+                        value.trim() !== emailVerification.verificationAddress)
+                    ) {
+                      emailVerification.reset()
+                    }
+                  }}
+                  emailPlaceholder={tCommon("emailPlaceholder")}
+                  emailError={emailVerification.emailError}
+                  disabled={isCreating}
+                  containerClassName="space-y-3"
+                  verificationButtonLayout="inline"
+                  leadingControl={deliveryMethodControl}
+                  verificationRequired
+                  verificationSent={emailVerification.verificationSent}
+                  verificationCode={emailVerification.verificationCode}
+                  onVerificationCodeChange={(code) => {
+                    emailVerification.setVerificationCode(code)
+                    emailVerification.clearVerificationError()
+                  }}
+                  verificationAddress={emailVerification.verificationAddress}
+                  verificationError={emailVerification.verificationError}
+                  isVerified={emailVerification.isVerified}
+                  showSuccess={emailVerification.showSuccess}
+                  isSending={emailVerification.isSending}
+                  isVerifying={emailVerification.isVerifying}
+                  timeRemaining={emailVerification.timeRemaining}
+                  formatTime={emailVerification.formatTime}
+                  onSendVerification={() => emailVerification.sendVerification(target.trim())}
+                  onVerifyCode={() => emailVerification.verifyCode()}
+                  onResendCode={() => emailVerification.resendCode()}
                 />
               )}
             </div>

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -995,6 +995,10 @@ function ContactNotificationCard({
               )
               const isNewMethod = !originalMethod
               const canEditTarget = method.provider_type === "ntfy" || isNewMethod
+              const isUnverifiedNewVerifiableMethod =
+                isNewMethod &&
+                ((method.provider_type === "sms" && !smsVerification.isVerified) ||
+                  (method.provider_type === "email" && !emailVerification.isVerified))
               return (
                 <div
                   key={`${method.provider_type}-${index}`}
@@ -1046,6 +1050,7 @@ function ContactNotificationCard({
                       phonePlaceholder={phonePlaceholder}
                       phoneError={smsVerification.phoneError}
                       disabled={isSaving}
+                      containerClassName="space-y-3"
                       verificationRequired={!smsVerification.isVerified}
                       verificationSent={smsVerification.verificationSent}
                       verificationCode={smsVerification.verificationCode}
@@ -1092,6 +1097,7 @@ function ContactNotificationCard({
                       emailPlaceholder={tCommon("emailPlaceholder")}
                       emailError={emailVerification.emailError}
                       disabled={isSaving}
+                      containerClassName="space-y-3"
                       verificationRequired={!emailVerification.isVerified}
                       verificationSent={emailVerification.verificationSent}
                       verificationCode={emailVerification.verificationCode}
@@ -1131,7 +1137,7 @@ function ContactNotificationCard({
                       }
                     />
                   )}
-                  {!hasSingleEditableDeliveryMethod && (
+                  {!hasSingleEditableDeliveryMethod && !isUnverifiedNewVerifiableMethod && (
                     <Button
                       variant="ghost"
                       size="icon"

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -1059,6 +1059,7 @@ function ContactNotificationCard({
                       phoneError={smsVerification.phoneError}
                       disabled={isSaving}
                       containerClassName="space-y-3"
+                      verificationButtonLayout="inline"
                       verificationRequired={!smsVerification.isVerified}
                       verificationSent={smsVerification.verificationSent}
                       verificationCode={smsVerification.verificationCode}
@@ -1106,6 +1107,7 @@ function ContactNotificationCard({
                       emailError={emailVerification.emailError}
                       disabled={isSaving}
                       containerClassName="space-y-3"
+                      verificationButtonLayout="inline"
                       verificationRequired={!emailVerification.isVerified}
                       verificationSent={emailVerification.verificationSent}
                       verificationCode={emailVerification.verificationCode}

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -521,12 +521,12 @@ function NewContactWizardCard({
                 className={
                   providerType === "ntfy"
                     ? "mb-3 flex flex-wrap items-center gap-3"
-                    : "flex flex-col gap-3 sm:flex-row sm:items-start"
+                    : "grid gap-3 sm:grid-cols-[10rem_minmax(0,1fr)] sm:items-start"
                 }
               >
                 {availableProviders.length > 1 && (
                   <Select value={providerType} onValueChange={handleProviderChange}>
-                    <SelectTrigger className="w-full sm:w-40" aria-label="Delivery method">
+                    <SelectTrigger className="w-full" aria-label="Delivery method">
                       <div className="flex items-center gap-2">
                         <SelectedProviderIcon className="h-4 w-4" />
                         <SelectValue />

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -304,6 +304,7 @@ function NewContactWizardCard({
   onCancel: () => void
   onCreated: () => void
 }) {
+  const tContacts = useTranslations("contacts")
   const tCommon = useTranslations("common")
   const tApiErrors = useTranslations("errors.api")
   const phonePlaceholder = usePhonePlaceholder()
@@ -372,7 +373,7 @@ function NewContactWizardCard({
 
   const nextFromName = () => {
     if (!name.trim()) {
-      setError("Enter a contact name")
+      setError(tContacts("errors.nameRequired"))
       return
     }
     setError(null)
@@ -383,15 +384,19 @@ function NewContactWizardCard({
     if (!targetValue.trim()) {
       setError(
         providerType === "ntfy"
-          ? "Enter an ntfy topic"
+          ? tContacts("errors.ntfyTopicRequired")
           : providerType === "sms"
-            ? "Enter a phone number"
-            : "Enter an email address"
+            ? tContacts("errors.phoneRequired")
+            : tContacts("errors.emailRequired")
       )
       return
     }
     if (!providerVerified) {
-      setError(providerType === "sms" ? "Verify the phone number first" : "Verify the email first")
+      setError(
+        providerType === "sms"
+          ? tContacts("verification.verifyNewSms")
+          : tContacts("verification.verifyNewEmail")
+      )
       return
     }
     setError(null)
@@ -400,7 +405,7 @@ function NewContactWizardCard({
 
   const createContact = async () => {
     if (!name.trim()) {
-      setError("Enter a contact name")
+      setError(tContacts("errors.nameRequired"))
       return
     }
     if (!validateMethod()) {
@@ -630,6 +635,7 @@ function ContactNotificationCard({
   onSaved: () => void
   onDeleted: () => void
 }) {
+  const tContacts = useTranslations("contacts")
   const tCommon = useTranslations("common")
   const phonePlaceholder = usePhonePlaceholder()
   const ntfyServerTarget = useNtfyServerTarget()
@@ -749,21 +755,21 @@ function ContactNotificationCard({
     if (blankMethod) {
       setContactError(
         blankMethod.provider_type === "ntfy"
-          ? "Enter an ntfy topic"
+          ? tContacts("errors.ntfyTopicRequired")
           : blankMethod.provider_type === "sms"
-            ? "Enter a phone number"
-            : "Enter an email address"
+            ? tContacts("errors.phoneRequired")
+            : tContacts("errors.emailRequired")
       )
       return
     }
 
     if (addedSmsMethod && !smsVerification.isVerified) {
-      setContactError("Verify the phone number first")
+      setContactError(tContacts("verification.verifyNewSms"))
       return
     }
 
     if (addedEmailMethod && !emailVerification.isVerified) {
-      setContactError("Verify the email first")
+      setContactError(tContacts("verification.verifyNewEmail"))
       return
     }
 
@@ -793,6 +799,8 @@ function ContactNotificationCard({
       latestTxDraftRef.current = savedDraft
       latestContactDraftRef.current = savedDraft
       setIsEditingContact(false)
+      smsVerification.reset()
+      emailVerification.reset()
       onSaved()
     } catch (err) {
       setContactError(err instanceof Error ? err.message : "Failed to save contact")

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -62,7 +62,7 @@ import {
 } from "@/lib/utils"
 import { useTranslations } from "next-intl"
 import { parsePhoneNumberFromString } from "libphonenumber-js"
-import type { BalanceAlert, Contact, Wallet } from "@/types"
+import type { BalanceAlert, Contact, CreateBalanceAlertRequest, Wallet } from "@/types"
 
 type MethodDraft = {
   provider_type: "email" | "sms" | "ntfy"
@@ -80,6 +80,10 @@ type ContactDraft = {
   notify_cpfp: boolean
   notify_rbf: boolean
   include_wallet_balance_in_tx_notifications: boolean
+}
+
+type BalanceAlertDraft = Omit<CreateBalanceAlertRequest, "contact_id"> & {
+  id: string
 }
 
 const DEFAULT_NEW_CONTACT_TX_SETTINGS: Omit<ContactDraft, "name" | "methods"> = {
@@ -234,6 +238,18 @@ function txSettingsFromDraft(draft: ContactDraft) {
   }
 }
 
+function formatBalanceAlertDraft(
+  alert: Pick<
+    CreateBalanceAlertRequest,
+    "alert_type" | "threshold_sats" | "threshold_currency" | "threshold_fiat_amount"
+  >
+) {
+  if (alert.threshold_currency && alert.threshold_fiat_amount) {
+    return `${alert.threshold_fiat_amount} ${alert.threshold_currency}`
+  }
+  return `${satsToBtc(alert.threshold_sats ?? 0)} BTC`
+}
+
 function nullableThresholdFieldMatches<T>(
   left: T | null | undefined,
   right: T | null | undefined
@@ -328,21 +344,33 @@ function TransactionEventGroups({
 function NewContactWizardCard({
   walletChecksum,
   isSelfHostedMode,
+  preferredFiatCurrency,
   onCancel,
   onCreated,
 }: {
   walletChecksum: string
   isSelfHostedMode: boolean
+  preferredFiatCurrency: string
   onCancel: () => void
   onCreated: () => void
 }) {
   const tContacts = useTranslations("contacts")
   const tCommon = useTranslations("common")
   const tApiErrors = useTranslations("errors.api")
+  const tNotifications = useTranslations("walletNotifications")
   const phonePlaceholder = usePhonePlaceholder()
   const ntfyServerTarget = useNtfyServerTarget()
-  const [step, setStep] = useState(0)
   const [name, setName] = useState("")
+  const [txDraft, setTxDraft] = useState<ContactDraft>({
+    name: "",
+    methods: [],
+    ...DEFAULT_NEW_CONTACT_TX_SETTINGS,
+  })
+  const [draftBalanceAlerts, setDraftBalanceAlerts] = useState<BalanceAlertDraft[]>([])
+  const [thresholdType, setThresholdType] = useState<"below" | "above" | "equals">("below")
+  const [thresholdAmount, setThresholdAmount] = useState("")
+  const [thresholdCurrency, setThresholdCurrency] = useState("BTC")
+  const [thresholdError, setThresholdError] = useState<string | null>(null)
   const [providerType, setProviderType] = useState<MethodDraft["provider_type"]>(
     isSelfHostedMode ? "ntfy" : "email"
   )
@@ -375,22 +403,18 @@ function NewContactWizardCard({
   const SelectedProviderIcon = selectedProvider.icon
 
   useEffect(() => {
-    if (providerType === "ntfy" && ntfyServerTarget.defaultTopic && !userEditedNtfyTopic) {
-      setNtfyTopic(ntfyServerTarget.defaultTopic)
-    }
-  }, [providerType, ntfyServerTarget.defaultTopic, userEditedNtfyTopic])
-
-  useEffect(() => {
-    if (providerType === "ntfy" && !ntfyServerTarget.defaultTopic && !userEditedNtfyTopic) {
+    if (providerType === "ntfy" && !userEditedNtfyTopic) {
       setNtfyTopic(generateDefaultNtfyTopic(name || "contact", walletChecksum))
     }
-  }, [name, providerType, ntfyServerTarget.defaultTopic, userEditedNtfyTopic, walletChecksum])
+  }, [name, providerType, userEditedNtfyTopic, walletChecksum])
 
   const targetValue = providerType === "ntfy" ? ntfyTopic : target
   const providerVerified =
     providerType === "ntfy" ||
     (providerType === "sms" && smsVerification.isVerified) ||
     (providerType === "email" && emailVerification.isVerified)
+  const hasTxNotifications = hasSelectedTxNotifications(txDraft)
+  const fiatThresholdCurrency = preferredFiatCurrency || "USD"
 
   const handleProviderChange = (value: string) => {
     setProviderType(value as MethodDraft["provider_type"])
@@ -399,17 +423,43 @@ function NewContactWizardCard({
     smsVerification.reset()
     emailVerification.reset()
     if (value === "ntfy" && !ntfyTopic && !userEditedNtfyTopic) {
-      setNtfyTopic(ntfyServerTarget.defaultTopic || generateDefaultNtfyTopic(name || "contact", walletChecksum))
+      setNtfyTopic(generateDefaultNtfyTopic(name || "contact", walletChecksum))
     }
   }
 
-  const nextFromName = () => {
-    if (!name.trim()) {
-      setError(tContacts("errors.nameRequired"))
-      return
+  const addDraftThreshold = () => {
+    setThresholdError(null)
+    if (thresholdCurrency === "BTC") {
+      const btc = parseBtcInput(thresholdAmount)
+      if (btc === null) {
+        setThresholdError("Enter a valid BTC amount")
+        return
+      }
+      setDraftBalanceAlerts((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          alert_type: thresholdType,
+          threshold_sats: btcToSats(btc),
+        },
+      ])
+    } else {
+      const amount = Number.parseFloat(thresholdAmount)
+      if (!Number.isFinite(amount) || amount <= 0) {
+        setThresholdError("Enter a valid fiat amount")
+        return
+      }
+      setDraftBalanceAlerts((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          alert_type: thresholdType,
+          threshold_currency: thresholdCurrency,
+          threshold_fiat_amount: amount,
+        },
+      ])
     }
-    setError(null)
-    setStep(1)
+    setThresholdAmount("")
   }
 
   const validateMethod = () => {
@@ -447,7 +497,7 @@ function NewContactWizardCard({
     setIsCreating(true)
     setError(null)
     try {
-      await api.createContact(
+      const createdContact = await api.createContact(
         walletChecksum,
         name.trim(),
         [
@@ -463,11 +513,24 @@ function NewContactWizardCard({
           },
         ],
         txSettingsFromDraft({
+          ...txDraft,
           name: name.trim(),
           methods: [],
-          ...DEFAULT_NEW_CONTACT_TX_SETTINGS,
         })
       )
+      if (draftBalanceAlerts.length > 0) {
+        await Promise.all(
+          draftBalanceAlerts.map((alert) =>
+            api.createBalanceAlert(walletChecksum, {
+              contact_id: createdContact.id,
+              alert_type: alert.alert_type,
+              threshold_sats: alert.threshold_sats,
+              threshold_currency: alert.threshold_currency,
+              threshold_fiat_amount: alert.threshold_fiat_amount,
+            })
+          )
+        )
+      }
       onCreated()
     } catch (err) {
       setError(err instanceof ApiError ? getTranslatedApiError(err, tApiErrors) : "Failed to create contact")
@@ -514,33 +577,175 @@ function NewContactWizardCard({
       </CardHeader>
       <CardContent className="space-y-6">
         <section className="space-y-3">
-          <h3 className="text-sm font-medium">Name</h3>
+          <label className="block text-sm text-muted-foreground" htmlFor="new-contact-name">
+            Name
+          </label>
           <Input
+            id="new-contact-name"
             value={name}
             onChange={(event) => {
               const nextName = event.target.value
               setName(nextName)
-              if (providerType === "ntfy" && !ntfyServerTarget.defaultTopic && !userEditedNtfyTopic) {
-                setNtfyTopic(generateDefaultNtfyTopic(nextName || "contact", walletChecksum))
-              }
             }}
             placeholder="Alice"
             disabled={isCreating}
             aria-label="New contact name"
           />
-          {step === 0 && (
-            <div className="flex justify-end">
-              <Button onClick={nextFromName} disabled={isCreating}>
-                Next
-              </Button>
-            </div>
-          )}
         </section>
 
-        {step >= 1 && (
-          <section className="space-y-3">
-            <h3 className="text-sm font-medium">Delivery method</h3>
-            <div className="rounded-md border p-3">
+        <section className="space-y-3">
+          <div className="space-y-5 rounded-md border p-3">
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium text-muted-foreground">
+                {tNotifications("transaction.title")}
+              </h3>
+              <label className="flex items-start gap-2 text-sm">
+                <Checkbox
+                  checked={
+                    hasTxNotifications &&
+                    txDraft.include_wallet_balance_in_tx_notifications
+                  }
+                  disabled={!hasTxNotifications || isCreating}
+                  className={
+                    !hasTxNotifications || isCreating ? "cursor-not-allowed" : undefined
+                  }
+                  onCheckedChange={(checked) =>
+                    setTxDraft((prev) => ({
+                      ...prev,
+                      include_wallet_balance_in_tx_notifications: checked === true,
+                    }))
+                  }
+                />
+                <span className="space-y-1">
+                  <span className="block font-medium">
+                    {tNotifications("transaction.includeBalance")}
+                  </span>
+                  <span className="block text-xs leading-snug text-muted-foreground">
+                    {hasTxNotifications
+                      ? tNotifications("transaction.includeBalanceDescription")
+                      : tNotifications("transaction.selectTypeFirst")}
+                  </span>
+                </span>
+              </label>
+              <TransactionEventGroups
+                groups={EVENT_GROUPS}
+                draft={txDraft}
+                onChange={(key, checked) =>
+                  setTxDraft((prev) => ({ ...prev, [key]: checked }))
+                }
+              />
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium text-muted-foreground">
+                {tNotifications("balance.title")}
+              </h3>
+              {draftBalanceAlerts.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {draftBalanceAlerts.map((alert) => (
+                    <div
+                      key={alert.id}
+                      className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                    >
+                      <span>
+                        {tNotifications(ALERT_TYPE_LABEL_KEYS[alert.alert_type])}{" "}
+                        {formatBalanceAlertDraft(alert)}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() =>
+                          setDraftBalanceAlerts((prev) =>
+                            prev.filter((item) => item.id !== alert.id)
+                          )
+                        }
+                        aria-label="Delete threshold"
+                        className="h-7 w-7"
+                        disabled={isCreating}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="flex flex-wrap items-center gap-3">
+                <RadioGroup
+                  value={thresholdType}
+                  onValueChange={(value) => {
+                    setThresholdType(value as typeof thresholdType)
+                    setThresholdError(null)
+                  }}
+                  className="flex flex-wrap items-center gap-4"
+                  aria-label="Threshold type"
+                >
+                  {THRESHOLD_TYPES.map((type) => {
+                    const Icon = type.icon
+                    return (
+                      <label
+                        key={type.value}
+                        className="flex items-center gap-2 text-sm"
+                        htmlFor={`new-threshold-${type.value}`}
+                      >
+                        <RadioGroupItem
+                          value={type.value}
+                          id={`new-threshold-${type.value}`}
+                        />
+                        <Icon className="h-4 w-4 text-muted-foreground" />
+                        {tNotifications(type.labelKey)}
+                      </label>
+                    )
+                  })}
+                </RadioGroup>
+                <Input
+                  value={thresholdAmount}
+                  onChange={(event) => {
+                    setThresholdAmount(event.target.value)
+                    setThresholdError(null)
+                  }}
+                  placeholder={thresholdCurrency === "BTC" ? "0.10" : "10000"}
+                  className="w-[120px]"
+                  disabled={isCreating}
+                />
+                <Select
+                  value={thresholdCurrency}
+                  onValueChange={(value) => {
+                    setThresholdCurrency(value)
+                    setThresholdError(null)
+                  }}
+                  disabled={isCreating}
+                >
+                  <SelectTrigger className="w-[120px]" aria-label="Threshold currency">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="BTC">BTC</SelectItem>
+                    <SelectItem value={fiatThresholdCurrency}>
+                      {fiatThresholdCurrency}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  onClick={addDraftThreshold}
+                  disabled={!thresholdAmount.trim() || isCreating}
+                  className="w-[160px] whitespace-nowrap"
+                >
+                  <Plus className="h-4 w-4" />
+                  Add
+                </Button>
+              </div>
+              {thresholdError && (
+                <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {thresholdError}
+                </p>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h3 className="text-sm font-medium text-muted-foreground">Delivery method</h3>
+          <div className="rounded-md border p-3">
               {providerType === "ntfy" && (
                 <NtfyProviderFields
                   topic={ntfyTopic}
@@ -642,16 +847,13 @@ function NewContactWizardCard({
                   onResendCode={() => emailVerification.resendCode()}
                 />
               )}
-            </div>
-            {step === 1 && (
-              <div className="flex justify-end">
-                <Button onClick={createContact} disabled={isCreating}>
-                  {isCreating ? tCommon("saving") : "Create contact"}
-                </Button>
-              </div>
-            )}
-          </section>
-        )}
+          </div>
+          <div className="flex justify-end">
+            <Button onClick={createContact} disabled={isCreating}>
+              {isCreating ? tCommon("saving") : "Create contact"}
+            </Button>
+          </div>
+        </section>
 
         {error && (
           <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -1582,6 +1784,7 @@ export default function WalletNotificationsPage() {
             <NewContactWizardCard
               walletChecksum={wallet!.checksum}
               isSelfHostedMode={isSelfHostedMode}
+              preferredFiatCurrency={preferredFiatCurrency}
               onCancel={() => setIsCreatingContact(false)}
               onCreated={() => {
                 setIsCreatingContact(false)

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -162,6 +162,12 @@ const TX_NOTIFICATION_KEYS = [
 
 type TxNotificationKey = (typeof TX_NOTIFICATION_KEYS)[number]
 
+const ALERT_TYPE_LABEL_KEYS = {
+  above: "alertTypes.above",
+  equals: "alertTypes.equals",
+  below: "alertTypes.below",
+} as const satisfies Record<BalanceAlert["alert_type"], string>
+
 function sanitizeForNtfyTopic(name: string): string {
   return name
     .toLowerCase()
@@ -1289,7 +1295,7 @@ function ContactNotificationCard({
               {alerts.map((alert) => (
                 <div key={alert.id} className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
                   <span>
-                    {tNotifications(`alertTypes.${alert.alert_type}`)}{" "}
+                    {tNotifications(ALERT_TYPE_LABEL_KEYS[alert.alert_type])}{" "}
                     {alert.threshold_currency && alert.threshold_fiat_amount
                       ? `${alert.threshold_fiat_amount} ${alert.threshold_currency}`
                       : `${satsToBtc(alert.threshold_sats)} BTC`}

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -698,6 +698,7 @@ function ContactNotificationCard({
   }, [isSelfHostedMode])
 
   const addableProviders = useMemo(() => {
+    // Editing may add any delivery method type not currently present in the draft.
     return availableProviders.filter(
       (provider) =>
         !editDraft.methods.some((method) => method.provider_type === provider.value)
@@ -726,6 +727,12 @@ function ContactNotificationCard({
   const hasTxNotifications = hasSelectedTxNotifications(draft)
   const hasSingleEditableDeliveryMethod = editDraft.methods.length === 1
   const fiatThresholdCurrency = preferredFiatCurrency || "USD"
+  const hasSavedDeliveryTarget = (method: MethodDraft) =>
+    draft.methods.some(
+      (savedMethod) =>
+        savedMethod.provider_type === method.provider_type &&
+        savedMethod.notification_target.trim() === method.notification_target.trim()
+    )
   const deliverySummary =
     draft.methods.length === 0
       ? tNotifications("delivery.noMethods")
@@ -767,12 +774,12 @@ function ContactNotificationCard({
     const addedSmsMethod = nextContactDraft.methods.find(
       (method) =>
         method.provider_type === "sms" &&
-        !draft.methods.some((savedMethod) => savedMethod.provider_type === "sms")
+        !hasSavedDeliveryTarget(method)
     )
     const addedEmailMethod = nextContactDraft.methods.find(
       (method) =>
         method.provider_type === "email" &&
-        !draft.methods.some((savedMethod) => savedMethod.provider_type === "email")
+        !hasSavedDeliveryTarget(method)
     )
 
     if (blankMethod) {
@@ -1185,7 +1192,10 @@ function ContactNotificationCard({
                         notification_target:
                           providerToAdd.value === "ntfy"
                             ? ntfyServerTarget.defaultTopic ||
-                              generateDefaultNtfyTopic(draft.name || "contact", walletChecksum)
+                              generateDefaultNtfyTopic(
+                                editDraft.name || draft.name || "contact",
+                                walletChecksum
+                              )
                             : "",
                         is_enabled: true,
                       },
@@ -1451,7 +1461,8 @@ export default function WalletNotificationsPage() {
   }, [contacts])
 
   const currentTier = billingStatus?.subscription_tier || user?.subscription_tier || "personal"
-  const isCloudReadOnlyUser =
+  // Cloud admins and demo users inspect shared demo data, so notification controls stay view-only.
+  const isCloudViewOnlyUser =
     isCloudMode && (user?.is_admin === true || user?.is_demo === true)
   const contactLimitReached =
     isCloudMode && hasReachedContactLimit(contacts.length, currentTier)
@@ -1516,7 +1527,7 @@ export default function WalletNotificationsPage() {
               {tNotifications("description")}
             </p>
           </div>
-          {!isCreatingContact && !isCloudReadOnlyUser && (
+          {!isCreatingContact && !isCloudViewOnlyUser && (
             <Button onClick={startContactCreation}>
               <Plus className="h-4 w-4" />
               {tNotifications("addContact")}
@@ -1588,7 +1599,7 @@ export default function WalletNotificationsPage() {
                   alerts={alertsByContact[contact.id] || []}
                   walletChecksum={wallet!.checksum}
                   isSelfHostedMode={isSelfHostedMode}
-                  isReadOnly={isCloudReadOnlyUser}
+                  isReadOnly={isCloudViewOnlyUser}
                   preferredFiatCurrency={preferredFiatCurrency}
                   onSaved={load}
                   onDeleted={load}

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -98,54 +98,54 @@ const PROVIDERS = [
 ] as const
 
 const THRESHOLD_TYPES = [
-  { value: "above", label: "Above", icon: TrendingUp },
-  { value: "equals", label: "Equal", icon: Target },
-  { value: "below", label: "Below", icon: TrendingDown },
+  { value: "above", labelKey: "thresholdTypes.above", icon: TrendingUp },
+  { value: "equals", labelKey: "thresholdTypes.equals", icon: Target },
+  { value: "below", labelKey: "thresholdTypes.below", icon: TrendingDown },
 ] as const
 
 const EVENT_GROUPS = [
   {
-    label: "Activity",
+    labelKey: "eventGroups.activity",
     options: [
       {
         key: "notify_sending",
-        label: "Sending",
-        description: "An outgoing transaction is seen in the mempool and is still unconfirmed.",
+        labelKey: "events.sending.label",
+        descriptionKey: "events.sending.description",
       },
       {
         key: "notify_receiving",
-        label: "Receiving",
-        description: "An incoming transaction is seen in the mempool and is still unconfirmed.",
+        labelKey: "events.receiving.label",
+        descriptionKey: "events.receiving.description",
       },
     ],
   },
   {
-    label: "First confirmation",
+    labelKey: "eventGroups.firstConfirmation",
     options: [
       {
         key: "notify_sent",
-        label: "Sent",
-        description: "An outgoing transaction receives its first confirmation.",
+        labelKey: "events.sent.label",
+        descriptionKey: "events.sent.description",
       },
       {
         key: "notify_received",
-        label: "Received",
-        description: "An incoming transaction receives its first confirmation.",
+        labelKey: "events.received.label",
+        descriptionKey: "events.received.description",
       },
     ],
   },
   {
-    label: "Replacements / fee bumps",
+    labelKey: "eventGroups.replacements",
     options: [
       {
         key: "notify_rbf",
-        label: "RBF replacement",
-        description: "Replace-By-Fee: an unconfirmed transaction is replaced by a newer version.",
+        labelKey: "events.rbf.label",
+        descriptionKey: "events.rbf.description",
       },
       {
         key: "notify_cpfp",
-        label: "CPFP fee bump",
-        description: "Child Pays For Parent: a child transaction is used to help confirm its parent.",
+        labelKey: "events.cpfp.label",
+        descriptionKey: "events.cpfp.description",
       },
     ],
   },
@@ -255,26 +255,28 @@ function TransactionEventGroups({
   isReadOnly = false,
 }: {
   groups: readonly {
-    label: string
+    labelKey: string
     options: readonly {
       key: TxNotificationKey
-      label: string
-      description: string
+      labelKey: string
+      descriptionKey: string
     }[]
   }[]
   draft: Pick<ContactDraft, TxNotificationKey>
   onChange: (key: TxNotificationKey, checked: boolean) => void
   isReadOnly?: boolean
 }) {
+  const tNotifications = useTranslations("walletNotifications")
+
   return (
     <div className="grid gap-4 lg:grid-cols-3">
       {groups.map((group) => (
-        <div key={group.label} className="space-y-3">
+        <div key={group.labelKey} className="space-y-3">
           <h4 className="text-xs font-semibold uppercase tracking-normal text-muted-foreground">
-            {group.label}
+            {tNotifications(group.labelKey)}
           </h4>
           <div className="space-y-3">
-            {group.options.map(({ key, label, description }) => (
+            {group.options.map(({ key, labelKey, descriptionKey }) => (
               <label
                 key={key}
                 className={
@@ -292,9 +294,11 @@ function TransactionEventGroups({
                   }}
                 />
                 <span className="space-y-1">
-                  <span className="block font-medium leading-none">{label}</span>
+                  <span className="block font-medium leading-none">
+                    {tNotifications(labelKey)}
+                  </span>
                   <span className="block text-xs leading-snug text-muted-foreground">
-                    {description}
+                    {tNotifications(descriptionKey)}
                   </span>
                 </span>
               </label>
@@ -652,6 +656,7 @@ function ContactNotificationCard({
 }) {
   const tContacts = useTranslations("contacts")
   const tCommon = useTranslations("common")
+  const tNotifications = useTranslations("walletNotifications")
   const phonePlaceholder = usePhonePlaceholder()
   const ntfyServerTarget = useNtfyServerTarget()
   const [draft, setDraft] = useState<ContactDraft>(() => contactToDraft(contact))
@@ -723,12 +728,15 @@ function ContactNotificationCard({
   const fiatThresholdCurrency = preferredFiatCurrency || "USD"
   const deliverySummary =
     draft.methods.length === 0
-      ? "No delivery methods"
+      ? tNotifications("delivery.noMethods")
       : draft.methods
           .map((method) => {
             const provider = PROVIDERS.find((item) => item.value === method.provider_type)
             const target = method.notification_target.trim()
-            return `${provider?.label ?? method.provider_type}: ${target || "not set"}`
+            return tNotifications("delivery.summary", {
+              provider: provider?.label ?? method.provider_type,
+              target: target || tNotifications("delivery.notSet"),
+            })
           })
           .join(", ")
 
@@ -1204,15 +1212,17 @@ function ContactNotificationCard({
 
         <section className="space-y-3">
           <div className="flex items-center justify-between gap-3">
-            <h3 className="text-sm font-medium text-muted-foreground">Transaction notifications</h3>
+            <h3 className="text-sm font-medium text-muted-foreground">
+              {tNotifications("transaction.title")}
+            </h3>
             <span className="text-xs text-muted-foreground">
               {txSaveState === "saving"
-                ? "Saving..."
+                ? tCommon("saving")
                 : txSaveState === "saved"
-                  ? "Saved"
+                  ? tNotifications("saveState.saved")
                   : txSaveState === "error"
-                    ? "Could not save"
-                    : "Saved on change"}
+                    ? tNotifications("saveState.error")
+                    : tNotifications("saveState.savedOnChange")}
             </span>
           </div>
           <div>
@@ -1236,12 +1246,12 @@ function ContactNotificationCard({
               />
               <span className="space-y-1">
                 <span className="block font-medium">
-                  Include wallet balance in transaction notifications
+                  {tNotifications("transaction.includeBalance")}
                 </span>
                 <span className="block text-xs leading-snug text-muted-foreground">
                   {hasTxNotifications
-                    ? "Applies to all selected transaction notification types below."
-                    : "Select at least one transaction notification type first."}
+                    ? tNotifications("transaction.includeBalanceDescription")
+                    : tNotifications("transaction.selectTypeFirst")}
                 </span>
               </span>
             </label>
@@ -1255,13 +1265,15 @@ function ContactNotificationCard({
         </section>
 
         <section className="space-y-3">
-          <h3 className="text-sm font-medium text-muted-foreground">Balance threshold notifications</h3>
+          <h3 className="text-sm font-medium text-muted-foreground">
+            {tNotifications("balance.title")}
+          </h3>
           {alerts.length > 0 && (
             <div className="flex flex-wrap gap-2">
               {alerts.map((alert) => (
                 <div key={alert.id} className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
                   <span>
-                    {alert.alert_type}{" "}
+                    {tNotifications(`alertTypes.${alert.alert_type}`)}{" "}
                     {alert.threshold_currency && alert.threshold_fiat_amount
                       ? `${alert.threshold_fiat_amount} ${alert.threshold_currency}`
                       : `${satsToBtc(alert.threshold_sats)} BTC`}
@@ -1302,7 +1314,7 @@ function ContactNotificationCard({
                       id={`threshold-${contact.id}-${type.value}`}
                     />
                     <Icon className="h-4 w-4 text-muted-foreground" />
-                    {type.label}
+                    {tNotifications(type.labelKey)}
                   </label>
                 )
               })}
@@ -1367,6 +1379,7 @@ export default function WalletNotificationsPage() {
   const t = useTranslations("wallets")
   const tCommon = useTranslations("common")
   const tApiErrors = useTranslations("errors.api")
+  const tNotifications = useTranslations("walletNotifications")
   const [wallet, setWallet] = useState<Wallet | null>(null)
   const [contacts, setContacts] = useState<Contact[]>([])
   const [alerts, setAlerts] = useState<BalanceAlert[]>([])
@@ -1498,15 +1511,15 @@ export default function WalletNotificationsPage() {
       <section className="space-y-4">
         <div className="flex items-center justify-between gap-4">
           <div>
-            <h1 className="text-xl font-semibold">Notifications</h1>
+            <h1 className="text-xl font-semibold">{tNotifications("title")}</h1>
             <p className="text-sm text-muted-foreground">
-              Choose who gets notified, how, and for which wallet events.
+              {tNotifications("description")}
             </p>
           </div>
           {!isCreatingContact && !isCloudReadOnlyUser && (
             <Button onClick={startContactCreation}>
               <Plus className="h-4 w-4" />
-              Add contact
+              {tNotifications("addContact")}
             </Button>
           )}
         </div>

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -774,6 +774,7 @@ function ContactNotificationCard({
 
   const saveContact = async () => {
     const nextContactDraft = editDraft
+    // Ntfy rows are prefilled when added, so a blank target means the user cleared it.
     const blankMethod = nextContactDraft.methods.find(
       (method) => !method.notification_target.trim()
     )
@@ -1001,6 +1002,7 @@ function ContactNotificationCard({
               )
               const isNewMethod = !originalMethod
               const canEditTarget = method.provider_type === "ntfy" || isNewMethod
+              // Provider types are unique in the draft, so each verification hook maps to one row.
               const isUnverifiedNewVerifiableMethod =
                 isNewMethod &&
                 ((method.provider_type === "sms" && !smsVerification.isVerified) ||

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -999,18 +999,14 @@ function ContactNotificationCard({
             {editDraft.methods.map((method, index) => {
               const provider = PROVIDERS.find((item) => item.value === method.provider_type) ?? PROVIDERS[0]
               const Icon = provider.icon
-              const originalMethod = draft.methods.find(
-                (item) => item.provider_type === method.provider_type
-              )
-              const isNewMethod = !originalMethod
-              const canEditTarget = method.provider_type === "ntfy" || isNewMethod
+              const hasSavedTarget = hasSavedDeliveryTarget(method)
               // Provider types are unique in the draft, so each verification hook maps to one row.
-              const isUnverifiedNewVerifiableMethod =
-                isNewMethod &&
+              const isUnverifiedVerifiableMethod =
+                !hasSavedTarget &&
                 ((method.provider_type === "sms" && !smsVerification.isVerified) ||
                   (method.provider_type === "email" && !emailVerification.isVerified))
               const showDeleteDeliveryMethod =
-                canRemoveDeliveryMethod && !isUnverifiedNewVerifiableMethod
+                canRemoveDeliveryMethod && !isUnverifiedVerifiableMethod
               return (
                 <div
                   key={`${method.provider_type}-${index}`}
@@ -1037,7 +1033,7 @@ function ContactNotificationCard({
                     <Icon className="h-4 w-4" />
                     {provider.label}
                   </div>
-                  {method.provider_type === "sms" && isNewMethod ? (
+                  {method.provider_type === "sms" ? (
                     <SmsProviderFields
                       phoneNumber={method.notification_target}
                       onPhoneNumberChange={(value) => {
@@ -1064,7 +1060,7 @@ function ContactNotificationCard({
                       disabled={isSaving}
                       containerClassName="space-y-3"
                       verificationButtonLayout="inline"
-                      verificationRequired={!smsVerification.isVerified}
+                      verificationRequired={!hasSavedTarget && !smsVerification.isVerified}
                       verificationSent={smsVerification.verificationSent}
                       verificationCode={smsVerification.verificationCode}
                       onVerificationCodeChange={(code) => {
@@ -1073,8 +1069,8 @@ function ContactNotificationCard({
                       }}
                       verificationPhone={smsVerification.verificationPhone}
                       verificationError={smsVerification.verificationError}
-                      isVerified={smsVerification.isVerified}
-                      showSuccess={smsVerification.showSuccess}
+                      isVerified={hasSavedTarget || smsVerification.isVerified}
+                      showSuccess={!hasSavedTarget && smsVerification.showSuccess}
                       isSending={smsVerification.isSending}
                       isVerifying={smsVerification.isVerifying}
                       timeRemaining={smsVerification.timeRemaining}
@@ -1085,7 +1081,7 @@ function ContactNotificationCard({
                       onVerifyCode={() => smsVerification.verifyCode()}
                       onResendCode={() => smsVerification.resendCode()}
                     />
-                  ) : method.provider_type === "email" && isNewMethod ? (
+                  ) : method.provider_type === "email" ? (
                     <EmailProviderFields
                       emailAddress={method.notification_target}
                       onEmailAddressChange={(value) => {
@@ -1112,7 +1108,7 @@ function ContactNotificationCard({
                       disabled={isSaving}
                       containerClassName="space-y-3"
                       verificationButtonLayout="inline"
-                      verificationRequired={!emailVerification.isVerified}
+                      verificationRequired={!hasSavedTarget && !emailVerification.isVerified}
                       verificationSent={emailVerification.verificationSent}
                       verificationCode={emailVerification.verificationCode}
                       onVerificationCodeChange={(code) => {
@@ -1121,8 +1117,8 @@ function ContactNotificationCard({
                       }}
                       verificationAddress={emailVerification.verificationAddress}
                       verificationError={emailVerification.verificationError}
-                      isVerified={emailVerification.isVerified}
-                      showSuccess={emailVerification.showSuccess}
+                      isVerified={hasSavedTarget || emailVerification.isVerified}
+                      showSuccess={!hasSavedTarget && emailVerification.showSuccess}
                       isSending={emailVerification.isSending}
                       isVerifying={emailVerification.isVerifying}
                       timeRemaining={emailVerification.timeRemaining}
@@ -1137,8 +1133,8 @@ function ContactNotificationCard({
                     <Input
                       value={method.notification_target}
                       placeholder={methodPlaceholder(method.provider_type)}
-                      readOnly={!canEditTarget}
-                      disabled={!canEditTarget}
+                      readOnly={method.provider_type !== "ntfy"}
+                      disabled={method.provider_type !== "ntfy"}
                       onChange={(event) =>
                         setEditDraft((prev) => ({
                           ...prev,
@@ -1160,10 +1156,10 @@ function ContactNotificationCard({
                           ...prev,
                           methods: prev.methods.filter((_, methodIndex) => methodIndex !== index),
                         }))
-                        if (method.provider_type === "sms" && isNewMethod) {
+                        if (method.provider_type === "sms") {
                           smsVerification.reset()
                         }
-                        if (method.provider_type === "email" && isNewMethod) {
+                        if (method.provider_type === "email") {
                           emailVerification.reset()
                         }
                       }}

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -1176,7 +1176,7 @@ function ContactNotificationCard({
             <div className="flex flex-wrap items-center gap-2">
               {addableProviders.length > 1 && (
                 <Select
-                  value={newMethodProvider}
+                  value={providerToAdd.value}
                   onValueChange={(value) =>
                     setNewMethodProvider(value as MethodDraft["provider_type"])
                   }

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -732,6 +732,8 @@ function ContactNotificationCard({
   })
   const hasTxNotifications = hasSelectedTxNotifications(draft)
   const hasSingleEditableDeliveryMethod = editDraft.methods.length === 1
+  const canRemoveDeliveryMethod =
+    editDraft.methods.length > 1 || addableProviders.length > 0
   const fiatThresholdCurrency = preferredFiatCurrency || "USD"
   const hasSavedDeliveryTarget = (method: MethodDraft) =>
     draft.methods.some(
@@ -1007,11 +1009,13 @@ function ContactNotificationCard({
                 isNewMethod &&
                 ((method.provider_type === "sms" && !smsVerification.isVerified) ||
                   (method.provider_type === "email" && !emailVerification.isVerified))
+              const showDeleteDeliveryMethod =
+                canRemoveDeliveryMethod && !isUnverifiedNewVerifiableMethod
               return (
                 <div
                   key={`${method.provider_type}-${index}`}
                   className={
-                    hasSingleEditableDeliveryMethod
+                    !canRemoveDeliveryMethod
                       ? "grid gap-2 sm:grid-cols-[120px_1fr]"
                       : "grid gap-2 sm:grid-cols-[120px_1fr_auto]"
                   }
@@ -1147,7 +1151,7 @@ function ContactNotificationCard({
                       }
                     />
                   )}
-                  {!hasSingleEditableDeliveryMethod && !isUnverifiedNewVerifiableMethod && (
+                  {showDeleteDeliveryMethod && (
                     <Button
                       variant="ghost"
                       size="icon"
@@ -1228,7 +1232,11 @@ function ContactNotificationCard({
             <Button variant="ghost" onClick={cancelContactEdit} disabled={isSaving}>
               Cancel
             </Button>
-            <Button onClick={saveContact} disabled={isSaving || !editDraft.name.trim()} size="sm">
+            <Button
+              onClick={saveContact}
+              disabled={isSaving || !editDraft.name.trim() || editDraft.methods.length === 0}
+              size="sm"
+            >
               <Save className="h-4 w-4" />
               {isSaving ? tCommon("saving") : "Save contact"}
             </Button>

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -252,6 +252,7 @@ function TransactionEventGroups({
   groups,
   draft,
   onChange,
+  isReadOnly = false,
 }: {
   groups: readonly {
     label: string
@@ -263,6 +264,7 @@ function TransactionEventGroups({
   }[]
   draft: Pick<ContactDraft, TxNotificationKey>
   onChange: (key: TxNotificationKey, checked: boolean) => void
+  isReadOnly?: boolean
 }) {
   return (
     <div className="grid gap-4 lg:grid-cols-3">
@@ -273,10 +275,21 @@ function TransactionEventGroups({
           </h4>
           <div className="space-y-3">
             {group.options.map(({ key, label, description }) => (
-              <label key={key} className="flex items-start gap-2 text-sm">
+              <label
+                key={key}
+                className={
+                  isReadOnly
+                    ? "flex cursor-not-allowed items-start gap-2 text-sm"
+                    : "flex items-start gap-2 text-sm"
+                }
+              >
                 <Checkbox
                   checked={draft[key]}
-                  onCheckedChange={(checked) => onChange(key, checked === true)}
+                  disabled={isReadOnly}
+                  className={isReadOnly ? "cursor-not-allowed" : undefined}
+                  onCheckedChange={(checked) => {
+                    if (!isReadOnly) onChange(key, checked === true)
+                  }}
                 />
                 <span className="space-y-1">
                   <span className="block font-medium leading-none">{label}</span>
@@ -623,6 +636,7 @@ function ContactNotificationCard({
   alerts,
   walletChecksum,
   isSelfHostedMode,
+  isReadOnly,
   preferredFiatCurrency,
   onSaved,
   onDeleted,
@@ -631,6 +645,7 @@ function ContactNotificationCard({
   alerts: BalanceAlert[]
   walletChecksum: string
   isSelfHostedMode: boolean
+  isReadOnly: boolean
   preferredFiatCurrency: string
   onSaved: () => void
   onDeleted: () => void
@@ -917,27 +932,29 @@ function ContactNotificationCard({
             <h2 className="truncate text-base font-semibold">{draft.name}</h2>
             <p className="truncate text-sm text-muted-foreground">{deliverySummary}</p>
           </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label="Contact actions">
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => setIsEditingContact(true)}>
-                <Pencil className="mr-2 h-4 w-4" />
-                Edit contact
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={deleteContact}
-                className="text-destructive focus:text-destructive"
-              >
-                <Trash2 className="mr-2 h-4 w-4" />
-                Delete contact
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {!isReadOnly && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="Contact actions">
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setIsEditingContact(true)}>
+                  <Pencil className="mr-2 h-4 w-4" />
+                  Edit contact
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={deleteContact}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete contact
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -1205,13 +1222,17 @@ function ContactNotificationCard({
                   hasTxNotifications &&
                   draft.include_wallet_balance_in_tx_notifications
                 }
-                disabled={!hasTxNotifications}
-                onCheckedChange={(checked) =>
+                disabled={!hasTxNotifications || isReadOnly}
+                className={
+                  !hasTxNotifications || isReadOnly ? "cursor-not-allowed" : undefined
+                }
+                onCheckedChange={(checked) => {
+                  if (isReadOnly) return
                   autosaveTxDraft({
                     ...draft,
                     include_wallet_balance_in_tx_notifications: checked === true,
                   })
-                }
+                }}
               />
               <span className="space-y-1">
                 <span className="block font-medium">
@@ -1229,6 +1250,7 @@ function ContactNotificationCard({
             groups={EVENT_GROUPS}
             draft={draft}
             onChange={(key, checked) => autosaveTxDraft({ ...draft, [key]: checked })}
+            isReadOnly={isReadOnly}
           />
         </section>
 
@@ -1416,6 +1438,8 @@ export default function WalletNotificationsPage() {
   }, [contacts])
 
   const currentTier = billingStatus?.subscription_tier || user?.subscription_tier || "personal"
+  const isCloudReadOnlyUser =
+    isCloudMode && (user?.is_admin === true || user?.is_demo === true)
   const contactLimitReached =
     isCloudMode && hasReachedContactLimit(contacts.length, currentTier)
 
@@ -1479,7 +1503,7 @@ export default function WalletNotificationsPage() {
               Choose who gets notified, how, and for which wallet events.
             </p>
           </div>
-          {!isCreatingContact && (
+          {!isCreatingContact && !isCloudReadOnlyUser && (
             <Button onClick={startContactCreation}>
               <Plus className="h-4 w-4" />
               Add contact
@@ -1551,6 +1575,7 @@ export default function WalletNotificationsPage() {
                   alerts={alertsByContact[contact.id] || []}
                   walletChecksum={wallet!.checksum}
                   isSelfHostedMode={isSelfHostedMode}
+                  isReadOnly={isCloudReadOnlyUser}
                   preferredFiatCurrency={preferredFiatCurrency}
                   onSaved={load}
                   onDeleted={load}

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -250,35 +250,6 @@ function formatBalanceAlertDraft(
   return `${satsToBtc(alert.threshold_sats ?? 0)} BTC`
 }
 
-function nullableThresholdFieldMatches<T>(
-  left: T | null | undefined,
-  right: T | null | undefined
-) {
-  return left == null ? right == null : left === right
-}
-
-function isMigratedWalletLevelAlert(
-  walletLevelAlert: BalanceAlert,
-  candidate: BalanceAlert
-) {
-  return (
-    !walletLevelAlert.contact_id &&
-    Boolean(candidate.contact_id) &&
-    candidate.wallet_checksum === walletLevelAlert.wallet_checksum &&
-    candidate.threshold_sats === walletLevelAlert.threshold_sats &&
-    candidate.alert_type === walletLevelAlert.alert_type &&
-    candidate.created_at === walletLevelAlert.created_at &&
-    nullableThresholdFieldMatches(
-      candidate.threshold_currency,
-      walletLevelAlert.threshold_currency
-    ) &&
-    nullableThresholdFieldMatches(
-      candidate.threshold_fiat_amount,
-      walletLevelAlert.threshold_fiat_amount
-    )
-  )
-}
-
 function TransactionEventGroups({
   groups,
   draft,
@@ -371,6 +342,7 @@ function NewContactWizardCard({
   const [thresholdAmount, setThresholdAmount] = useState("")
   const [thresholdCurrency, setThresholdCurrency] = useState("BTC")
   const [thresholdError, setThresholdError] = useState<string | null>(null)
+  const [isValidatingThreshold, setIsValidatingThreshold] = useState(false)
   const [providerType, setProviderType] = useState<MethodDraft["provider_type"]>(
     isSelfHostedMode ? "ntfy" : "email"
   )
@@ -427,39 +399,64 @@ function NewContactWizardCard({
     }
   }
 
-  const addDraftThreshold = () => {
+  const addDraftThreshold = async () => {
     setThresholdError(null)
+    let draft: BalanceAlertDraft
     if (thresholdCurrency === "BTC") {
       const btc = parseBtcInput(thresholdAmount)
       if (btc === null) {
         setThresholdError("Enter a valid BTC amount")
         return
       }
-      setDraftBalanceAlerts((prev) => [
-        ...prev,
-        {
-          id: crypto.randomUUID(),
-          alert_type: thresholdType,
-          threshold_sats: btcToSats(btc),
-        },
-      ])
+      draft = {
+        id: crypto.randomUUID(),
+        alert_type: thresholdType,
+        threshold_sats: btcToSats(btc),
+      }
     } else {
       const amount = Number.parseFloat(thresholdAmount)
       if (!Number.isFinite(amount) || amount <= 0) {
         setThresholdError("Enter a valid fiat amount")
         return
       }
-      setDraftBalanceAlerts((prev) => [
-        ...prev,
-        {
-          id: crypto.randomUUID(),
-          alert_type: thresholdType,
-          threshold_currency: thresholdCurrency,
-          threshold_fiat_amount: amount,
-        },
-      ])
+      draft = {
+        id: crypto.randomUUID(),
+        alert_type: thresholdType,
+        threshold_currency: thresholdCurrency,
+        threshold_fiat_amount: amount,
+      }
     }
-    setThresholdAmount("")
+
+    const isDuplicate = draftBalanceAlerts.some(
+      (alert) =>
+        alert.alert_type === draft.alert_type &&
+        alert.threshold_sats === draft.threshold_sats &&
+        alert.threshold_currency === draft.threshold_currency &&
+        alert.threshold_fiat_amount === draft.threshold_fiat_amount
+    )
+
+    if (isDuplicate) {
+      setThresholdError(tApiErrors("duplicate_alert"))
+      return
+    }
+
+    setIsValidatingThreshold(true)
+    try {
+      await api.validateBalanceAlert(walletChecksum, {
+        alert_type: draft.alert_type,
+        threshold_sats: draft.threshold_sats,
+        threshold_currency: draft.threshold_currency,
+        threshold_fiat_amount: draft.threshold_fiat_amount,
+      })
+      setDraftBalanceAlerts((prev) => [...prev, draft])
+      setThresholdAmount("")
+    } catch (err) {
+      setThresholdError(
+        err instanceof ApiError ? getTranslatedApiError(err, tApiErrors) : "Failed to add threshold"
+      )
+    } finally {
+      setIsValidatingThreshold(false)
+    }
   }
 
   const validateMethod = () => {
@@ -705,7 +702,7 @@ function NewContactWizardCard({
                   }}
                   placeholder={thresholdCurrency === "BTC" ? "0.10" : "10000"}
                   className="w-[120px]"
-                  disabled={isCreating}
+                  disabled={isCreating || isValidatingThreshold}
                 />
                 <Select
                   value={thresholdCurrency}
@@ -713,7 +710,7 @@ function NewContactWizardCard({
                     setThresholdCurrency(value)
                     setThresholdError(null)
                   }}
-                  disabled={isCreating}
+                  disabled={isCreating || isValidatingThreshold}
                 >
                   <SelectTrigger className="w-[120px]" aria-label="Threshold currency">
                     <SelectValue />
@@ -727,7 +724,7 @@ function NewContactWizardCard({
                 </Select>
                 <Button
                   onClick={addDraftThreshold}
-                  disabled={!thresholdAmount.trim() || isCreating}
+                  disabled={!thresholdAmount.trim() || isCreating || isValidatingThreshold}
                   className="w-[160px] whitespace-nowrap"
                 >
                   <Plus className="h-4 w-4" />
@@ -1685,18 +1682,6 @@ export default function WalletNotificationsPage() {
       return acc
     }, {})
   }, [alerts])
-  const walletLevelAlerts = useMemo(
-    () =>
-      alerts.filter(
-        (alert) =>
-          !alert.contact_id &&
-          (alert.is_active ||
-            !alerts.some((candidate) =>
-              isMigratedWalletLevelAlert(alert, candidate)
-            ))
-      ),
-    [alerts]
-  )
 
   const sortedContacts = useMemo(() => {
     return [...contacts].sort((a, b) =>
@@ -1717,16 +1702,6 @@ export default function WalletNotificationsPage() {
       return
     }
     setIsCreatingContact(true)
-  }
-
-  const deleteWalletLevelAlert = async (alertId: string) => {
-    setError(null)
-    try {
-      await api.deleteBalanceAlert(alertId)
-      await load()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to delete threshold")
-    }
   }
 
   if (authLoading || (isLoading && !wallet)) {
@@ -1791,42 +1766,6 @@ export default function WalletNotificationsPage() {
                 load()
               }}
             />
-          )}
-
-          {walletLevelAlerts.length > 0 && (
-            <Card>
-              <CardHeader>
-                <h2 className="text-base font-semibold">
-                  Legacy wallet balance thresholds
-                </h2>
-              </CardHeader>
-              <CardContent>
-                <div className="flex flex-wrap gap-2">
-                  {walletLevelAlerts.map((alert) => (
-                    <div
-                      key={alert.id}
-                      className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
-                    >
-                      <span>
-                        {alert.alert_type}{" "}
-                        {alert.threshold_currency && alert.threshold_fiat_amount
-                          ? `${alert.threshold_fiat_amount} ${alert.threshold_currency}`
-                          : `${satsToBtc(alert.threshold_sats)} BTC`}
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => deleteWalletLevelAlert(alert.id)}
-                        aria-label="Delete wallet-level threshold"
-                        className="h-7 w-7"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
           )}
 
           {contacts.length === 0 && !isCreatingContact ? (

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -631,6 +631,8 @@ function ContactNotificationCard({
   onDeleted: () => void
 }) {
   const tCommon = useTranslations("common")
+  const phonePlaceholder = usePhonePlaceholder()
+  const ntfyServerTarget = useNtfyServerTarget()
   const [draft, setDraft] = useState<ContactDraft>(() => contactToDraft(contact))
   const [editDraft, setEditDraft] = useState<ContactDraft>(() => contactToDraft(contact))
   const [contactError, setContactError] = useState<string | null>(null)
@@ -670,23 +672,31 @@ function ContactNotificationCard({
   }, [isSelfHostedMode])
 
   const addableProviders = useMemo(() => {
-    const editableProviders = availableProviders.filter((provider) => provider.value === "ntfy")
-
-    if (editableProviders.length !== 1) {
-      return editableProviders
-    }
-
-    const onlyProvider = editableProviders[0]
-    const hasOnlyProvider = editDraft.methods.some(
-      (method) => method.provider_type === onlyProvider.value
+    return availableProviders.filter(
+      (provider) =>
+        !editDraft.methods.some((method) => method.provider_type === provider.value)
     )
-
-    return hasOnlyProvider ? [] : editableProviders
   }, [availableProviders, editDraft.methods])
 
   const providerToAdd =
     addableProviders.find((provider) => provider.value === newMethodProvider) ??
     addableProviders[0]
+  const originalSmsTarget =
+    draft.methods.find((method) => method.provider_type === "sms")?.notification_target ?? null
+  const originalEmailTarget =
+    draft.methods.find((method) => method.provider_type === "email")?.notification_target ?? null
+  const smsVerification = useSmsVerification({
+    walletChecksum,
+    contactName: editDraft.name,
+    originalPhoneNumber: originalSmsTarget,
+    onError: setContactError,
+  })
+  const emailVerification = useEmailVerification({
+    walletChecksum,
+    contactName: editDraft.name,
+    originalEmailAddress: originalEmailTarget,
+    onError: setContactError,
+  })
   const hasTxNotifications = hasSelectedTxNotifications(draft)
   const hasSingleEditableDeliveryMethod = editDraft.methods.length === 1
   const fiatThresholdCurrency = preferredFiatCurrency || "USD"
@@ -722,6 +732,41 @@ function ContactNotificationCard({
 
   const saveContact = async () => {
     const nextContactDraft = editDraft
+    const blankMethod = nextContactDraft.methods.find(
+      (method) => !method.notification_target.trim()
+    )
+    const addedSmsMethod = nextContactDraft.methods.find(
+      (method) =>
+        method.provider_type === "sms" &&
+        !draft.methods.some((savedMethod) => savedMethod.provider_type === "sms")
+    )
+    const addedEmailMethod = nextContactDraft.methods.find(
+      (method) =>
+        method.provider_type === "email" &&
+        !draft.methods.some((savedMethod) => savedMethod.provider_type === "email")
+    )
+
+    if (blankMethod) {
+      setContactError(
+        blankMethod.provider_type === "ntfy"
+          ? "Enter an ntfy topic"
+          : blankMethod.provider_type === "sms"
+            ? "Enter a phone number"
+            : "Enter an email address"
+      )
+      return
+    }
+
+    if (addedSmsMethod && !smsVerification.isVerified) {
+      setContactError("Verify the phone number first")
+      return
+    }
+
+    if (addedEmailMethod && !emailVerification.isVerified) {
+      setContactError("Verify the email first")
+      return
+    }
+
     latestContactDraftRef.current = nextContactDraft
     setIsSaving(true)
     setContactError(null)
@@ -761,6 +806,8 @@ function ContactNotificationCard({
     latestContactDraftRef.current = draft
     setContactError(null)
     setIsEditingContact(false)
+    smsVerification.reset()
+    emailVerification.reset()
   }
 
   const autosaveTxDraft = (nextDraft: ContactDraft) => {
@@ -903,7 +950,11 @@ function ContactNotificationCard({
             {editDraft.methods.map((method, index) => {
               const provider = PROVIDERS.find((item) => item.value === method.provider_type) ?? PROVIDERS[0]
               const Icon = provider.icon
-              const canEditTarget = method.provider_type === "ntfy"
+              const originalMethod = draft.methods.find(
+                (item) => item.provider_type === method.provider_type
+              )
+              const isNewMethod = !originalMethod
+              const canEditTarget = method.provider_type === "ntfy" || isNewMethod
               return (
                 <div
                   key={`${method.provider_type}-${index}`}
@@ -930,32 +981,132 @@ function ContactNotificationCard({
                     <Icon className="h-4 w-4" />
                     {provider.label}
                   </div>
-                  <Input
-                    value={method.notification_target}
-                    placeholder={methodPlaceholder(method.provider_type)}
-                    readOnly={!canEditTarget}
-                    disabled={!canEditTarget}
-                    onChange={(event) =>
-                      setEditDraft((prev) => ({
-                        ...prev,
-                        methods: prev.methods.map((item, methodIndex) =>
-                          methodIndex === index
-                            ? { ...item, notification_target: event.target.value }
-                            : item
-                        ),
-                      }))
-                    }
-                  />
+                  {method.provider_type === "sms" && isNewMethod ? (
+                    <SmsProviderFields
+                      phoneNumber={method.notification_target}
+                      onPhoneNumberChange={(value) => {
+                        setEditDraft((prev) => ({
+                          ...prev,
+                          methods: prev.methods.map((item, methodIndex) =>
+                            methodIndex === index
+                              ? { ...item, notification_target: value }
+                              : item
+                          ),
+                        }))
+                        setContactError(null)
+                        smsVerification.clearPhoneError()
+                        if (
+                          smsVerification.isVerified ||
+                          (smsVerification.verificationPhone &&
+                            value.trim() !== smsVerification.verificationPhone)
+                        ) {
+                          smsVerification.reset()
+                        }
+                      }}
+                      phonePlaceholder={phonePlaceholder}
+                      phoneError={smsVerification.phoneError}
+                      disabled={isSaving}
+                      verificationRequired={!smsVerification.isVerified}
+                      verificationSent={smsVerification.verificationSent}
+                      verificationCode={smsVerification.verificationCode}
+                      onVerificationCodeChange={(code) => {
+                        smsVerification.setVerificationCode(code)
+                        smsVerification.clearVerificationError()
+                      }}
+                      verificationPhone={smsVerification.verificationPhone}
+                      verificationError={smsVerification.verificationError}
+                      isVerified={smsVerification.isVerified}
+                      showSuccess={smsVerification.showSuccess}
+                      isSending={smsVerification.isSending}
+                      isVerifying={smsVerification.isVerifying}
+                      timeRemaining={smsVerification.timeRemaining}
+                      formatTime={smsVerification.formatTime}
+                      onSendVerification={() =>
+                        smsVerification.sendVerification(method.notification_target.trim())
+                      }
+                      onVerifyCode={() => smsVerification.verifyCode()}
+                      onResendCode={() => smsVerification.resendCode()}
+                    />
+                  ) : method.provider_type === "email" && isNewMethod ? (
+                    <EmailProviderFields
+                      emailAddress={method.notification_target}
+                      onEmailAddressChange={(value) => {
+                        setEditDraft((prev) => ({
+                          ...prev,
+                          methods: prev.methods.map((item, methodIndex) =>
+                            methodIndex === index
+                              ? { ...item, notification_target: value }
+                              : item
+                          ),
+                        }))
+                        setContactError(null)
+                        emailVerification.clearEmailError()
+                        if (
+                          emailVerification.isVerified ||
+                          (emailVerification.verificationAddress &&
+                            value.trim() !== emailVerification.verificationAddress)
+                        ) {
+                          emailVerification.reset()
+                        }
+                      }}
+                      emailPlaceholder={tCommon("emailPlaceholder")}
+                      emailError={emailVerification.emailError}
+                      disabled={isSaving}
+                      verificationRequired={!emailVerification.isVerified}
+                      verificationSent={emailVerification.verificationSent}
+                      verificationCode={emailVerification.verificationCode}
+                      onVerificationCodeChange={(code) => {
+                        emailVerification.setVerificationCode(code)
+                        emailVerification.clearVerificationError()
+                      }}
+                      verificationAddress={emailVerification.verificationAddress}
+                      verificationError={emailVerification.verificationError}
+                      isVerified={emailVerification.isVerified}
+                      showSuccess={emailVerification.showSuccess}
+                      isSending={emailVerification.isSending}
+                      isVerifying={emailVerification.isVerifying}
+                      timeRemaining={emailVerification.timeRemaining}
+                      formatTime={emailVerification.formatTime}
+                      onSendVerification={() =>
+                        emailVerification.sendVerification(method.notification_target.trim())
+                      }
+                      onVerifyCode={() => emailVerification.verifyCode()}
+                      onResendCode={() => emailVerification.resendCode()}
+                    />
+                  ) : (
+                    <Input
+                      value={method.notification_target}
+                      placeholder={methodPlaceholder(method.provider_type)}
+                      readOnly={!canEditTarget}
+                      disabled={!canEditTarget}
+                      onChange={(event) =>
+                        setEditDraft((prev) => ({
+                          ...prev,
+                          methods: prev.methods.map((item, methodIndex) =>
+                            methodIndex === index
+                              ? { ...item, notification_target: event.target.value }
+                              : item
+                          ),
+                        }))
+                      }
+                    />
+                  )}
                   {!hasSingleEditableDeliveryMethod && (
                     <Button
                       variant="ghost"
                       size="icon"
-                      onClick={() =>
+                      onClick={() => {
                         setEditDraft((prev) => ({
                           ...prev,
                           methods: prev.methods.filter((_, methodIndex) => methodIndex !== index),
                         }))
-                      }
+                        if (method.provider_type === "sms" && isNewMethod) {
+                          smsVerification.reset()
+                        }
+                        if (method.provider_type === "email" && isNewMethod) {
+                          emailVerification.reset()
+                        }
+                      }}
                       aria-label="Delete delivery method"
                     >
                       <Trash2 className="h-4 w-4" />
@@ -994,9 +1145,15 @@ function ContactNotificationCard({
                     ...prev,
                     methods: [
                       ...prev.methods,
-                      {
+                      draft.methods.find(
+                        (method) => method.provider_type === providerToAdd.value
+                      ) ?? {
                         provider_type: providerToAdd.value,
-                        notification_target: "",
+                        notification_target:
+                          providerToAdd.value === "ntfy"
+                            ? ntfyServerTarget.defaultTopic ||
+                              generateDefaultNtfyTopic(draft.name || "contact", walletChecksum)
+                            : "",
                         is_enabled: true,
                       },
                     ],

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -957,7 +957,7 @@ function ContactNotificationCard({
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onClick={() => setIsEditingContact(true)}>
                   <Pencil className="mr-2 h-4 w-4" />
-                  Edit contact
+                  {tNotifications("contactActions.edit")}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
@@ -965,7 +965,7 @@ function ContactNotificationCard({
                   className="text-destructive focus:text-destructive"
                 >
                   <Trash2 className="mr-2 h-4 w-4" />
-                  Delete contact
+                  {tNotifications("contactActions.delete")}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/frontend/src/components/contact-modal/email-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/email-provider-fields.tsx
@@ -17,6 +17,7 @@ interface EmailProviderFieldsProps {
   emailError: string | null
   disabled?: boolean
   hideEmailInput?: boolean
+  containerClassName?: string
 
   // Verification state
   verificationRequired: boolean
@@ -45,6 +46,7 @@ export function EmailProviderFields({
   emailError,
   disabled = false,
   hideEmailInput = false,
+  containerClassName = "mt-2 space-y-3",
   verificationRequired,
   verificationSent,
   verificationCode,
@@ -64,7 +66,7 @@ export function EmailProviderFields({
   const t = useTranslations('contacts')
 
   return (
-    <div className="mt-2 space-y-3">
+    <div className={containerClassName}>
       {!hideEmailInput && (
         <div>
           <Input

--- a/frontend/src/components/contact-modal/email-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/email-provider-fields.tsx
@@ -71,14 +71,18 @@ export function EmailProviderFields({
     <Button
       type="button"
       variant="outline"
-      size="sm"
+      size={verificationButtonLayout === "inline" ? "default" : "sm"}
       onClick={onSendVerification}
       disabled={isSending || disabled || !emailAddress.trim()}
-      className={verificationButtonLayout === "inline" ? "h-10 shrink-0 px-6" : "w-full"}
+      className={verificationButtonLayout === "inline" ? "self-start shrink-0 px-6" : "w-full"}
     >
       {isSending ? t('verification.sendingCode') : t('verification.sendCode')}
     </Button>
   )
+  const emailInputClassName = [
+    verificationButtonLayout === "inline" && showSendVerificationButton ? "min-w-0 flex-1" : "",
+    emailError ? "border-red-500 focus:border-red-500" : "",
+  ].filter(Boolean).join(" ")
 
   return (
     <div className={containerClassName}>
@@ -87,7 +91,7 @@ export function EmailProviderFields({
           <div
             className={
               verificationButtonLayout === "inline" && showSendVerificationButton
-                ? "grid grid-cols-[minmax(0,1fr)_auto] gap-2"
+                ? "flex items-start gap-2"
                 : undefined
             }
           >
@@ -98,7 +102,7 @@ export function EmailProviderFields({
               disabled={disabled || isSending}
               type="email"
               enterKeyHint="next"
-              className={emailError ? 'border-red-500 focus:border-red-500' : ''}
+              className={emailInputClassName}
             />
             {verificationButtonLayout === "inline" &&
               showSendVerificationButton &&

--- a/frontend/src/components/contact-modal/email-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/email-provider-fields.tsx
@@ -18,6 +18,7 @@ interface EmailProviderFieldsProps {
   disabled?: boolean
   hideEmailInput?: boolean
   containerClassName?: string
+  verificationButtonLayout?: "block" | "inline"
 
   // Verification state
   verificationRequired: boolean
@@ -47,6 +48,7 @@ export function EmailProviderFields({
   disabled = false,
   hideEmailInput = false,
   containerClassName = "mt-2 space-y-3",
+  verificationButtonLayout = "block",
   verificationRequired,
   verificationSent,
   verificationCode,
@@ -64,20 +66,44 @@ export function EmailProviderFields({
   onResendCode
 }: EmailProviderFieldsProps) {
   const t = useTranslations('contacts')
+  const showSendVerificationButton = verificationRequired && !verificationSent
+  const sendVerificationButton = (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={onSendVerification}
+      disabled={isSending || disabled || !emailAddress.trim()}
+      className={verificationButtonLayout === "inline" ? "h-10 shrink-0 px-6" : "w-full"}
+    >
+      {isSending ? t('verification.sendingCode') : t('verification.sendCode')}
+    </Button>
+  )
 
   return (
     <div className={containerClassName}>
       {!hideEmailInput && (
         <div>
-          <Input
-            value={emailAddress}
-            onChange={(e) => onEmailAddressChange(e.target.value)}
-            placeholder={emailPlaceholder}
-            disabled={disabled || isSending}
-            type="email"
-            enterKeyHint="next"
-            className={emailError ? 'border-red-500 focus:border-red-500' : ''}
-          />
+          <div
+            className={
+              verificationButtonLayout === "inline" && showSendVerificationButton
+                ? "grid grid-cols-[minmax(0,1fr)_auto] gap-2"
+                : undefined
+            }
+          >
+            <Input
+              value={emailAddress}
+              onChange={(e) => onEmailAddressChange(e.target.value)}
+              placeholder={emailPlaceholder}
+              disabled={disabled || isSending}
+              type="email"
+              enterKeyHint="next"
+              className={emailError ? 'border-red-500 focus:border-red-500' : ''}
+            />
+            {verificationButtonLayout === "inline" &&
+              showSendVerificationButton &&
+              sendVerificationButton}
+          </div>
           {emailError && (
             <FieldError message={emailError} className="mt-1" announce />
           )}
@@ -90,18 +116,7 @@ export function EmailProviderFields({
       )}
 
       {/* Send Verification Button */}
-      {verificationRequired && !verificationSent && (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={onSendVerification}
-          disabled={isSending || disabled || !emailAddress.trim()}
-          className="w-full"
-        >
-          {isSending ? t('verification.sendingCode') : t('verification.sendCode')}
-        </Button>
-      )}
+      {verificationButtonLayout === "block" && showSendVerificationButton && sendVerificationButton}
 
       {/* OTP Input Field */}
       {verificationSent && !isVerified && (

--- a/frontend/src/components/contact-modal/email-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/email-provider-fields.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { ReactNode } from "react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
@@ -19,6 +20,7 @@ interface EmailProviderFieldsProps {
   hideEmailInput?: boolean
   containerClassName?: string
   verificationButtonLayout?: "block" | "inline"
+  leadingControl?: ReactNode
 
   // Verification state
   verificationRequired: boolean
@@ -49,6 +51,7 @@ export function EmailProviderFields({
   hideEmailInput = false,
   containerClassName = "mt-2 space-y-3",
   verificationButtonLayout = "block",
+  leadingControl,
   verificationRequired,
   verificationSent,
   verificationCode,
@@ -79,8 +82,10 @@ export function EmailProviderFields({
       {isSending ? t('verification.sendingCode') : t('verification.sendCode')}
     </Button>
   )
+  const hasInlineRow =
+    verificationButtonLayout === "inline" && (showSendVerificationButton || Boolean(leadingControl))
   const emailInputClassName = [
-    verificationButtonLayout === "inline" && showSendVerificationButton ? "min-w-0 flex-1" : "",
+    hasInlineRow ? "min-w-0 flex-1" : "",
     emailError ? "border-red-500 focus:border-red-500" : "",
   ].filter(Boolean).join(" ")
 
@@ -90,11 +95,12 @@ export function EmailProviderFields({
         <div>
           <div
             className={
-              verificationButtonLayout === "inline" && showSendVerificationButton
+              hasInlineRow
                 ? "flex items-start gap-2"
                 : undefined
             }
           >
+            {verificationButtonLayout === "inline" && leadingControl}
             <Input
               value={emailAddress}
               onChange={(e) => onEmailAddressChange(e.target.value)}

--- a/frontend/src/components/contact-modal/ntfy-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/ntfy-provider-fields.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { ReactNode } from "react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useTranslations } from "next-intl"
@@ -11,6 +12,9 @@ interface NtfyProviderFieldsProps {
   disabled?: boolean
   ntfyServerUrl?: string
   ntfyServerIsBrowserSafe?: boolean
+  containerClassName?: string
+  leadingControl?: ReactNode
+  inline?: boolean
 }
 
 export function NtfyProviderFields({
@@ -20,6 +24,9 @@ export function NtfyProviderFields({
   disabled = false,
   ntfyServerUrl,
   ntfyServerIsBrowserSafe = true,
+  containerClassName = "mt-2 space-y-2",
+  leadingControl,
+  inline = false,
 }: NtfyProviderFieldsProps) {
   const t = useTranslations('contacts')
 
@@ -36,16 +43,21 @@ export function NtfyProviderFields({
   }
 
   return (
-    <div className="mt-2 space-y-2">
+    <div className={containerClassName}>
       <div>
-        <Label htmlFor="ntfy-topic">{t('add.ntfy.topicLabel')}</Label>
-        <Input
-          id="ntfy-topic"
-          value={topic}
-          onChange={(e) => onTopicChange(e.target.value)}
-          placeholder={defaultTopicPlaceholder}
-          disabled={disabled}
-        />
+        {!inline && <Label htmlFor="ntfy-topic">{t('add.ntfy.topicLabel')}</Label>}
+        <div className={inline ? "flex items-start gap-2" : undefined}>
+          {inline && leadingControl}
+          <Input
+            id="ntfy-topic"
+            value={topic}
+            onChange={(e) => onTopicChange(e.target.value)}
+            placeholder={defaultTopicPlaceholder}
+            disabled={disabled}
+            aria-label={inline ? t('add.ntfy.topicLabel') : undefined}
+            className={inline ? "min-w-0 flex-1" : undefined}
+          />
+        </div>
         <p className="text-xs text-muted-foreground mt-1">
           {t('add.ntfy.topicHint', { server: serverDisplay })}
         </p>

--- a/frontend/src/components/contact-modal/sms-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/sms-provider-fields.tsx
@@ -72,14 +72,18 @@ export function SmsProviderFields({
     <Button
       type="button"
       variant="outline"
-      size="sm"
+      size={verificationButtonLayout === "inline" ? "default" : "sm"}
       onClick={onSendVerification}
       disabled={isSending || disabled || !phoneNumber.trim()}
-      className={verificationButtonLayout === "inline" ? "h-10 shrink-0 px-6" : "w-full"}
+      className={verificationButtonLayout === "inline" ? "self-start shrink-0 px-6" : "w-full"}
     >
       {isSending ? t('verification.sendingCode') : t('verification.sendCode')}
     </Button>
   )
+  const phoneInputClassName = [
+    verificationButtonLayout === "inline" && showSendVerificationButton ? "min-w-0 flex-1" : "",
+    phoneError ? "border-red-500 focus:border-red-500" : "",
+  ].filter(Boolean).join(" ")
 
   const formattedPhone = verificationPhone
     ? (parsePhoneNumberFromString(verificationPhone)?.formatInternational() ?? verificationPhone)
@@ -92,7 +96,7 @@ export function SmsProviderFields({
           <div
             className={
               verificationButtonLayout === "inline" && showSendVerificationButton
-                ? "grid grid-cols-[minmax(0,1fr)_auto] gap-2"
+                ? "flex items-start gap-2"
                 : undefined
             }
           >
@@ -102,7 +106,7 @@ export function SmsProviderFields({
               placeholder={phonePlaceholder}
               disabled={disabled || isSending}
               inputMode="tel"
-              className={phoneError ? 'border-red-500 focus:border-red-500' : ''}
+              className={phoneInputClassName}
             />
             {verificationButtonLayout === "inline" &&
               showSendVerificationButton &&

--- a/frontend/src/components/contact-modal/sms-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/sms-provider-fields.tsx
@@ -19,6 +19,7 @@ interface SmsProviderFieldsProps {
   disabled?: boolean
   hidePhoneInput?: boolean
   containerClassName?: string
+  verificationButtonLayout?: "block" | "inline"
 
   // Verification state
   verificationRequired: boolean
@@ -48,6 +49,7 @@ export function SmsProviderFields({
   disabled = false,
   hidePhoneInput = false,
   containerClassName = "mt-2 space-y-3",
+  verificationButtonLayout = "block",
   verificationRequired,
   verificationSent,
   verificationCode,
@@ -65,6 +67,19 @@ export function SmsProviderFields({
   onResendCode
 }: SmsProviderFieldsProps) {
   const t = useTranslations('contacts')
+  const showSendVerificationButton = verificationRequired && !verificationSent
+  const sendVerificationButton = (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={onSendVerification}
+      disabled={isSending || disabled || !phoneNumber.trim()}
+      className={verificationButtonLayout === "inline" ? "h-10 shrink-0 px-6" : "w-full"}
+    >
+      {isSending ? t('verification.sendingCode') : t('verification.sendCode')}
+    </Button>
+  )
 
   const formattedPhone = verificationPhone
     ? (parsePhoneNumberFromString(verificationPhone)?.formatInternational() ?? verificationPhone)
@@ -74,14 +89,25 @@ export function SmsProviderFields({
     <div className={containerClassName}>
       {!hidePhoneInput && (
         <div>
-          <Input
-            value={phoneNumber}
-            onChange={(e) => onPhoneNumberChange(e.target.value)}
-            placeholder={phonePlaceholder}
-            disabled={disabled || isSending}
-            inputMode="tel"
-            className={phoneError ? 'border-red-500 focus:border-red-500' : ''}
-          />
+          <div
+            className={
+              verificationButtonLayout === "inline" && showSendVerificationButton
+                ? "grid grid-cols-[minmax(0,1fr)_auto] gap-2"
+                : undefined
+            }
+          >
+            <Input
+              value={phoneNumber}
+              onChange={(e) => onPhoneNumberChange(e.target.value)}
+              placeholder={phonePlaceholder}
+              disabled={disabled || isSending}
+              inputMode="tel"
+              className={phoneError ? 'border-red-500 focus:border-red-500' : ''}
+            />
+            {verificationButtonLayout === "inline" &&
+              showSendVerificationButton &&
+              sendVerificationButton}
+          </div>
           {phoneError && (
             <FieldError message={phoneError} className="mt-1" announce />
           )}
@@ -94,18 +120,7 @@ export function SmsProviderFields({
       )}
 
       {/* Send Verification Button */}
-      {verificationRequired && !verificationSent && (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={onSendVerification}
-          disabled={isSending || disabled || !phoneNumber.trim()}
-          className="w-full"
-        >
-          {isSending ? t('verification.sendingCode') : t('verification.sendCode')}
-        </Button>
-      )}
+      {verificationButtonLayout === "block" && showSendVerificationButton && sendVerificationButton}
 
       {/* OTP Input Field */}
       {verificationSent && !isVerified && (

--- a/frontend/src/components/contact-modal/sms-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/sms-provider-fields.tsx
@@ -18,6 +18,7 @@ interface SmsProviderFieldsProps {
   phoneError: string | null
   disabled?: boolean
   hidePhoneInput?: boolean
+  containerClassName?: string
 
   // Verification state
   verificationRequired: boolean
@@ -46,6 +47,7 @@ export function SmsProviderFields({
   phoneError,
   disabled = false,
   hidePhoneInput = false,
+  containerClassName = "mt-2 space-y-3",
   verificationRequired,
   verificationSent,
   verificationCode,
@@ -69,7 +71,7 @@ export function SmsProviderFields({
     : ''
 
   return (
-    <div className="mt-2 space-y-3">
+    <div className={containerClassName}>
       {!hidePhoneInput && (
         <div>
           <Input

--- a/frontend/src/components/contact-modal/sms-provider-fields.tsx
+++ b/frontend/src/components/contact-modal/sms-provider-fields.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { ReactNode } from "react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
@@ -20,6 +21,7 @@ interface SmsProviderFieldsProps {
   hidePhoneInput?: boolean
   containerClassName?: string
   verificationButtonLayout?: "block" | "inline"
+  leadingControl?: ReactNode
 
   // Verification state
   verificationRequired: boolean
@@ -50,6 +52,7 @@ export function SmsProviderFields({
   hidePhoneInput = false,
   containerClassName = "mt-2 space-y-3",
   verificationButtonLayout = "block",
+  leadingControl,
   verificationRequired,
   verificationSent,
   verificationCode,
@@ -80,8 +83,10 @@ export function SmsProviderFields({
       {isSending ? t('verification.sendingCode') : t('verification.sendCode')}
     </Button>
   )
+  const hasInlineRow =
+    verificationButtonLayout === "inline" && (showSendVerificationButton || Boolean(leadingControl))
   const phoneInputClassName = [
-    verificationButtonLayout === "inline" && showSendVerificationButton ? "min-w-0 flex-1" : "",
+    hasInlineRow ? "min-w-0 flex-1" : "",
     phoneError ? "border-red-500 focus:border-red-500" : "",
   ].filter(Boolean).join(" ")
 
@@ -95,11 +100,12 @@ export function SmsProviderFields({
         <div>
           <div
             className={
-              verificationButtonLayout === "inline" && showSendVerificationButton
+              hasInlineRow
                 ? "flex items-start gap-2"
                 : undefined
             }
           >
+            {verificationButtonLayout === "inline" && leadingControl}
             <Input
               value={phoneNumber}
               onChange={(e) => onPhoneNumberChange(e.target.value)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,6 +52,11 @@ export interface UserPreferencesResponse {
   ntfy_username: string | null
 }
 
+interface CreateContactResponse {
+  message: string
+  contact_id: string
+}
+
 // Base API client
 class ApiClient {
   private baseUrl: string
@@ -192,8 +197,8 @@ class ApiClient {
       notify_rbf?: boolean
       include_wallet_balance_in_tx_notifications?: boolean
     }
-  ): Promise<Contact> {
-    return this.request<Contact>(`/api/wallets/${walletChecksum}/contacts`, {
+  ): Promise<{ id: string }> {
+    const response = await this.request<CreateContactResponse>(`/api/wallets/${walletChecksum}/contacts`, {
       method: 'POST',
       body: JSON.stringify({
         name,
@@ -201,6 +206,7 @@ class ApiClient {
         ...settings,
       }),
     })
+    return { id: response.contact_id }
   }
 
   async sendContactVerification(
@@ -461,6 +467,13 @@ class ApiClient {
 
   async createBalanceAlert(walletChecksum: string, alertData: CreateBalanceAlertRequest): Promise<BalanceAlert> {
     return this.request<BalanceAlert>(`/api/wallets/${walletChecksum}/balance-alerts`, {
+      method: 'POST',
+      body: JSON.stringify(alertData),
+    })
+  }
+
+  async validateBalanceAlert(walletChecksum: string, alertData: CreateBalanceAlertRequest): Promise<void> {
+    await this.request<void>(`/api/wallets/${walletChecksum}/balance-alerts/validate`, {
       method: 'POST',
       body: JSON.stringify(alertData),
     })


### PR DESCRIPTION
## Summary
- allow existing cloud contacts to add missing email or SMS delivery methods
- restore an unsaved deleted delivery method when the same provider is added again
- require verification for newly added SMS/email methods while keeping existing targets read-only

## Verification
- git diff --check
- pnpm exec jest --runTestsByPath 'src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx'
- pnpm --dir frontend lint
- .agent-loop/checks.sh frontend

## Notes
- .agent-loop/checks.sh quick currently fails in backend clippy before reaching frontend. The reported failures are in untouched backend/system-test files, so they appear unrelated to this frontend-only fix.