### PR TITLE
Pin Rust toolchain to 1.97.1

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.97.1 --profile minimal --component rustfmt,clippy
+
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -31,7 +34,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             backend/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('backend/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('backend/Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for Rust
-FROM rust:1.88-slim AS rust-builder
+FROM rust:1.97.1-slim-bookworm AS rust-builder
 
 WORKDIR /app
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.1"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

- pin local Rust/rustup and CI to Rust 1.97.1 with Clippy and rustfmt
- invalidate the Cargo cache when the pinned toolchain changes
- build the production image with the exact Rust 1.97.1 Bookworm base

## Why

Rust 1.97.1 fixes an LLVM miscompilation present since at least Rust 1.87, while the current production builder uses Rust 1.88.

This deliberately does not add Cargo's `rust-version`: Canary is an application, so this change pins the build toolchain without declaring a separate minimum-supported-Rust policy.

## Validation

- `.agent-loop/checks.sh backend`
- `.agent-loop/checks.sh quick`
- `docker build --pull --tag canary:issue-447-rust-1.97.1 .`
- production image startup smoke test reached `Server running on http://0.0.0.0:3000`

Closes #447
