### PR TITLE
Fix self-hosted Electrum sync load

### DIFF
--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -70,11 +70,17 @@ jobs:
           patch = Path(patch_path).read_text(encoding="utf-8", errors="replace")
           # `diff --git` headers already identify each file. Removing redundant metadata preserves
           # more reviewable changed lines inside the prompt budget.
-          patch = "".join(
-              line
-              for line in patch.splitlines(keepends=True)
-              if not line.startswith(("index ", "--- ", "+++ "))
-          )
+          filtered_patch = []
+          in_hunk = False
+          for line in patch.splitlines(keepends=True):
+              if line.startswith("diff --git "):
+                  in_hunk = False
+              elif line.startswith("@@ "):
+                  in_hunk = True
+              if not in_hunk and line.startswith(("index ", "--- ", "+++ ")):
+                  continue
+              filtered_patch.append(line)
+          patch = "".join(filtered_patch)
           # Leave more than 10 KiB for the static instructions, PR metadata, markers, action
           # wrapper, and environment differences below Linux's ~128 KiB per-argument ceiling.
           files, files_truncated = truncate_utf8(files, 8_000, "File list")

--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -40,12 +40,11 @@ jobs:
 
           git diff --name-only "$BASE_SHA" HEAD > "$FILES_FILE"
           # The Claude action transports its prompt as a process argument, which Linux caps near
-          # 128 KiB. Zero context keeps every changed line below that limit for large PRs.
+          # 128 KiB. Zero context reduces overhead; the byte budget below enforces the limit.
           git diff --no-ext-diff --unified=0 "$BASE_SHA" HEAD > "$PATCH_FILE"
 
-          # GitHub limits all outputs from a job to approximately 1 MB, measured
-          # using UTF-16 encoding. Keep enough headroom for action metadata while
-          # still providing a substantial patch to the tool-free reviewer.
+          # The Claude action passes the completed prompt as one process argument. Enforce a
+          # conservative UTF-8 byte budget here so future large PRs cannot fail with E2BIG.
           python3 - "$BASE_SHA" "$FILES_FILE" "$PATCH_FILE" "$GITHUB_OUTPUT" <<'PY'
           import secrets
           import sys
@@ -53,16 +52,14 @@ jobs:
 
           base_sha, files_path, patch_path, output_path = sys.argv[1:]
 
-          def truncate_utf16(value: str, budget: int, label: str):
-              encoded = value.encode("utf-16-le")
+          def truncate_utf8(value: str, budget: int, label: str):
+              encoded = value.encode("utf-8")
               if len(encoded) <= budget:
                   return value, False
 
-              notice = f"\n\n[{label} truncated to fit the GitHub Actions output limit]"
-              notice_size = len(notice.encode("utf-16-le"))
-              truncated = encoded[: budget - notice_size].decode(
-                  "utf-16-le", errors="ignore"
-              )
+              notice = f"\n\n[{label} truncated to fit the Claude process-argument limit]"
+              notice_size = len(notice.encode("utf-8"))
+              truncated = encoded[: budget - notice_size].decode("utf-8", errors="ignore")
               return truncated + notice, True
 
           def append_multiline(handle, name: str, value: str):
@@ -71,10 +68,17 @@ jobs:
 
           files = Path(files_path).read_text(encoding="utf-8", errors="replace")
           patch = Path(patch_path).read_text(encoding="utf-8", errors="replace")
-          # Reserve 40 KB for unusually long file lists and 700 KB for the
-          # patch, leaving roughly 260 KB of the job-output limit as headroom.
-          files, files_truncated = truncate_utf16(files, 40_000, "File list")
-          patch, patch_truncated = truncate_utf16(patch, 700_000, "Patch")
+          # `diff --git` headers already identify each file. Removing redundant metadata preserves
+          # more reviewable changed lines inside the prompt budget.
+          patch = "".join(
+              line
+              for line in patch.splitlines(keepends=True)
+              if not line.startswith(("index ", "--- ", "+++ "))
+          )
+          # Leave more than 10 KiB for the static instructions, PR metadata, markers, action
+          # wrapper, and environment differences below Linux's ~128 KiB per-argument ceiling.
+          files, files_truncated = truncate_utf8(files, 8_000, "File list")
+          patch, patch_truncated = truncate_utf8(patch, 108_000, "Patch")
 
           content_marker = f"CLAUDE_UNTRUSTED_{secrets.token_hex(16)}"
           while content_marker in files or content_marker in patch:

--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -40,8 +40,8 @@ jobs:
 
           git diff --name-only "$BASE_SHA" HEAD > "$FILES_FILE"
           # The Claude action transports its prompt as a process argument, which Linux caps near
-          # 128 KiB. One context line keeps the complete PR diff below that limit for large PRs.
-          git diff --no-ext-diff --unified=1 "$BASE_SHA" HEAD > "$PATCH_FILE"
+          # 128 KiB. Zero context keeps every changed line below that limit for large PRs.
+          git diff --no-ext-diff --unified=0 "$BASE_SHA" HEAD > "$PATCH_FILE"
 
           # GitHub limits all outputs from a job to approximately 1 MB, measured
           # using UTF-16 encoding. Keep enough headroom for action metadata while

--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -259,28 +259,60 @@ jobs:
               console.log('Created new Claude comment');
             }
 
+            // Resolve a status comment left by an earlier failed run. Keep a
+            // stable marker so a later failure can update the same comment
+            // instead of accumulating stale, contradictory notices.
+            const statusMarker = '<!-- claude-review-status -->';
+            const existingStatus = comments.find(c =>
+              c.body?.includes(statusMarker) ||
+              c.body?.includes('Claude code review failed')
+            );
+
+            if (existingStatus) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingStatus.id,
+                body: `${statusMarker}\n✅ **Claude code review recovered.** The latest [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) completed successfully.`,
+              });
+              console.log('Marked the Claude review status as recovered');
+            }
+
       - name: Notify on failure
         if: failure() || (always() && steps.claude-review.outcome == 'failure')
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}
           script: |
-            // Check for existing failure comment
+            // Reuse one status comment across failures and successful retries.
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
             });
 
+            const statusMarker = '<!-- claude-review-status -->';
             const existingFailure = comments.find(c =>
+              c.body?.includes(statusMarker) ||
               c.body?.includes('Claude code review failed')
             );
 
-            if (!existingFailure) {
+            const body = `${statusMarker}\n⚠️ **Claude code review failed.** Check the [workflow logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`;
+
+            if (existingFailure) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingFailure.id,
+                body,
+              });
+              console.log('Updated existing Claude failure status');
+            } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: '⚠️ **Claude code review failed.** Check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.',
+                body,
               });
+              console.log('Created Claude failure status');
             }

--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -39,7 +39,9 @@ jobs:
           PATCH_FILE="$RUNNER_TEMP/claude-pr.patch"
 
           git diff --name-only "$BASE_SHA" HEAD > "$FILES_FILE"
-          git diff --no-ext-diff "$BASE_SHA" HEAD > "$PATCH_FILE"
+          # The Claude action transports its prompt as a process argument, which Linux caps near
+          # 128 KiB. One context line keeps the complete PR diff below that limit for large PRs.
+          git diff --no-ext-diff --unified=1 "$BASE_SHA" HEAD > "$PATCH_FILE"
 
           # GitHub limits all outputs from a job to approximately 1 MB, measured
           # using UTF-16 encoding. Keep enough headroom for action metadata while

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -17,6 +17,13 @@ CANARY_NETWORK=regtest
 CANARY_ELECTRUM_URL=tcp://127.0.0.1:50001
 CANARY_BIND_ADDRESS=127.0.0.1:3000
 
+# Per-wallet freshness target (OPTIONAL)
+# Canary serializes script-heavy work against a self-hosted Electrum endpoint. Faster nodes
+# complete the queue sooner; if aggregate wallet work exceeds this target, wallets remain fairly
+# serviced in oldest-first order but may sync later. This is not a guaranteed latency SLA.
+# Network defaults: regtest=30, testnet=60, mainnet=300 seconds. Node packages may override it.
+# CANARY_SYNC_INTERVAL=300
+
 # Storage Configuration
 CANARY_DATA_DIR=./database/self-hosted
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -941,8 +941,9 @@ impl AppConfig {
         format!("{}/{}/metadata.sqlite", self.data_dir, self.network_name())
     }
 
-    /// Get sync interval based on mode and configuration
-    /// Self-hosted mode: Uses CANARY_SYNC_INTERVAL with network defaults
+    /// Get sync interval based on mode and configuration.
+    /// Self-hosted mode treats CANARY_SYNC_INTERVAL as a per-wallet freshness target and uses
+    /// network defaults when it is absent.
     /// Cloud mode: Delegates to subscription tier logic
     pub fn get_sync_interval(&self) -> u64 {
         let sync_interval = std::env::var("CANARY_SYNC_INTERVAL").ok();

--- a/backend/src/electrum.rs
+++ b/backend/src/electrum.rs
@@ -561,7 +561,7 @@ impl ElectrumClient {
         })?;
         cleanup_result.map_err(|error| {
             anyhow!(
-                "Electrum subscription cleanup was cancelled; connection replacement required: {error}"
+                "Electrum subscription cleanup did not complete cleanly; connection replacement required: {error}"
             )
         })?;
         Ok(())
@@ -720,6 +720,7 @@ impl ElectrumClientManager {
         let client_arc = Arc::clone(&client.client);
         if let Err(error) = client_arc.inner.start_work() {
             debug!("ElectrumClientManager: Connection verification cannot start: {error}");
+            self.mark_disconnected(&error.to_string()).await;
             return false;
         }
         let cancellation_client = Arc::clone(&client_arc);

--- a/backend/src/electrum.rs
+++ b/backend/src/electrum.rs
@@ -490,6 +490,19 @@ impl ElectrumClient {
         Ok(tx)
     }
 
+    /// Remove recurring-history subscriptions and cached histories for scripts no longer owned by
+    /// an active wallet. Callers serialize this with other self-hosted Electrum work.
+    async fn forget_scripts(&self, scripts: Vec<ScriptBuf>) -> Result<()> {
+        if scripts.is_empty() {
+            return Ok(());
+        }
+        let client = Arc::clone(&self.client);
+        spawn_blocking(move || client.inner.forget_scripts(&scripts))
+            .await
+            .map_err(|error| anyhow!("Electrum subscription cleanup task failed: {error}"))?;
+        Ok(())
+    }
+
     pub async fn get_current_block_height(&self) -> Result<u32> {
         let client = Arc::clone(&self.client);
         let height = timeout(Duration::from_secs(BLOCK_OP_TIMEOUT_SECS), spawn_blocking(move || {
@@ -572,6 +585,19 @@ impl ElectrumClientManager {
     /// Get a clone of the current client for operations
     pub async fn get_client(&self) -> Option<ElectrumClient> {
         self.client.read().await.clone()
+    }
+
+    /// Forget scripts after wallet deletion even if the socket is currently disconnected.
+    pub async fn forget_scripts(&self, scripts: Vec<ScriptBuf>) -> Result<()> {
+        if let Some(client) = self.get_client().await {
+            if let Err(error) = client.forget_scripts(scripts.clone()).await {
+                self.history_cache.forget_scripts(&scripts);
+                return Err(error);
+            }
+        } else {
+            self.history_cache.forget_scripts(&scripts);
+        }
+        Ok(())
     }
 
     /// Check if we have an active client (passive check - may return true for dead connections)

--- a/backend/src/electrum.rs
+++ b/backend/src/electrum.rs
@@ -25,6 +25,7 @@ pub const BATCH_SIZE: usize = 20;
 const PRIMARY_SYNC_TIMEOUT_SECS: u64 = 60;
 const FULL_SCAN_TIMEOUT_SECS: u64 = 120;
 const BLOCK_OP_TIMEOUT_SECS: u64 = 10;
+const SUBSCRIPTION_CLEANUP_TIMEOUT_SECS: u64 = 60;
 const CANCELLATION_DRAIN_TIMEOUT_SECS: u64 = 45;
 
 fn self_hosted_operation_gate(subscriptions_enabled: bool) -> Option<Arc<Mutex<()>>> {
@@ -540,9 +541,29 @@ impl ElectrumClient {
         }
         let _operation = self.acquire_operation().await;
         let client = Arc::clone(&self.client);
-        spawn_blocking(move || client.inner.forget_scripts(&scripts))
-            .await
-            .map_err(|error| anyhow!("Electrum subscription cleanup task failed: {error}"))?;
+        client
+            .inner
+            .start_work()
+            .map_err(|error| anyhow!("Electrum subscription cleanup cannot start: {error}"))?;
+        let cancellation_client = Arc::clone(&client);
+        let mut cleanup_task = spawn_blocking(move || client.inner.forget_scripts(&scripts));
+        let cleanup_result = await_blocking_with_timeout(
+            &mut cleanup_task,
+            Duration::from_secs(SUBSCRIPTION_CLEANUP_TIMEOUT_SECS),
+            "Electrum subscription cleanup",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
+        )
+        .await
+        .map_err(|error| {
+            anyhow!(
+                "Electrum subscription cleanup could not finish safely; connection replacement required: {error}"
+            )
+        })?;
+        cleanup_result.map_err(|error| {
+            anyhow!(
+                "Electrum subscription cleanup was cancelled; connection replacement required: {error}"
+            )
+        })?;
         Ok(())
     }
 
@@ -643,6 +664,9 @@ impl ElectrumClientManager {
         if let Some(client) = self.get_client().await {
             if let Err(error) = client.forget_scripts(scripts.clone()).await {
                 self.history_cache.forget_scripts(&scripts);
+                if Self::is_transport_error(&error.to_string()) {
+                    self.mark_disconnected(&error.to_string()).await;
+                }
                 return Err(error);
             }
         } else {

--- a/backend/src/electrum.rs
+++ b/backend/src/electrum.rs
@@ -1,12 +1,11 @@
+use crate::electrum_history::{SharedHistoryCache, SubscriptionHistoryClient};
 use anyhow::{anyhow, Result};
 use bdk_electrum::electrum_client::{self, ElectrumApi, GetBalanceRes, GetHistoryRes};
 use bdk_electrum::BdkElectrumClient;
 use bdk_wallet::bitcoin::{ScriptBuf, Transaction, Txid};
-use bdk_wallet::chain::collections::HashSet;
 use bdk_wallet::rusqlite::Connection;
 use bdk_wallet::{KeychainKind, PersistedWallet};
 use serde::{Deserialize, Serialize};
-use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -29,11 +28,21 @@ const BLOCK_OP_TIMEOUT_SECS: u64 = 10;
 
 #[derive(Clone)]
 pub struct ElectrumClient {
-    pub client: Arc<BdkElectrumClient<electrum_client::Client>>,
+    pub(crate) client:
+        Arc<BdkElectrumClient<SubscriptionHistoryClient<Arc<electrum_client::Client>>>>,
+    polling_client: Arc<BdkElectrumClient<Arc<electrum_client::Client>>>,
 }
 
 impl ElectrumClient {
     pub fn new(url: &str) -> Result<Self> {
+        Self::new_with_history_cache(url, SharedHistoryCache::default(), false)
+    }
+
+    fn new_with_history_cache(
+        url: &str,
+        history_cache: SharedHistoryCache,
+        subscriptions_enabled: bool,
+    ) -> Result<Self> {
         // electrum_client::Client::new() handles both tcp:// and ssl:// schemes automatically
         if !url.starts_with("tcp://") && !url.starts_with("ssl://") {
             return Err(anyhow!(
@@ -48,11 +57,56 @@ impl ElectrumClient {
         let config = electrum_client::Config::builder()
             .timeout(Some(Duration::from_secs(BLOCK_OP_TIMEOUT_SECS)))
             .build();
-        let electrum_client = electrum_client::Client::from_config(url, config)?;
-        let client = BdkElectrumClient::new(electrum_client);
+        let electrum_client = Arc::new(electrum_client::Client::from_config(url, config)?);
+
+        // electrum-client negotiates this when opening the connection but does not expose the
+        // stored value on its general Client wrapper. A diagnostic server.version call records
+        // the same negotiated range without changing sync behavior.
+        match electrum_client.raw_call(
+            "server.version",
+            [
+                electrum_client::Param::String(format!("Canary {}", env!("CARGO_PKG_VERSION"))),
+                electrum_client::Param::StringVec(vec!["1.4".to_string(), "1.6".to_string()]),
+            ],
+        ) {
+            Ok(value) => match serde_json::from_value::<electrum_client::ServerVersionRes>(value) {
+                Ok(version) => info!(
+                    "Electrum connection negotiated protocol {} with {}",
+                    version.protocol_version, version.server_software_version
+                ),
+                Err(error) => debug!("Could not decode Electrum protocol diagnostics: {error}"),
+            },
+            Err(error) => debug!("Could not query Electrum protocol diagnostics: {error}"),
+        }
+
+        let subscription_client = SubscriptionHistoryClient::new(
+            Arc::clone(&electrum_client),
+            history_cache,
+            subscriptions_enabled,
+        );
         Ok(ElectrumClient {
-            client: Arc::new(client),
+            client: Arc::new(BdkElectrumClient::new(subscription_client)),
+            polling_client: Arc::new(BdkElectrumClient::new(electrum_client)),
         })
+    }
+
+    fn populate_caches(&self, wallet: &PersistedWallet<Connection>) {
+        let txs: Vec<_> = wallet
+            .tx_graph()
+            .full_txs()
+            .map(|tx_node| tx_node.tx.clone())
+            .collect();
+        self.client.populate_tx_cache(txs.iter().cloned());
+        self.polling_client.populate_tx_cache(txs);
+
+        let anchors: Vec<_> = wallet
+            .tx_graph()
+            .all_anchors()
+            .iter()
+            .map(|(txid, anchors)| (*txid, anchors.iter().cloned().collect::<Vec<_>>()))
+            .collect();
+        self.client.populate_anchor_cache(anchors.iter().cloned());
+        self.polling_client.populate_anchor_cache(anchors);
     }
 
     /// Get the highest address index that has been used (has transactions)
@@ -161,94 +215,48 @@ impl ElectrumClient {
     pub async fn full_scan_wallet(
         &self,
         wallet: &mut PersistedWallet<Connection>,
-        custom_stop_gap: Option<usize>,
+        scan_gap: usize,
     ) -> Result<()> {
-        info!("Full scanning with electrum...");
+        info!("Full scanning with Electrum (scan gap: {scan_gap})...");
 
         // Print initial balance
         let balance_before = wallet.balance();
         info!("Wallet balance before syncing: {}", balance_before.total());
 
-        let stop_gap = custom_stop_gap.unwrap_or(STOP_GAP);
-        let initial_reveal: u32 = std::cmp::max(stop_gap as u32, 50);
-
-        info!(
-            "Initial address revelation (up to index {}):",
-            initial_reveal
-        );
-        let ext_revealed: Vec<_> = wallet
-            .reveal_addresses_to(KeychainKind::External, initial_reveal)
-            .collect();
-        info!("  Revealed {} external addresses", ext_revealed.len());
-
-        let int_revealed: Vec<_> = wallet
-            .reveal_addresses_to(KeychainKind::Internal, initial_reveal)
-            .collect();
-        info!("  Revealed {} internal addresses", int_revealed.len());
-
-        // Loop until we've satisfied the stop gap for both keychains
-        let mut scan_iteration = 0;
-        loop {
-            scan_iteration += 1;
-            info!("\nScan iteration {}", scan_iteration);
-
-            // Populate the electrum client's transaction cache
-            self.client
-                .populate_tx_cache(wallet.tx_graph().full_txs().map(|tx_node| tx_node.tx));
-
-            // Start full scan with progress indicator
-            let request = wallet.start_full_scan().inspect({
-                let mut stdout = io::stdout();
-                let mut once = HashSet::<KeychainKind>::new();
-                move |k, spk_i, _| {
-                    if once.insert(k) {
-                        print!("\nScanning keychain [{:?}]", k);
-                    }
-                    print!(" {:<3}", spk_i);
-                    stdout.flush().expect("must flush");
-                }
-            });
-
-            // Perform the full scan with timeout protection (120 seconds for more intensive operation)
-            let stop_gap = custom_stop_gap.unwrap_or(STOP_GAP);
-            info!("Using stop gap: {}", stop_gap);
-            let client = Arc::clone(&self.client);
-            let update = timeout(
-                Duration::from_secs(FULL_SCAN_TIMEOUT_SECS),
-                spawn_blocking(move || client.full_scan(request, stop_gap, BATCH_SIZE, false)),
-            )
+        // Full scans deliberately use the polling client: speculative recovery scripts should
+        // not remain subscribed. BDK applies last_active_indices from this response, so no manual
+        // pre-reveal or repeated deep-sync loop is needed.
+        self.populate_caches(wallet);
+        let request = wallet.start_full_scan();
+        let client = Arc::clone(&self.polling_client);
+        let mut scan_task =
+            spawn_blocking(move || client.full_scan(request, scan_gap, BATCH_SIZE, false));
+        let scan_result = match timeout(Duration::from_secs(FULL_SCAN_TIMEOUT_SECS), &mut scan_task)
             .await
-            .map_err(|_| {
-                anyhow!("Full scan operation timed out after {FULL_SCAN_TIMEOUT_SECS} seconds")
-            })?
+        {
+            Ok(result) => result,
+            Err(_) => {
+                warn!(
+                    "Full scan exceeded {FULL_SCAN_TIMEOUT_SECS}s; waiting for the blocking worker before releasing the Electrum work gate"
+                );
+                let _ = scan_task.await;
+                return Err(anyhow!(
+                    "Full scan operation timed out after {FULL_SCAN_TIMEOUT_SECS} seconds"
+                ));
+            }
+        };
+        let update = scan_result
             .map_err(|e| anyhow!("Full scan task failed: {}", e))?
             .map_err(|e| anyhow!("Full scan failed: {}", e))?;
 
-            println!(); // New line after scan progress
+        wallet
+            .apply_update(update)
+            .map_err(|e| anyhow!("Failed to apply update: {}", e))?;
 
-            // Apply the update
-            wallet
-                .apply_update(update)
-                .map_err(|e| anyhow!("Failed to apply update: {}", e))?;
-
-            // Check if we need to reveal more addresses to satisfy the stop gap
-            let ext_needs_more =
-                Self::ensure_stop_gap_maintained(wallet, KeychainKind::External, stop_gap)?;
-            let int_needs_more =
-                Self::ensure_stop_gap_maintained(wallet, KeychainKind::Internal, stop_gap)?;
-
-            // If no new addresses were revealed, we're done
-            if !ext_needs_more && !int_needs_more {
-                info!("Stop gap satisfied for both keychains");
-                break;
-            }
-
-            // Safety check to prevent infinite loops
-            if scan_iteration > 10 {
-                warn!("Warning: Reached maximum scan iterations");
-                break;
-            }
-        }
+        // Retain only Canary's normal lookahead beyond activity. This only grows reveal indices,
+        // so legacy wallets that already persisted a deeper reveal are never shrunk.
+        Self::ensure_stop_gap_maintained(wallet, KeychainKind::External, STOP_GAP)?;
+        Self::ensure_stop_gap_maintained(wallet, KeychainKind::Internal, STOP_GAP)?;
 
         // Print final balance
         let balance_after = wallet.balance();
@@ -270,8 +278,7 @@ impl ElectrumClient {
 
         // Populate the electrum client's transaction cache
         let cache_start = Instant::now();
-        self.client
-            .populate_tx_cache(wallet.tx_graph().full_txs().map(|tx_node| tx_node.tx));
+        self.populate_caches(wallet);
         debug!(
             "[electrum] populate_tx_cache completed in {:.2?}",
             cache_start.elapsed()
@@ -283,14 +290,30 @@ impl ElectrumClient {
         // Perform the sync with timeout protection to avoid indefinite hangs
         let electrum_sync_start = Instant::now();
         let client = Arc::clone(&self.client);
-        let update = timeout(
+        let mut sync_task = spawn_blocking(move || {
+            client.inner.prepare_recurring_work();
+            client.sync(request, BATCH_SIZE, false)
+        });
+        let sync_result = match timeout(
             Duration::from_secs(PRIMARY_SYNC_TIMEOUT_SECS),
-            spawn_blocking(move || client.sync(request, BATCH_SIZE, false)),
+            &mut sync_task,
         )
         .await
-        .map_err(|_| anyhow!("Sync operation timed out after {PRIMARY_SYNC_TIMEOUT_SECS} seconds"))?
-        .map_err(|e| anyhow!("Sync task failed: {}", e))?
-        .map_err(|e| anyhow!("Sync failed: {}", e))?;
+        {
+            Ok(result) => result,
+            Err(_) => {
+                warn!(
+                    "Sync exceeded {PRIMARY_SYNC_TIMEOUT_SECS}s; waiting for the blocking worker before releasing the Electrum work gate"
+                );
+                let _ = sync_task.await;
+                return Err(anyhow!(
+                    "Sync operation timed out after {PRIMARY_SYNC_TIMEOUT_SECS} seconds"
+                ));
+            }
+        };
+        let update = sync_result
+            .map_err(|e| anyhow!("Sync task failed: {}", e))?
+            .map_err(|e| anyhow!("Sync failed: {}", e))?;
         debug!(
             "[electrum] primary sync completed in {:.2?}",
             electrum_sync_start.elapsed()
@@ -320,18 +343,30 @@ impl ElectrumClient {
             let request = wallet.start_sync_with_revealed_spks();
             let additional_sync_start = Instant::now();
             let client = Arc::clone(&self.client);
-            let update = timeout(
+            let mut additional_task = spawn_blocking(move || {
+                client.inner.prepare_recurring_work();
+                client.sync(request, BATCH_SIZE, false)
+            });
+            let additional_result = match timeout(
                 Duration::from_secs(PRIMARY_SYNC_TIMEOUT_SECS),
-                spawn_blocking(move || client.sync(request, BATCH_SIZE, false)),
+                &mut additional_task,
             )
             .await
-            .map_err(|_| {
-                anyhow!(
-                    "Additional sync operation timed out after {PRIMARY_SYNC_TIMEOUT_SECS} seconds"
-                )
-            })?
-            .map_err(|e| anyhow!("Additional sync task failed: {}", e))?
-            .map_err(|e| anyhow!("Additional sync failed: {}", e))?;
+            {
+                Ok(result) => result,
+                Err(_) => {
+                    warn!(
+                        "Additional sync exceeded {PRIMARY_SYNC_TIMEOUT_SECS}s; waiting for the blocking worker before releasing the Electrum work gate"
+                    );
+                    let _ = additional_task.await;
+                    return Err(anyhow!(
+                        "Additional sync operation timed out after {PRIMARY_SYNC_TIMEOUT_SECS} seconds"
+                    ));
+                }
+            };
+            let update = additional_result
+                .map_err(|e| anyhow!("Additional sync task failed: {}", e))?
+                .map_err(|e| anyhow!("Additional sync failed: {}", e))?;
             debug!(
                 "[electrum] additional sync completed in {:.2?}",
                 additional_sync_start.elapsed()
@@ -378,14 +413,27 @@ impl ElectrumClient {
     pub async fn script_get_history(&self, script: &ScriptBuf) -> Result<Vec<GetHistoryRes>> {
         let client = Arc::clone(&self.client);
         let script = script.clone();
-        let history = timeout(
+        let mut history_task = spawn_blocking(move || {
+            client.inner.prepare_recurring_work();
+            client.inner.script_get_history(&script)
+        });
+        let history_result = match timeout(
             Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
-            spawn_blocking(move || client.inner.script_get_history(&script)),
+            &mut history_task,
         )
         .await
-        .map_err(|_| anyhow!("script_get_history timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"))?
-        .map_err(|e| anyhow!("script_get_history task failed: {}", e))?
-        .map_err(|e| anyhow!("script_get_history failed: {}", e))?;
+        {
+            Ok(result) => result,
+            Err(_) => {
+                let _ = history_task.await;
+                return Err(anyhow!(
+                    "script_get_history timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"
+                ));
+            }
+        };
+        let history = history_result
+            .map_err(|e| anyhow!("script_get_history task failed: {}", e))?
+            .map_err(|e| anyhow!("script_get_history failed: {}", e))?;
 
         Ok(history)
     }
@@ -394,14 +442,24 @@ impl ElectrumClient {
     pub async fn script_get_balance(&self, script: &ScriptBuf) -> Result<GetBalanceRes> {
         let client = Arc::clone(&self.client);
         let script = script.clone();
-        let balance = timeout(
+        let mut balance_task = spawn_blocking(move || client.inner.script_get_balance(&script));
+        let balance_result = match timeout(
             Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
-            spawn_blocking(move || client.inner.script_get_balance(&script)),
+            &mut balance_task,
         )
         .await
-        .map_err(|_| anyhow!("script_get_balance timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"))?
-        .map_err(|e| anyhow!("script_get_balance task failed: {}", e))?
-        .map_err(|e| anyhow!("script_get_balance failed: {}", e))?;
+        {
+            Ok(result) => result,
+            Err(_) => {
+                let _ = balance_task.await;
+                return Err(anyhow!(
+                    "script_get_balance timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"
+                ));
+            }
+        };
+        let balance = balance_result
+            .map_err(|e| anyhow!("script_get_balance task failed: {}", e))?
+            .map_err(|e| anyhow!("script_get_balance failed: {}", e))?;
 
         Ok(balance)
     }
@@ -410,14 +468,24 @@ impl ElectrumClient {
     pub async fn transaction_get(&self, txid: &Txid) -> Result<Transaction> {
         let client = Arc::clone(&self.client);
         let txid = *txid;
-        let tx = timeout(
+        let mut transaction_task = spawn_blocking(move || client.inner.transaction_get(&txid));
+        let transaction_result = match timeout(
             Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
-            spawn_blocking(move || client.inner.transaction_get(&txid)),
+            &mut transaction_task,
         )
         .await
-        .map_err(|_| anyhow!("transaction_get timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"))?
-        .map_err(|e| anyhow!("transaction_get task failed: {}", e))?
-        .map_err(|e| anyhow!("transaction_get failed: {}", e))?;
+        {
+            Ok(result) => result,
+            Err(_) => {
+                let _ = transaction_task.await;
+                return Err(anyhow!(
+                    "transaction_get timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"
+                ));
+            }
+        };
+        let tx = transaction_result
+            .map_err(|e| anyhow!("transaction_get task failed: {}", e))?
+            .map_err(|e| anyhow!("transaction_get failed: {}", e))?;
 
         Ok(tx)
     }
@@ -455,12 +523,24 @@ pub struct ElectrumClientManager {
     alert_sent: AtomicBool,
     /// Last error message for diagnostics
     last_error: RwLock<Option<String>>,
+    history_cache: SharedHistoryCache,
+    subscriptions_enabled: bool,
 }
 
 impl ElectrumClientManager {
     /// Create a new manager with initial connection attempt
     pub fn new(url: &str) -> Result<Self> {
-        let client = ElectrumClient::new(url).ok();
+        Self::new_with_subscriptions(url, false)
+    }
+
+    pub(crate) fn new_with_subscriptions(url: &str, subscriptions_enabled: bool) -> Result<Self> {
+        let history_cache = SharedHistoryCache::default();
+        let client = ElectrumClient::new_with_history_cache(
+            url,
+            history_cache.clone(),
+            subscriptions_enabled,
+        )
+        .ok();
         let has_client = client.is_some();
 
         let manager = Self {
@@ -470,6 +550,8 @@ impl ElectrumClientManager {
             consecutive_failures: AtomicU32::new(0),
             alert_sent: AtomicBool::new(false),
             last_error: RwLock::new(None),
+            history_cache,
+            subscriptions_enabled,
         };
 
         if has_client {
@@ -609,7 +691,11 @@ impl ElectrumClientManager {
             self.url
         );
 
-        let result = match ElectrumClient::new(&self.url) {
+        let result = match ElectrumClient::new_with_history_cache(
+            &self.url,
+            self.history_cache.clone(),
+            self.subscriptions_enabled,
+        ) {
             Ok(new_client) => {
                 // Update the client
                 let mut client_guard = self.client.write().await;
@@ -689,6 +775,8 @@ impl ElectrumClientManager {
             consecutive_failures: AtomicU32::new(0),
             alert_sent: AtomicBool::new(false),
             last_error: RwLock::new(None),
+            history_cache: SharedHistoryCache::default(),
+            subscriptions_enabled: false,
         }
     }
 }

--- a/backend/src/electrum.rs
+++ b/backend/src/electrum.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
-use tokio::task::spawn_blocking;
+use tokio::task::{spawn_blocking, JoinHandle};
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
@@ -25,12 +25,56 @@ pub const BATCH_SIZE: usize = 20;
 const PRIMARY_SYNC_TIMEOUT_SECS: u64 = 60;
 const FULL_SCAN_TIMEOUT_SECS: u64 = 120;
 const BLOCK_OP_TIMEOUT_SECS: u64 = 10;
+const CANCELLATION_DRAIN_TIMEOUT_SECS: u64 = 45;
+
+async fn await_blocking_with_timeout<T>(
+    task: &mut JoinHandle<T>,
+    deadline: Duration,
+    operation: &str,
+    update_cancellation: impl Fn(bool),
+) -> Result<T>
+where
+    T: Send + 'static,
+{
+    match timeout(deadline, &mut *task).await {
+        Ok(result) => result.map_err(|error| anyhow!("{operation} task failed: {error}")),
+        Err(_) => {
+            update_cancellation(false);
+            warn!(
+                "{operation} exceeded {:.2?}; cancellation requested, draining the blocking worker for at most {CANCELLATION_DRAIN_TIMEOUT_SECS}s",
+                deadline
+            );
+            match timeout(
+                Duration::from_secs(CANCELLATION_DRAIN_TIMEOUT_SECS),
+                &mut *task,
+            )
+            .await
+            {
+                Ok(_) => Err(anyhow!(
+                    "{operation} timed out after {} seconds",
+                    deadline.as_secs()
+                )),
+                Err(_) => {
+                    // Tokio cannot abort a spawn_blocking closure once it is running. The adapter
+                    // checks cancellation between bounded socket RPCs; reaching this branch means
+                    // the connection must be replaced before more work is attempted.
+                    update_cancellation(true);
+                    task.abort();
+                    Err(anyhow!(
+                        "{operation} timed out after {} seconds and its worker did not stop within {CANCELLATION_DRAIN_TIMEOUT_SECS} seconds; connection replacement required",
+                        deadline.as_secs()
+                    ))
+                }
+            }
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct ElectrumClient {
     pub(crate) client:
         Arc<BdkElectrumClient<SubscriptionHistoryClient<Arc<electrum_client::Client>>>>,
-    polling_client: Arc<BdkElectrumClient<Arc<electrum_client::Client>>>,
+    polling_client: Arc<BdkElectrumClient<SubscriptionHistoryClient<Arc<electrum_client::Client>>>>,
 }
 
 impl ElectrumClient {
@@ -84,9 +128,11 @@ impl ElectrumClient {
             history_cache,
             subscriptions_enabled,
         );
+        let polling_client =
+            SubscriptionHistoryClient::polling(electrum_client, &subscription_client);
         Ok(ElectrumClient {
             client: Arc::new(BdkElectrumClient::new(subscription_client)),
-            polling_client: Arc::new(BdkElectrumClient::new(electrum_client)),
+            polling_client: Arc::new(BdkElectrumClient::new(polling_client)),
         })
     }
 
@@ -229,25 +275,21 @@ impl ElectrumClient {
         self.populate_caches(wallet);
         let request = wallet.start_full_scan();
         let client = Arc::clone(&self.polling_client);
+        client
+            .inner
+            .start_work()
+            .map_err(|error| anyhow!("Full scan cannot start: {error}"))?;
+        let cancellation_client = Arc::clone(&client);
         let mut scan_task =
             spawn_blocking(move || client.full_scan(request, scan_gap, BATCH_SIZE, false));
-        let scan_result = match timeout(Duration::from_secs(FULL_SCAN_TIMEOUT_SECS), &mut scan_task)
-            .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                warn!(
-                    "Full scan exceeded {FULL_SCAN_TIMEOUT_SECS}s; waiting for the blocking worker before releasing the Electrum work gate"
-                );
-                let _ = scan_task.await;
-                return Err(anyhow!(
-                    "Full scan operation timed out after {FULL_SCAN_TIMEOUT_SECS} seconds"
-                ));
-            }
-        };
-        let update = scan_result
-            .map_err(|e| anyhow!("Full scan task failed: {}", e))?
-            .map_err(|e| anyhow!("Full scan failed: {}", e))?;
+        let scan_result = await_blocking_with_timeout(
+            &mut scan_task,
+            Duration::from_secs(FULL_SCAN_TIMEOUT_SECS),
+            "Full scan operation",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
+        )
+        .await?;
+        let update = scan_result.map_err(|e| anyhow!("Full scan failed: {}", e))?;
 
         wallet
             .apply_update(update)
@@ -290,30 +332,23 @@ impl ElectrumClient {
         // Perform the sync with timeout protection to avoid indefinite hangs
         let electrum_sync_start = Instant::now();
         let client = Arc::clone(&self.client);
+        client
+            .inner
+            .start_work()
+            .map_err(|error| anyhow!("Sync cannot start: {error}"))?;
+        let cancellation_client = Arc::clone(&client);
         let mut sync_task = spawn_blocking(move || {
             client.inner.prepare_recurring_work();
             client.sync(request, BATCH_SIZE, false)
         });
-        let sync_result = match timeout(
-            Duration::from_secs(PRIMARY_SYNC_TIMEOUT_SECS),
+        let sync_result = await_blocking_with_timeout(
             &mut sync_task,
+            Duration::from_secs(PRIMARY_SYNC_TIMEOUT_SECS),
+            "Sync operation",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
         )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                warn!(
-                    "Sync exceeded {PRIMARY_SYNC_TIMEOUT_SECS}s; waiting for the blocking worker before releasing the Electrum work gate"
-                );
-                let _ = sync_task.await;
-                return Err(anyhow!(
-                    "Sync operation timed out after {PRIMARY_SYNC_TIMEOUT_SECS} seconds"
-                ));
-            }
-        };
-        let update = sync_result
-            .map_err(|e| anyhow!("Sync task failed: {}", e))?
-            .map_err(|e| anyhow!("Sync failed: {}", e))?;
+        .await?;
+        let update = sync_result.map_err(|e| anyhow!("Sync failed: {}", e))?;
         debug!(
             "[electrum] primary sync completed in {:.2?}",
             electrum_sync_start.elapsed()
@@ -343,30 +378,23 @@ impl ElectrumClient {
             let request = wallet.start_sync_with_revealed_spks();
             let additional_sync_start = Instant::now();
             let client = Arc::clone(&self.client);
+            client
+                .inner
+                .start_work()
+                .map_err(|error| anyhow!("Additional sync cannot start: {error}"))?;
+            let cancellation_client = Arc::clone(&client);
             let mut additional_task = spawn_blocking(move || {
                 client.inner.prepare_recurring_work();
                 client.sync(request, BATCH_SIZE, false)
             });
-            let additional_result = match timeout(
-                Duration::from_secs(PRIMARY_SYNC_TIMEOUT_SECS),
+            let additional_result = await_blocking_with_timeout(
                 &mut additional_task,
+                Duration::from_secs(PRIMARY_SYNC_TIMEOUT_SECS),
+                "Additional sync operation",
+                move |poison| cancellation_client.inner.update_timeout_state(poison),
             )
-            .await
-            {
-                Ok(result) => result,
-                Err(_) => {
-                    warn!(
-                        "Additional sync exceeded {PRIMARY_SYNC_TIMEOUT_SECS}s; waiting for the blocking worker before releasing the Electrum work gate"
-                    );
-                    let _ = additional_task.await;
-                    return Err(anyhow!(
-                        "Additional sync operation timed out after {PRIMARY_SYNC_TIMEOUT_SECS} seconds"
-                    ));
-                }
-            };
-            let update = additional_result
-                .map_err(|e| anyhow!("Additional sync task failed: {}", e))?
-                .map_err(|e| anyhow!("Additional sync failed: {}", e))?;
+            .await?;
+            let update = additional_result.map_err(|e| anyhow!("Additional sync failed: {}", e))?;
             debug!(
                 "[electrum] additional sync completed in {:.2?}",
                 additional_sync_start.elapsed()
@@ -392,15 +420,19 @@ impl ElectrumClient {
 
     pub async fn get_block_header(&self, height: u32) -> Result<BlockHeader> {
         let client = Arc::clone(&self.client);
-        let header = timeout(
+        client
+            .inner
+            .start_work()
+            .map_err(|error| anyhow!("Block header lookup cannot start: {error}"))?;
+        let cancellation_client = Arc::clone(&client);
+        let mut header_task = spawn_blocking(move || client.inner.block_header(height as usize));
+        let header = await_blocking_with_timeout(
+            &mut header_task,
             Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
-            spawn_blocking(move || client.inner.block_header(height as usize)),
+            "Get block header operation",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
         )
-        .await
-        .map_err(|_| {
-            anyhow!("Get block header operation timed out after {BLOCK_OP_TIMEOUT_SECS} seconds")
-        })?
-        .map_err(|e| anyhow!("Get block header task failed: {}", e))?
+        .await?
         .map_err(|e| anyhow!("Failed to get block header for height {}: {}", height, e))?;
 
         Ok(BlockHeader {
@@ -412,28 +444,24 @@ impl ElectrumClient {
     /// Get transaction history for a specific script pubkey (for address watches)
     pub async fn script_get_history(&self, script: &ScriptBuf) -> Result<Vec<GetHistoryRes>> {
         let client = Arc::clone(&self.client);
+        client
+            .inner
+            .start_work()
+            .map_err(|error| anyhow!("script_get_history cannot start: {error}"))?;
+        let cancellation_client = Arc::clone(&client);
         let script = script.clone();
         let mut history_task = spawn_blocking(move || {
             client.inner.prepare_recurring_work();
             client.inner.script_get_history(&script)
         });
-        let history_result = match timeout(
-            Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
+        let history_result = await_blocking_with_timeout(
             &mut history_task,
+            Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
+            "script_get_history",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
         )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                let _ = history_task.await;
-                return Err(anyhow!(
-                    "script_get_history timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"
-                ));
-            }
-        };
-        let history = history_result
-            .map_err(|e| anyhow!("script_get_history task failed: {}", e))?
-            .map_err(|e| anyhow!("script_get_history failed: {}", e))?;
+        .await?;
+        let history = history_result.map_err(|e| anyhow!("script_get_history failed: {}", e))?;
 
         Ok(history)
     }
@@ -441,25 +469,21 @@ impl ElectrumClient {
     /// Get balance for a specific script pubkey (for address watches)
     pub async fn script_get_balance(&self, script: &ScriptBuf) -> Result<GetBalanceRes> {
         let client = Arc::clone(&self.client);
+        client
+            .inner
+            .start_work()
+            .map_err(|error| anyhow!("script_get_balance cannot start: {error}"))?;
+        let cancellation_client = Arc::clone(&client);
         let script = script.clone();
         let mut balance_task = spawn_blocking(move || client.inner.script_get_balance(&script));
-        let balance_result = match timeout(
-            Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
+        let balance_result = await_blocking_with_timeout(
             &mut balance_task,
+            Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
+            "script_get_balance",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
         )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                let _ = balance_task.await;
-                return Err(anyhow!(
-                    "script_get_balance timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"
-                ));
-            }
-        };
-        let balance = balance_result
-            .map_err(|e| anyhow!("script_get_balance task failed: {}", e))?
-            .map_err(|e| anyhow!("script_get_balance failed: {}", e))?;
+        .await?;
+        let balance = balance_result.map_err(|e| anyhow!("script_get_balance failed: {}", e))?;
 
         Ok(balance)
     }
@@ -467,25 +491,21 @@ impl ElectrumClient {
     /// Get a full transaction by txid (for address watches)
     pub async fn transaction_get(&self, txid: &Txid) -> Result<Transaction> {
         let client = Arc::clone(&self.client);
+        client
+            .inner
+            .start_work()
+            .map_err(|error| anyhow!("transaction_get cannot start: {error}"))?;
+        let cancellation_client = Arc::clone(&client);
         let txid = *txid;
         let mut transaction_task = spawn_blocking(move || client.inner.transaction_get(&txid));
-        let transaction_result = match timeout(
-            Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
+        let transaction_result = await_blocking_with_timeout(
             &mut transaction_task,
+            Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
+            "transaction_get",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
         )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                let _ = transaction_task.await;
-                return Err(anyhow!(
-                    "transaction_get timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"
-                ));
-            }
-        };
-        let tx = transaction_result
-            .map_err(|e| anyhow!("transaction_get task failed: {}", e))?
-            .map_err(|e| anyhow!("transaction_get failed: {}", e))?;
+        .await?;
+        let tx = transaction_result.map_err(|e| anyhow!("transaction_get failed: {}", e))?;
 
         Ok(tx)
     }
@@ -505,12 +525,19 @@ impl ElectrumClient {
 
     pub async fn get_current_block_height(&self) -> Result<u32> {
         let client = Arc::clone(&self.client);
-        let height = timeout(Duration::from_secs(BLOCK_OP_TIMEOUT_SECS), spawn_blocking(move || {
-            client.inner.block_headers_subscribe()
-        }))
-        .await
-        .map_err(|_| anyhow!("Get current block height operation timed out after {BLOCK_OP_TIMEOUT_SECS} seconds"))?
-        .map_err(|e| anyhow!("Get current block height task failed: {}", e))?
+        client
+            .inner
+            .start_work()
+            .map_err(|error| anyhow!("Block height lookup cannot start: {error}"))?;
+        let cancellation_client = Arc::clone(&client);
+        let mut height_task = spawn_blocking(move || client.inner.block_headers_subscribe());
+        let height = await_blocking_with_timeout(
+            &mut height_task,
+            Duration::from_secs(BLOCK_OP_TIMEOUT_SECS),
+            "Get current block height operation",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
+        )
+        .await?
         .map_err(|e| anyhow!("Failed to get current block height: {}", e))?
         .height;
         Ok(height as u32)
@@ -786,6 +813,7 @@ impl ElectrumClientManager {
             || msg_lower.contains("read error")
             || msg_lower.contains("stream closed")
             || msg_lower.contains("socket")
+            || msg_lower.contains("connection replacement")
             || msg_lower.contains("i/o error")
             || msg_lower.contains("os error 32") // Broken pipe on Linux
             || msg_lower.contains("os error 104") // Connection reset by peer on Linux
@@ -811,6 +839,39 @@ impl ElectrumClientManager {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn timeout_cancels_worker_and_allows_work_gate_release() {
+        let gate = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = gate.clone().acquire_owned().await.unwrap();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let worker_cancelled = Arc::clone(&cancelled);
+        let mut task = spawn_blocking(move || {
+            while !worker_cancelled.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            42
+        });
+        let cancel_signal = Arc::clone(&cancelled);
+        let started = Instant::now();
+
+        let error = await_blocking_with_timeout(
+            &mut task,
+            Duration::from_millis(10),
+            "test operation",
+            move |_| cancel_signal.store(true, Ordering::Release),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(cancelled.load(Ordering::Acquire));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        drop(permit);
+        assert!(timeout(Duration::from_secs(1), gate.acquire())
+            .await
+            .is_ok());
+    }
+
     #[test]
     fn test_is_transport_error() {
         // Should be detected as transport errors
@@ -830,6 +891,9 @@ mod tests {
         assert!(ElectrumClientManager::is_transport_error("I/O error"));
         assert!(ElectrumClientManager::is_transport_error("os error 32"));
         assert!(ElectrumClientManager::is_transport_error("os error 104"));
+        assert!(ElectrumClientManager::is_transport_error(
+            "connection replacement required"
+        ));
 
         // Should NOT be detected as transport errors
         assert!(!ElectrumClientManager::is_transport_error("timeout"));

--- a/backend/src/electrum.rs
+++ b/backend/src/electrum.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tokio::task::{spawn_blocking, JoinHandle};
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
@@ -72,9 +72,12 @@ where
 
 #[derive(Clone)]
 pub struct ElectrumClient {
-    pub(crate) client:
-        Arc<BdkElectrumClient<SubscriptionHistoryClient<Arc<electrum_client::Client>>>>,
+    client: Arc<BdkElectrumClient<SubscriptionHistoryClient<Arc<electrum_client::Client>>>>,
     polling_client: Arc<BdkElectrumClient<SubscriptionHistoryClient<Arc<electrum_client::Client>>>>,
+    // The recurring and polling adapters share one socket and cancellation state. Serializing at
+    // the client boundary prevents a health/header lookup from clearing or observing another
+    // operation's cooperative cancellation while its blocking worker is still draining.
+    operation_gate: Arc<Mutex<()>>,
 }
 
 impl ElectrumClient {
@@ -133,6 +136,7 @@ impl ElectrumClient {
         Ok(ElectrumClient {
             client: Arc::new(BdkElectrumClient::new(subscription_client)),
             polling_client: Arc::new(BdkElectrumClient::new(polling_client)),
+            operation_gate: Arc::new(Mutex::new(())),
         })
     }
 
@@ -263,6 +267,7 @@ impl ElectrumClient {
         wallet: &mut PersistedWallet<Connection>,
         scan_gap: usize,
     ) -> Result<()> {
+        let _operation = self.operation_gate.lock().await;
         info!("Full scanning with Electrum (scan gap: {scan_gap})...");
 
         // Print initial balance
@@ -316,6 +321,7 @@ impl ElectrumClient {
     }
 
     pub async fn sync_wallet(&self, wallet: &mut PersistedWallet<Connection>) -> Result<()> {
+        let _operation = self.operation_gate.lock().await;
         let total_start = Instant::now();
 
         // Populate the electrum client's transaction cache
@@ -419,6 +425,7 @@ impl ElectrumClient {
     }
 
     pub async fn get_block_header(&self, height: u32) -> Result<BlockHeader> {
+        let _operation = self.operation_gate.lock().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -443,6 +450,7 @@ impl ElectrumClient {
 
     /// Get transaction history for a specific script pubkey (for address watches)
     pub async fn script_get_history(&self, script: &ScriptBuf) -> Result<Vec<GetHistoryRes>> {
+        let _operation = self.operation_gate.lock().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -468,6 +476,7 @@ impl ElectrumClient {
 
     /// Get balance for a specific script pubkey (for address watches)
     pub async fn script_get_balance(&self, script: &ScriptBuf) -> Result<GetBalanceRes> {
+        let _operation = self.operation_gate.lock().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -490,6 +499,7 @@ impl ElectrumClient {
 
     /// Get a full transaction by txid (for address watches)
     pub async fn transaction_get(&self, txid: &Txid) -> Result<Transaction> {
+        let _operation = self.operation_gate.lock().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -516,6 +526,7 @@ impl ElectrumClient {
         if scripts.is_empty() {
             return Ok(());
         }
+        let _operation = self.operation_gate.lock().await;
         let client = Arc::clone(&self.client);
         spawn_blocking(move || client.inner.forget_scripts(&scripts))
             .await
@@ -524,6 +535,7 @@ impl ElectrumClient {
     }
 
     pub async fn get_current_block_height(&self) -> Result<u32> {
+        let _operation = self.operation_gate.lock().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -652,16 +664,38 @@ impl ElectrumClientManager {
             None => return false,
         };
 
-        // Try to get block height as a simple health check with a short timeout
-        // Use 3 seconds instead of default 10 to keep API responses fast
-        let client_arc = Arc::clone(&client.client);
-        let task_handle = spawn_blocking(move || client_arc.inner.block_headers_subscribe());
+        // Do not contend with active sync work. A client operation already holding the gate owns
+        // the shared socket and cancellation state; its normal timeout/reconnect path is the
+        // authoritative health signal.
+        let _operation = match client.operation_gate.try_lock() {
+            Ok(operation) => operation,
+            Err(_) => {
+                debug!("ElectrumClientManager: Skipping active verification while Electrum work is in progress");
+                return true;
+            }
+        };
 
-        let result = timeout(Duration::from_secs(3), task_handle).await;
+        // Try to get block height as a simple health check with a short timeout. This uses the
+        // same cooperative cancellation path as every other operation so a timed-out blocking
+        // worker cannot outlive the operation gate unnoticed.
+        let client_arc = Arc::clone(&client.client);
+        if let Err(error) = client_arc.inner.start_work() {
+            debug!("ElectrumClientManager: Connection verification cannot start: {error}");
+            return false;
+        }
+        let cancellation_client = Arc::clone(&client_arc);
+        let mut task_handle = spawn_blocking(move || client_arc.inner.block_headers_subscribe());
+        let result = await_blocking_with_timeout(
+            &mut task_handle,
+            Duration::from_secs(3),
+            "Connection verification",
+            move |poison| cancellation_client.inner.update_timeout_state(poison),
+        )
+        .await;
 
         match result {
-            Ok(Ok(Ok(_))) => true,
-            Ok(Ok(Err(e))) => {
+            Ok(Ok(_)) => true,
+            Ok(Err(e)) => {
                 let error_msg = e.to_string();
                 debug!(
                     "ElectrumClientManager: Connection verification failed: {}",
@@ -672,20 +706,12 @@ impl ElectrumClientManager {
                 }
                 false
             }
-            Ok(Err(e)) => {
-                debug!(
-                    "ElectrumClientManager: Connection verification task failed: {}",
-                    e
-                );
-                false
-            }
-            Err(_) => {
-                // Note: The blocking task may continue running, but this is acceptable
-                // because block_headers_subscribe will eventually complete or fail.
-                // We can't abort spawn_blocking tasks, but we return immediately.
-                debug!(
-                    "ElectrumClientManager: Connection verification timed out (server may be compressing)"
-                );
+            Err(error) => {
+                let error_msg = error.to_string();
+                debug!("ElectrumClientManager: Connection verification failed: {error_msg}");
+                if Self::is_transport_error(&error_msg) {
+                    self.mark_disconnected(&error_msg).await;
+                }
                 false
             }
         }

--- a/backend/src/electrum.rs
+++ b/backend/src/electrum.rs
@@ -27,6 +27,10 @@ const FULL_SCAN_TIMEOUT_SECS: u64 = 120;
 const BLOCK_OP_TIMEOUT_SECS: u64 = 10;
 const CANCELLATION_DRAIN_TIMEOUT_SECS: u64 = 45;
 
+fn self_hosted_operation_gate(subscriptions_enabled: bool) -> Option<Arc<Mutex<()>>> {
+    subscriptions_enabled.then(|| Arc::new(Mutex::new(())))
+}
+
 async fn await_blocking_with_timeout<T>(
     task: &mut JoinHandle<T>,
     deadline: Duration,
@@ -74,10 +78,11 @@ where
 pub struct ElectrumClient {
     client: Arc<BdkElectrumClient<SubscriptionHistoryClient<Arc<electrum_client::Client>>>>,
     polling_client: Arc<BdkElectrumClient<SubscriptionHistoryClient<Arc<electrum_client::Client>>>>,
-    // The recurring and polling adapters share one socket and cancellation state. Serializing at
-    // the client boundary prevents a health/header lookup from clearing or observing another
-    // operation's cooperative cancellation while its blocking worker is still draining.
-    operation_gate: Arc<Mutex<()>>,
+    // Subscription-enabled self-hosted clients share one socket and cancellation state between
+    // recurring and polling adapters. Serialize those operations at the client boundary so a
+    // health/header lookup cannot interfere with another worker's cancellation. Cloud clients
+    // keep their existing parallelism and do not allocate this gate.
+    operation_gate: Option<Arc<Mutex<()>>>,
 }
 
 impl ElectrumClient {
@@ -136,8 +141,15 @@ impl ElectrumClient {
         Ok(ElectrumClient {
             client: Arc::new(BdkElectrumClient::new(subscription_client)),
             polling_client: Arc::new(BdkElectrumClient::new(polling_client)),
-            operation_gate: Arc::new(Mutex::new(())),
+            operation_gate: self_hosted_operation_gate(subscriptions_enabled),
         })
+    }
+
+    async fn acquire_operation(&self) -> Option<tokio::sync::MutexGuard<'_, ()>> {
+        match &self.operation_gate {
+            Some(gate) => Some(gate.lock().await),
+            None => None,
+        }
     }
 
     fn populate_caches(&self, wallet: &PersistedWallet<Connection>) {
@@ -267,7 +279,7 @@ impl ElectrumClient {
         wallet: &mut PersistedWallet<Connection>,
         scan_gap: usize,
     ) -> Result<()> {
-        let _operation = self.operation_gate.lock().await;
+        let _operation = self.acquire_operation().await;
         info!("Full scanning with Electrum (scan gap: {scan_gap})...");
 
         // Print initial balance
@@ -321,7 +333,7 @@ impl ElectrumClient {
     }
 
     pub async fn sync_wallet(&self, wallet: &mut PersistedWallet<Connection>) -> Result<()> {
-        let _operation = self.operation_gate.lock().await;
+        let _operation = self.acquire_operation().await;
         let total_start = Instant::now();
 
         // Populate the electrum client's transaction cache
@@ -425,7 +437,7 @@ impl ElectrumClient {
     }
 
     pub async fn get_block_header(&self, height: u32) -> Result<BlockHeader> {
-        let _operation = self.operation_gate.lock().await;
+        let _operation = self.acquire_operation().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -450,7 +462,7 @@ impl ElectrumClient {
 
     /// Get transaction history for a specific script pubkey (for address watches)
     pub async fn script_get_history(&self, script: &ScriptBuf) -> Result<Vec<GetHistoryRes>> {
-        let _operation = self.operation_gate.lock().await;
+        let _operation = self.acquire_operation().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -476,7 +488,7 @@ impl ElectrumClient {
 
     /// Get balance for a specific script pubkey (for address watches)
     pub async fn script_get_balance(&self, script: &ScriptBuf) -> Result<GetBalanceRes> {
-        let _operation = self.operation_gate.lock().await;
+        let _operation = self.acquire_operation().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -499,7 +511,7 @@ impl ElectrumClient {
 
     /// Get a full transaction by txid (for address watches)
     pub async fn transaction_get(&self, txid: &Txid) -> Result<Transaction> {
-        let _operation = self.operation_gate.lock().await;
+        let _operation = self.acquire_operation().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -526,7 +538,7 @@ impl ElectrumClient {
         if scripts.is_empty() {
             return Ok(());
         }
-        let _operation = self.operation_gate.lock().await;
+        let _operation = self.acquire_operation().await;
         let client = Arc::clone(&self.client);
         spawn_blocking(move || client.inner.forget_scripts(&scripts))
             .await
@@ -535,7 +547,7 @@ impl ElectrumClient {
     }
 
     pub async fn get_current_block_height(&self) -> Result<u32> {
-        let _operation = self.operation_gate.lock().await;
+        let _operation = self.acquire_operation().await;
         let client = Arc::clone(&self.client);
         client
             .inner
@@ -667,12 +679,15 @@ impl ElectrumClientManager {
         // Do not contend with active sync work. A client operation already holding the gate owns
         // the shared socket and cancellation state; its normal timeout/reconnect path is the
         // authoritative health signal.
-        let _operation = match client.operation_gate.try_lock() {
-            Ok(operation) => operation,
-            Err(_) => {
-                debug!("ElectrumClientManager: Skipping active verification while Electrum work is in progress");
-                return true;
-            }
+        let _operation = match &client.operation_gate {
+            Some(gate) => match gate.try_lock() {
+                Ok(operation) => Some(operation),
+                Err(_) => {
+                    debug!("ElectrumClientManager: Skipping active verification while Electrum work is in progress");
+                    return true;
+                }
+            },
+            None => None,
         };
 
         // Try to get block height as a simple health check with a short timeout. This uses the
@@ -928,5 +943,11 @@ mod tests {
             "invalid response"
         ));
         assert!(!ElectrumClientManager::is_transport_error("parse error"));
+    }
+
+    #[test]
+    fn operation_gate_is_scoped_to_subscription_enabled_self_hosted_clients() {
+        assert!(self_hosted_operation_gate(true).is_some());
+        assert!(self_hosted_operation_gate(false).is_none());
     }
 }

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -210,6 +210,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
         let mut results = vec![None; scripts.len()];
         let mut fetch_indices = Vec::new();
         let mut statuses = vec![None; scripts.len()];
+        let mut status_observed = vec![false; scripts.len()];
         let mut safety_revalidation = false;
 
         for (index, script) in scripts.iter().enumerate() {
@@ -238,6 +239,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                             .expect("subscription set lock poisoned")
                             .insert(script.clone());
                         statuses[index] = status;
+                        status_observed[index] = true;
                         if let Some(entry) = &cached {
                             self.cache
                                 .0
@@ -276,6 +278,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                         Ok(Some(status)) => {
                             notifications_seen += 1;
                             statuses[index] = Some(status);
+                            status_observed[index] = true;
                             if cached
                                 .as_ref()
                                 .is_none_or(|entry| entry.status != Some(status))
@@ -290,6 +293,9 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                                 break;
                             }
                         }
+                        // `electrum-client` documents None here as an empty local queue. A wire
+                        // notification with a null status cannot be deserialized as ScriptStatus;
+                        // its internal reconnect is detected below as NotSubscribed.
                         Ok(None) => break,
                         Err(Error::NotSubscribed(_)) => {
                             self.subscribed
@@ -303,6 +309,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                                         .expect("subscription set lock poisoned")
                                         .insert(script.clone());
                                     statuses[index] = status;
+                                    status_observed[index] = true;
                                     self.cache
                                         .0
                                         .lock()
@@ -361,7 +368,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                 for &index in &fetch_indices {
                     if let Some(entry) = cache.entries.get_mut(&scripts[index]) {
                         entry.dirty = true;
-                        if statuses[index].is_some() {
+                        if status_observed[index] {
                             entry.status = statuses[index];
                         }
                     }
@@ -375,12 +382,14 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
             )?;
             let mut cache = self.cache.0.lock().expect("history cache lock poisoned");
             for (index, history) in fetch_indices.into_iter().zip(fetched) {
-                let effective_status = statuses[index].or_else(|| {
+                let effective_status = if status_observed[index] {
+                    statuses[index]
+                } else {
                     cache
                         .entries
                         .get(&scripts[index])
                         .and_then(|entry| entry.status)
-                });
+                };
                 cache.entries.insert(
                     scripts[index].clone(),
                     HistoryCacheEntry {
@@ -1148,6 +1157,39 @@ mod tests {
         assert_eq!(state.subscription_calls, 2);
         assert_eq!(state.history_batches.len(), 1);
         assert_eq!(cache.0.lock().unwrap().reconnect_resubscriptions, 1);
+    }
+
+    #[test]
+    fn null_status_after_hidden_reconnect_clears_non_empty_history() {
+        let cache = SharedHistoryCache::default();
+        let api = FakeApi::default();
+        let script = script(24);
+        {
+            let mut state = api.state();
+            state.statuses.insert(script.clone(), Some(status(24)));
+            state.histories.insert(script.clone(), history(24));
+        }
+        let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        // electrum-client cannot represent a null-status notification in its ScriptStatus queue.
+        // It replaces the raw client after the decode failure, which surfaces here as
+        // NotSubscribed; resubscribing then returns the current null status.
+        {
+            let mut state = api.state();
+            state.subscribed.clear();
+            state.statuses.insert(script.clone(), None);
+            state.histories.insert(script.clone(), Vec::new());
+        }
+        let refreshed = adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        assert!(refreshed[0].is_empty());
+        assert_eq!(api.state().history_batches.len(), 2);
+        assert_eq!(cache.0.lock().unwrap().entries[&script].status, None);
     }
 
     #[test]

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
 pub(crate) const HISTORY_REVALIDATION_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+const MAX_QUEUED_NOTIFICATIONS_PER_SCRIPT: usize = 1_024;
 
 #[derive(Clone, Debug)]
 struct HistoryCacheEntry {
@@ -33,6 +34,16 @@ struct HistoryCacheState {
 /// server's current status with the history cached before the disconnect.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SharedHistoryCache(Arc<Mutex<HistoryCacheState>>);
+
+impl SharedHistoryCache {
+    pub(crate) fn forget_scripts(&self, scripts: &[ScriptBuf]) -> usize {
+        let mut cache = self.0.lock().expect("history cache lock poisoned");
+        scripts
+            .iter()
+            .filter(|script| cache.entries.remove(*script).is_some())
+            .count()
+    }
+}
 
 /// Electrum API adapter that turns script subscriptions into a cache invalidation signal.
 ///
@@ -82,6 +93,35 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                 debug!("Electrum notification ping failed before recurring work: {error}");
             }
         }
+    }
+
+    pub(crate) fn forget_scripts(&self, scripts: &[ScriptBuf]) {
+        let subscribed_scripts: Vec<_> = {
+            let mut subscribed = self
+                .subscribed
+                .lock()
+                .expect("subscription set lock poisoned");
+            scripts
+                .iter()
+                .filter(|script| subscribed.remove(*script))
+                .cloned()
+                .collect()
+        };
+
+        for script in &subscribed_scripts {
+            match self.inner.script_unsubscribe(script.as_script()) {
+                Ok(_) | Err(Error::NotSubscribed(_)) => {}
+                Err(error) => warn!(
+                    "Electrum script unsubscribe failed during wallet cleanup; the local subscription was still removed: {error}"
+                ),
+            }
+        }
+        let evicted = self.cache.forget_scripts(scripts);
+        info!(
+            "Electrum subscription cleanup: requested_scripts={}, unsubscribed_scripts={}, evicted_history_entries={evicted}",
+            scripts.len(),
+            subscribed_scripts.len()
+        );
     }
 
     fn histories_at(
@@ -157,15 +197,24 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                     .expect("subscription set lock poisoned")
                     .contains(script)
             {
+                let mut notifications_seen = 0;
                 loop {
                     match self.inner.script_pop(script.as_script()) {
                         Ok(Some(status)) => {
+                            notifications_seen += 1;
                             statuses[index] = Some(status);
                             if cached
                                 .as_ref()
                                 .is_none_or(|entry| entry.status != Some(status))
                             {
                                 should_fetch = true;
+                            }
+                            if notifications_seen >= MAX_QUEUED_NOTIFICATIONS_PER_SCRIPT {
+                                warn!(
+                                    "Electrum notification drain reached its per-script safety limit; refreshing history and continuing on the next work item"
+                                );
+                                should_fetch = true;
+                                break;
                             }
                         }
                         Ok(None) => break,
@@ -474,6 +523,7 @@ mod tests {
         subscription_calls: usize,
         history_batches: Vec<Vec<ScriptBuf>>,
         unsubscribed_history_calls: usize,
+        unsubscribe_calls: usize,
         ping_calls: usize,
         fail_subscriptions: bool,
     }
@@ -569,8 +619,11 @@ mod tests {
                 .collect()
         }
 
-        fn script_unsubscribe(&self, _: &Script) -> Result<bool, Error> {
-            unimplemented!()
+        fn script_unsubscribe(&self, script: &Script) -> Result<bool, Error> {
+            let script = ScriptBuf::from_bytes(script.as_bytes().to_vec());
+            let mut state = self.state();
+            state.unsubscribe_calls += 1;
+            Ok(state.subscribed.remove(&script))
         }
 
         fn script_pop(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
@@ -813,6 +866,68 @@ mod tests {
             Some(status(13))
         );
         assert_eq!(api.state().history_batches[1], vec![scripts[2].clone()]);
+    }
+
+    #[test]
+    fn wallet_cleanup_unsubscribes_and_evicts_only_removed_scripts() {
+        let api = FakeApi::default();
+        let removed = script(20);
+        let retained = script(21);
+        {
+            let mut state = api.state();
+            for (seed, script) in [(20, &removed), (21, &retained)] {
+                state.statuses.insert(script.clone(), Some(status(seed)));
+                state.histories.insert(script.clone(), history(seed));
+            }
+        }
+        let cache = SharedHistoryCache::default();
+        let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        adapter
+            .batch_script_get_history([removed.as_script(), retained.as_script()])
+            .unwrap();
+
+        adapter.forget_scripts(std::slice::from_ref(&removed));
+
+        let state = api.state();
+        assert_eq!(state.unsubscribe_calls, 1);
+        assert!(!state.subscribed.contains(&removed));
+        assert!(state.subscribed.contains(&retained));
+        drop(state);
+        let cache = cache.0.lock().unwrap();
+        assert!(!cache.entries.contains_key(&removed));
+        assert!(cache.entries.contains_key(&retained));
+    }
+
+    #[test]
+    fn notification_drain_has_a_safety_bound() {
+        let api = FakeApi::default();
+        let script = script(22);
+        {
+            let mut state = api.state();
+            state.statuses.insert(script.clone(), Some(status(22)));
+            state.histories.insert(script.clone(), history(22));
+        }
+        let adapter =
+            SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
+        adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+        api.state()
+            .notifications
+            .entry(script.clone())
+            .or_default()
+            .extend(std::iter::repeat_n(
+                status(22),
+                MAX_QUEUED_NOTIFICATIONS_PER_SCRIPT + 1,
+            ));
+
+        adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        let state = api.state();
+        assert_eq!(state.history_batches.len(), 2);
+        assert_eq!(state.notifications[&script].len(), 1);
     }
 
     #[test]

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -293,10 +293,22 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                                 break;
                             }
                         }
-                        // `electrum-client` documents None here as an empty local queue. A wire
-                        // notification with a null status cannot be deserialized as ScriptStatus;
-                        // its internal reconnect is detected below as NotSubscribed.
-                        Ok(None) => break,
+                        Ok(None) => {
+                            // The trait cannot distinguish an empty local queue from a backend
+                            // representing Electrum's null status as None. Empty cached histories
+                            // remain cache hits; non-empty histories are revalidated defensively
+                            // so mempool eviction or reorg cannot leave stale transactions behind.
+                            if !status_observed[index]
+                                && cached
+                                    .as_ref()
+                                    .is_some_and(|entry| !entry.dirty && !entry.history.is_empty())
+                            {
+                                statuses[index] = None;
+                                status_observed[index] = true;
+                                should_fetch = true;
+                            }
+                            break;
+                        }
                         Err(Error::NotSubscribed(_)) => {
                             self.subscribed
                                 .lock()
@@ -876,8 +888,8 @@ mod tests {
         let script = script(1);
         {
             let mut state = api.state();
-            state.statuses.insert(script.clone(), Some(status(1)));
-            state.histories.insert(script.clone(), history(1));
+            state.statuses.insert(script.clone(), None);
+            state.histories.insert(script.clone(), Vec::new());
         }
         let adapter =
             SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
@@ -891,8 +903,8 @@ mod tests {
             .batch_script_get_history([script.as_script()])
             .unwrap();
 
-        assert_eq!(first[0][0].height, 1);
-        assert_eq!(second[0][0].height, 1);
+        assert!(first[0].is_empty());
+        assert!(second[0].is_empty());
         let state = api.state();
         assert_eq!(state.subscription_calls, 1);
         assert_eq!(state.history_batches.len(), 1);
@@ -1001,6 +1013,31 @@ mod tests {
     }
 
     #[test]
+    fn missing_status_revalidates_non_empty_history_to_empty() {
+        let api = FakeApi::default();
+        let script = script(25);
+        {
+            let mut state = api.state();
+            state.statuses.insert(script.clone(), Some(status(25)));
+            state.histories.insert(script.clone(), history(25));
+        }
+        let cache = SharedHistoryCache::default();
+        let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        api.state().histories.insert(script.clone(), Vec::new());
+        let refreshed = adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        assert!(refreshed[0].is_empty());
+        assert_eq!(api.state().history_batches.len(), 2);
+        assert_eq!(cache.0.lock().unwrap().entries[&script].status, None);
+    }
+
+    #[test]
     fn sparse_batch_refresh_keeps_status_with_its_original_script() {
         let api = FakeApi::default();
         let scripts = [script(10), script(11), script(12)];
@@ -1008,8 +1045,13 @@ mod tests {
             let mut state = api.state();
             for (offset, script) in scripts.iter().enumerate() {
                 let seed = 10 + offset as u8;
-                state.statuses.insert(script.clone(), Some(status(seed)));
-                state.histories.insert(script.clone(), history(seed));
+                if offset == 2 {
+                    state.statuses.insert(script.clone(), Some(status(seed)));
+                    state.histories.insert(script.clone(), history(seed));
+                } else {
+                    state.statuses.insert(script.clone(), None);
+                    state.histories.insert(script.clone(), Vec::new());
+                }
             }
         }
         let cache = SharedHistoryCache::default();

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -6,6 +6,7 @@ use bdk_electrum::electrum_client::{
 use bdk_wallet::bitcoin::{Script, ScriptBuf, Txid};
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
@@ -57,6 +58,14 @@ pub(crate) struct SubscriptionHistoryClient<E> {
     cache: SharedHistoryCache,
     subscribed: Mutex<HashSet<ScriptBuf>>,
     enabled: bool,
+    cancellation_enabled: bool,
+    work_state: Arc<WorkState>,
+}
+
+#[derive(Debug, Default)]
+struct WorkState {
+    cancelled: AtomicBool,
+    poisoned: AtomicBool,
 }
 
 impl<E> SubscriptionHistoryClient<E> {
@@ -66,6 +75,19 @@ impl<E> SubscriptionHistoryClient<E> {
             cache,
             subscribed: Mutex::new(HashSet::new()),
             enabled,
+            cancellation_enabled: enabled,
+            work_state: Arc::new(WorkState::default()),
+        }
+    }
+
+    pub(crate) fn polling(inner: E, recurring: &Self) -> Self {
+        Self {
+            inner,
+            cache: SharedHistoryCache::default(),
+            subscribed: Mutex::new(HashSet::new()),
+            enabled: false,
+            cancellation_enabled: recurring.cancellation_enabled,
+            work_state: Arc::clone(&recurring.work_state),
         }
     }
 
@@ -86,8 +108,56 @@ impl<E> SubscriptionHistoryClient<E> {
 }
 
 impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
+    pub(crate) fn start_work(&self) -> Result<(), Error> {
+        if self.cancellation_enabled {
+            if self.work_state.poisoned.load(Ordering::Acquire) {
+                return Err(Error::Message(
+                    "Electrum client requires connection replacement after an unresponsive worker"
+                        .to_string(),
+                ));
+            }
+            self.work_state.cancelled.store(false, Ordering::Release);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn cancel_work(&self) {
+        if self.cancellation_enabled {
+            self.work_state.cancelled.store(true, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn poison_work(&self) {
+        if self.cancellation_enabled {
+            self.work_state.cancelled.store(true, Ordering::Release);
+            self.work_state.poisoned.store(true, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn update_timeout_state(&self, poison: bool) {
+        if poison {
+            self.poison_work();
+        } else {
+            self.cancel_work();
+        }
+    }
+
+    fn ensure_work_active(&self) -> Result<(), Error> {
+        if self.cancellation_enabled && self.work_state.cancelled.load(Ordering::Acquire) {
+            return Err(Error::Message(
+                "Electrum work cancelled after operation timeout".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn call<T>(&self, operation: impl FnOnce(&E) -> Result<T, Error>) -> Result<T, Error> {
+        self.ensure_work_active()?;
+        operation(&self.inner)
+    }
+
     pub(crate) fn prepare_recurring_work(&self) {
-        if self.enabled {
+        if self.enabled && self.ensure_work_active().is_ok() {
             // electrum-client only processes queued notifications while an RPC reads the socket.
             // The following sync call will surface any real transport failure.
             if let Err(error) = self.inner.ping() {
@@ -130,6 +200,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
         scripts: &[ScriptBuf],
         now: Instant,
     ) -> Result<Vec<Vec<GetHistoryRes>>, Error> {
+        self.ensure_work_active()?;
         if !self.enabled {
             return self
                 .inner
@@ -142,6 +213,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
         let mut safety_revalidation = false;
 
         for (index, script) in scripts.iter().enumerate() {
+            self.ensure_work_active()?;
             let cached = self
                 .cache
                 .0
@@ -295,6 +367,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                     }
                 }
             }
+            self.ensure_work_active()?;
             let fetched = self.inner.batch_script_get_history(
                 fetch_indices
                     .iter()
@@ -346,39 +419,39 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         method_name: &str,
         params: impl IntoIterator<Item = Param>,
     ) -> Result<serde_json::Value, Error> {
-        self.inner.raw_call(method_name, params)
+        self.call(|inner| inner.raw_call(method_name, params))
     }
 
     fn batch_call(&self, batch: &Batch) -> Result<Vec<serde_json::Value>, Error> {
-        self.inner.batch_call(batch)
+        self.call(|inner| inner.batch_call(batch))
     }
 
     fn block_headers_subscribe_raw(&self) -> Result<RawHeaderNotification, Error> {
-        self.inner.block_headers_subscribe_raw()
+        self.call(ElectrumApi::block_headers_subscribe_raw)
     }
 
     fn block_headers_pop_raw(&self) -> Result<Option<RawHeaderNotification>, Error> {
-        self.inner.block_headers_pop_raw()
+        self.call(ElectrumApi::block_headers_pop_raw)
     }
 
     fn block_header_raw(&self, height: usize) -> Result<Vec<u8>, Error> {
-        self.inner.block_header_raw(height)
+        self.call(|inner| inner.block_header_raw(height))
     }
 
     fn block_headers(&self, start_height: usize, count: usize) -> Result<GetHeadersRes, Error> {
-        self.inner.block_headers(start_height, count)
+        self.call(|inner| inner.block_headers(start_height, count))
     }
 
     fn estimate_fee(&self, number: usize, mode: Option<EstimationMode>) -> Result<f64, Error> {
-        self.inner.estimate_fee(number, mode)
+        self.call(|inner| inner.estimate_fee(number, mode))
     }
 
     fn relay_fee(&self) -> Result<f64, Error> {
-        self.inner.relay_fee()
+        self.call(ElectrumApi::relay_fee)
     }
 
     fn script_subscribe(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
-        self.inner.script_subscribe(script)
+        self.call(|inner| inner.script_subscribe(script))
     }
 
     fn batch_script_subscribe<'s, I>(&self, scripts: I) -> Result<Vec<Option<ScriptStatus>>, Error>
@@ -386,19 +459,19 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         I: IntoIterator + Clone,
         I::Item: Borrow<&'s Script>,
     {
-        self.inner.batch_script_subscribe(scripts)
+        self.call(|inner| inner.batch_script_subscribe(scripts))
     }
 
     fn script_unsubscribe(&self, script: &Script) -> Result<bool, Error> {
-        self.inner.script_unsubscribe(script)
+        self.call(|inner| inner.script_unsubscribe(script))
     }
 
     fn script_pop(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
-        self.inner.script_pop(script)
+        self.call(|inner| inner.script_pop(script))
     }
 
     fn script_get_balance(&self, script: &Script) -> Result<GetBalanceRes, Error> {
-        self.inner.script_get_balance(script)
+        self.call(|inner| inner.script_get_balance(script))
     }
 
     fn batch_script_get_balance<'s, I>(&self, scripts: I) -> Result<Vec<GetBalanceRes>, Error>
@@ -406,7 +479,7 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         I: IntoIterator + Clone,
         I::Item: Borrow<&'s Script>,
     {
-        self.inner.batch_script_get_balance(scripts)
+        self.call(|inner| inner.batch_script_get_balance(scripts))
     }
 
     fn script_get_history(&self, script: &Script) -> Result<Vec<GetHistoryRes>, Error> {
@@ -427,7 +500,7 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
     }
 
     fn script_list_unspent(&self, script: &Script) -> Result<Vec<ListUnspentRes>, Error> {
-        self.inner.script_list_unspent(script)
+        self.call(|inner| inner.script_list_unspent(script))
     }
 
     fn batch_script_list_unspent<'s, I>(
@@ -438,11 +511,11 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         I: IntoIterator + Clone,
         I::Item: Borrow<&'s Script>,
     {
-        self.inner.batch_script_list_unspent(scripts)
+        self.call(|inner| inner.batch_script_list_unspent(scripts))
     }
 
     fn transaction_get_raw(&self, txid: &Txid) -> Result<Vec<u8>, Error> {
-        self.inner.transaction_get_raw(txid)
+        self.call(|inner| inner.transaction_get_raw(txid))
     }
 
     fn batch_transaction_get_raw<'t, I>(&self, txids: I) -> Result<Vec<Vec<u8>>, Error>
@@ -450,7 +523,7 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         I: IntoIterator + Clone,
         I::Item: Borrow<&'t Txid>,
     {
-        self.inner.batch_transaction_get_raw(txids)
+        self.call(|inner| inner.batch_transaction_get_raw(txids))
     }
 
     fn batch_block_header_raw<I>(&self, heights: I) -> Result<Vec<Vec<u8>>, Error>
@@ -458,7 +531,7 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         I: IntoIterator + Clone,
         I::Item: Borrow<u32>,
     {
-        self.inner.batch_block_header_raw(heights)
+        self.call(|inner| inner.batch_block_header_raw(heights))
     }
 
     fn batch_estimate_fee<I>(&self, numbers: I) -> Result<Vec<f64>, Error>
@@ -466,22 +539,22 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         I: IntoIterator + Clone,
         I::Item: Borrow<usize>,
     {
-        self.inner.batch_estimate_fee(numbers)
+        self.call(|inner| inner.batch_estimate_fee(numbers))
     }
 
     fn transaction_broadcast_raw(&self, raw_tx: &[u8]) -> Result<Txid, Error> {
-        self.inner.transaction_broadcast_raw(raw_tx)
+        self.call(|inner| inner.transaction_broadcast_raw(raw_tx))
     }
 
     fn transaction_broadcast_package_raw<T: AsRef<[u8]>>(
         &self,
         raw_txs: &[T],
     ) -> Result<BroadcastPackageRes, Error> {
-        self.inner.transaction_broadcast_package_raw(raw_txs)
+        self.call(|inner| inner.transaction_broadcast_package_raw(raw_txs))
     }
 
     fn transaction_get_merkle(&self, txid: &Txid, height: usize) -> Result<GetMerkleRes, Error> {
-        self.inner.transaction_get_merkle(txid, height)
+        self.call(|inner| inner.transaction_get_merkle(txid, height))
     }
 
     fn batch_transaction_get_merkle<I>(
@@ -492,11 +565,11 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         I: IntoIterator + Clone,
         I::Item: Borrow<(Txid, usize)>,
     {
-        self.inner.batch_transaction_get_merkle(txids_and_heights)
+        self.call(|inner| inner.batch_transaction_get_merkle(txids_and_heights))
     }
 
     fn txid_from_pos(&self, height: usize, tx_pos: usize) -> Result<Txid, Error> {
-        self.inner.txid_from_pos(height, tx_pos)
+        self.call(|inner| inner.txid_from_pos(height, tx_pos))
     }
 
     fn txid_from_pos_with_merkle(
@@ -504,23 +577,23 @@ impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
         height: usize,
         tx_pos: usize,
     ) -> Result<TxidFromPosRes, Error> {
-        self.inner.txid_from_pos_with_merkle(height, tx_pos)
+        self.call(|inner| inner.txid_from_pos_with_merkle(height, tx_pos))
     }
 
     fn server_features(&self) -> Result<ServerFeaturesRes, Error> {
-        self.inner.server_features()
+        self.call(ElectrumApi::server_features)
     }
 
     fn mempool_get_info(&self) -> Result<MempoolInfoRes, Error> {
-        self.inner.mempool_get_info()
+        self.call(ElectrumApi::mempool_get_info)
     }
 
     fn ping(&self) -> Result<(), Error> {
-        self.inner.ping()
+        self.call(ElectrumApi::ping)
     }
 
     fn calls_made(&self) -> Result<usize, Error> {
-        self.inner.calls_made()
+        self.call(ElectrumApi::calls_made)
     }
 }
 
@@ -816,6 +889,35 @@ mod tests {
         assert_eq!(state.history_batches.len(), 1);
         assert_eq!(state.unsubscribed_history_calls, 0);
         assert_eq!(state.ping_calls, 2);
+    }
+
+    #[test]
+    fn cancelled_work_stops_before_the_next_electrum_rpc() {
+        let api = FakeApi::default();
+        let adapter =
+            SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
+
+        adapter.cancel_work();
+        assert!(adapter.ping().is_err());
+        assert_eq!(api.state().ping_calls, 0);
+
+        adapter.start_work().unwrap();
+        adapter.ping().unwrap();
+        assert_eq!(api.state().ping_calls, 1);
+
+        adapter.poison_work();
+        assert!(adapter.start_work().is_err());
+    }
+
+    #[test]
+    fn polling_and_recurring_clients_share_timeout_state() {
+        let api = FakeApi::default();
+        let recurring =
+            SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
+        let polling = SubscriptionHistoryClient::polling(api, &recurring);
+
+        polling.poison_work();
+        assert!(recurring.start_work().is_err());
     }
 
     #[test]

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -261,10 +261,54 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                 }
                 Err(error) => {
                     warn!(
-                        "Electrum batch script subscription failed; polling history for this work item: {error}"
+                        "Electrum batch script subscription failed; reconciling partial subscriptions before polling fallback: {error}"
                     );
-                    for index in cold_indices {
-                        subscription_failed[index] = true;
+                    let mut recovered = true;
+                    for &index in &cold_indices {
+                        self.ensure_work_active()?;
+                        match self.inner.script_unsubscribe(scripts[index].as_script()) {
+                            Ok(_) | Err(Error::NotSubscribed(_)) => {}
+                            Err(error) => {
+                                warn!(
+                                    "Electrum partial batch subscription cleanup failed; polling history for this work item: {error}"
+                                );
+                                recovered = false;
+                                break;
+                            }
+                        }
+                    }
+                    if recovered {
+                        for &index in &cold_indices {
+                            self.ensure_work_active()?;
+                            match self.inner.script_subscribe(scripts[index].as_script()) {
+                                Ok(status) => {
+                                    self.subscribed
+                                        .lock()
+                                        .expect("subscription set lock poisoned")
+                                        .insert(scripts[index].clone());
+                                    statuses[index] = status;
+                                    status_observed[index] = true;
+                                }
+                                Err(Error::AlreadySubscribed(_)) => {
+                                    self.subscribed
+                                        .lock()
+                                        .expect("subscription set lock poisoned")
+                                        .insert(scripts[index].clone());
+                                }
+                                Err(error) => {
+                                    warn!(
+                                        "Electrum individual subscription recovery failed; polling history for this work item: {error}"
+                                    );
+                                    recovered = false;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if !recovered {
+                        for index in cold_indices {
+                            subscription_failed[index] = true;
+                        }
                     }
                 }
             }
@@ -657,6 +701,7 @@ mod tests {
         subscribed: HashSet<ScriptBuf>,
         subscription_calls: usize,
         subscription_batch_calls: usize,
+        partial_batch_failure_after: Option<usize>,
         history_batches: Vec<Vec<ScriptBuf>>,
         unsubscribed_history_calls: usize,
         unsubscribe_calls: usize,
@@ -759,6 +804,13 @@ mod tests {
             I::Item: Borrow<&'s Script>,
         {
             self.state().subscription_batch_calls += 1;
+            let partial_batch_failure_after = { self.state().partial_batch_failure_after.take() };
+            if let Some(successful) = partial_batch_failure_after {
+                for script in scripts.into_iter().take(successful) {
+                    self.script_subscribe(script.borrow())?;
+                }
+                return Err(Error::Message("partial batch failure".to_string()));
+            }
             scripts
                 .into_iter()
                 .map(|script| self.script_subscribe(script.borrow()))
@@ -981,6 +1033,41 @@ mod tests {
         assert_eq!(state.subscription_batch_calls, scripts.len().div_ceil(20));
         assert_eq!(state.subscription_calls, scripts.len());
         assert_eq!(state.history_batches.len(), scripts.len().div_ceil(20));
+        assert_eq!(state.unsubscribed_history_calls, 0);
+    }
+
+    #[test]
+    fn partial_batch_subscription_is_reconciled_without_an_already_subscribed_loop() {
+        let api = FakeApi::default();
+        let scripts = [script(30), script(31), script(32)];
+        {
+            let mut state = api.state();
+            state.partial_batch_failure_after = Some(1);
+            for (seed, script) in [(30, &scripts[0]), (31, &scripts[1]), (32, &scripts[2])] {
+                state.statuses.insert(script.clone(), Some(status(seed)));
+                state.histories.insert(script.clone(), history(seed));
+            }
+        }
+        let adapter =
+            SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
+
+        let cold = adapter
+            .batch_script_get_history(scripts.iter().map(ScriptBuf::as_script))
+            .unwrap();
+        let warm = adapter
+            .batch_script_get_history(scripts.iter().map(ScriptBuf::as_script))
+            .unwrap();
+
+        let cold_heights: Vec<_> = cold.iter().map(|history| history[0].height).collect();
+        let warm_heights: Vec<_> = warm.iter().map(|history| history[0].height).collect();
+        assert_eq!(cold_heights, [30, 31, 32]);
+        assert_eq!(warm_heights, cold_heights);
+        let state = api.state();
+        assert_eq!(state.subscription_batch_calls, 1);
+        assert_eq!(state.subscription_calls, 4);
+        assert_eq!(state.unsubscribe_calls, scripts.len());
+        assert_eq!(state.subscribed.len(), scripts.len());
+        assert_eq!(state.history_batches.len(), 1);
         assert_eq!(state.unsubscribed_history_calls, 0);
     }
 

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -184,6 +184,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
 
         let mut server_unsubscribe_attempts = 0;
         let mut cancellation_error = None;
+        let mut unsubscribe_error = None;
         for script in &subscribed_scripts {
             if let Err(error) = self.ensure_work_active() {
                 cancellation_error = Some(error);
@@ -192,9 +193,12 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
             server_unsubscribe_attempts += 1;
             match self.inner.script_unsubscribe(script.as_script()) {
                 Ok(_) | Err(Error::NotSubscribed(_)) => {}
-                Err(error) => warn!(
-                    "Electrum script unsubscribe failed during wallet cleanup; the local subscription was still removed: {error}"
-                ),
+                Err(error) => {
+                    warn!(
+                        "Electrum script unsubscribe failed during wallet cleanup; the local subscription was still removed and the connection must be replaced: {error}"
+                    );
+                    unsubscribe_error.get_or_insert(error);
+                }
             }
         }
         let evicted = self.cache.forget_scripts(scripts);
@@ -204,6 +208,9 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
             subscribed_scripts.len()
         );
         if let Some(error) = cancellation_error {
+            return Err(error);
+        }
+        if let Some(error) = unsubscribe_error {
             return Err(error);
         }
         Ok(())
@@ -710,6 +717,7 @@ mod tests {
         unsubscribe_calls: usize,
         unsubscribe_started: Option<Arc<Barrier>>,
         unsubscribe_release: Option<Arc<Barrier>>,
+        fail_unsubscribes: bool,
         ping_calls: usize,
         fail_subscriptions: bool,
         fail_history_batches: usize,
@@ -835,6 +843,9 @@ mod tests {
             }
             if let Some(release) = release {
                 release.wait();
+            }
+            if self.state().fail_unsubscribes {
+                return Err(Error::Message("unsubscribe failed".to_string()));
             }
             Ok(self.state().subscribed.remove(&script))
         }
@@ -1366,6 +1377,36 @@ mod tests {
         assert!(worker.join().unwrap().is_err());
         assert_eq!(api.state().unsubscribe_calls, 1);
         assert_eq!(api.state().subscribed.len(), 1);
+        assert!(adapter.subscribed.lock().unwrap().is_empty());
+        assert!(cache.0.lock().unwrap().entries.is_empty());
+    }
+
+    #[test]
+    fn wallet_cleanup_error_requires_connection_replacement() {
+        let api = FakeApi::default();
+        let cache = SharedHistoryCache::default();
+        let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        let script = script(40);
+        adapter.subscribed.lock().unwrap().insert(script.clone());
+        {
+            let mut state = api.state();
+            state.subscribed.insert(script.clone());
+            state.fail_unsubscribes = true;
+        }
+        cache.0.lock().unwrap().entries.insert(
+            script.clone(),
+            HistoryCacheEntry {
+                status: None,
+                history: Vec::new(),
+                last_revalidated: Instant::now(),
+                dirty: false,
+            },
+        );
+
+        assert!(adapter
+            .forget_scripts(std::slice::from_ref(&script))
+            .is_err());
+        assert!(api.state().subscribed.contains(&script));
         assert!(adapter.subscribed.lock().unwrap().is_empty());
         assert!(cache.0.lock().unwrap().entries.is_empty());
     }

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -166,7 +166,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
         }
     }
 
-    pub(crate) fn forget_scripts(&self, scripts: &[ScriptBuf]) {
+    pub(crate) fn forget_scripts(&self, scripts: &[ScriptBuf]) -> Result<(), Error> {
         let subscribed_scripts: Vec<_> = {
             let mut subscribed = self
                 .subscribed
@@ -179,7 +179,14 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                 .collect()
         };
 
+        let mut server_unsubscribe_attempts = 0;
+        let mut cancellation_error = None;
         for script in &subscribed_scripts {
+            if let Err(error) = self.ensure_work_active() {
+                cancellation_error = Some(error);
+                break;
+            }
+            server_unsubscribe_attempts += 1;
             match self.inner.script_unsubscribe(script.as_script()) {
                 Ok(_) | Err(Error::NotSubscribed(_)) => {}
                 Err(error) => warn!(
@@ -189,10 +196,14 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
         }
         let evicted = self.cache.forget_scripts(scripts);
         info!(
-            "Electrum subscription cleanup: requested_scripts={}, unsubscribed_scripts={}, evicted_history_entries={evicted}",
+            "Electrum subscription cleanup: requested_scripts={}, locally_removed_subscriptions={}, server_unsubscribe_attempts={server_unsubscribe_attempts}, evicted_history_entries={evicted}",
             scripts.len(),
             subscribed_scripts.len()
         );
+        if let Some(error) = cancellation_error {
+            return Err(error);
+        }
+        Ok(())
     }
 
     fn histories_at(
@@ -619,6 +630,7 @@ mod tests {
     use super::*;
     use bdk_electrum::electrum_client::ToElectrumScriptHash;
     use std::collections::VecDeque;
+    use std::sync::Barrier;
 
     #[derive(Default)]
     struct FakeState {
@@ -630,6 +642,8 @@ mod tests {
         history_batches: Vec<Vec<ScriptBuf>>,
         unsubscribed_history_calls: usize,
         unsubscribe_calls: usize,
+        unsubscribe_started: Option<Arc<Barrier>>,
+        unsubscribe_release: Option<Arc<Barrier>>,
         ping_calls: usize,
         fail_subscriptions: bool,
         fail_history_batches: usize,
@@ -646,6 +660,12 @@ mod tests {
 
     fn script(seed: u8) -> ScriptBuf {
         ScriptBuf::from_bytes(vec![0x51, seed])
+    }
+
+    fn indexed_script(index: u32) -> ScriptBuf {
+        let mut bytes = vec![0x51];
+        bytes.extend_from_slice(&index.to_le_bytes());
+        ScriptBuf::from_bytes(bytes)
     }
 
     fn status(seed: u8) -> ScriptStatus {
@@ -728,9 +748,21 @@ mod tests {
 
         fn script_unsubscribe(&self, script: &Script) -> Result<bool, Error> {
             let script = ScriptBuf::from_bytes(script.as_bytes().to_vec());
-            let mut state = self.state();
-            state.unsubscribe_calls += 1;
-            Ok(state.subscribed.remove(&script))
+            let (started, release) = {
+                let mut state = self.state();
+                state.unsubscribe_calls += 1;
+                (
+                    state.unsubscribe_started.take(),
+                    state.unsubscribe_release.take(),
+                )
+            };
+            if let Some(started) = started {
+                started.wait();
+            }
+            if let Some(release) = release {
+                release.wait();
+            }
+            Ok(self.state().subscribed.remove(&script))
         }
 
         fn script_pop(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
@@ -1098,7 +1130,9 @@ mod tests {
             .batch_script_get_history([removed.as_script(), retained.as_script()])
             .unwrap();
 
-        adapter.forget_scripts(std::slice::from_ref(&removed));
+        adapter
+            .forget_scripts(std::slice::from_ref(&removed))
+            .unwrap();
 
         let state = api.state();
         assert_eq!(state.unsubscribe_calls, 1);
@@ -1108,6 +1142,98 @@ mod tests {
         let cache = cache.0.lock().unwrap();
         assert!(!cache.entries.contains_key(&removed));
         assert!(cache.entries.contains_key(&retained));
+    }
+
+    #[test]
+    fn wallet_cleanup_handles_large_subscription_sets() {
+        let api = FakeApi::default();
+        let cache = SharedHistoryCache::default();
+        let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        let scripts: Vec<_> = (0..512).map(indexed_script).collect();
+
+        adapter
+            .subscribed
+            .lock()
+            .unwrap()
+            .extend(scripts.iter().cloned());
+        api.state().subscribed.extend(scripts.iter().cloned());
+        cache
+            .0
+            .lock()
+            .unwrap()
+            .entries
+            .extend(scripts.iter().cloned().map(|script| {
+                (
+                    script,
+                    HistoryCacheEntry {
+                        status: None,
+                        history: Vec::new(),
+                        last_revalidated: Instant::now(),
+                        dirty: false,
+                    },
+                )
+            }));
+
+        adapter.forget_scripts(&scripts).unwrap();
+
+        assert_eq!(api.state().unsubscribe_calls, scripts.len());
+        assert!(api.state().subscribed.is_empty());
+        assert!(adapter.subscribed.lock().unwrap().is_empty());
+        assert!(cache.0.lock().unwrap().entries.is_empty());
+    }
+
+    #[test]
+    fn wallet_cleanup_stops_between_rpcs_after_cancellation() {
+        let api = FakeApi::default();
+        let cache = SharedHistoryCache::default();
+        let adapter = Arc::new(SubscriptionHistoryClient::new(
+            api.clone(),
+            cache.clone(),
+            true,
+        ));
+        let scripts = vec![indexed_script(1), indexed_script(2)];
+        adapter
+            .subscribed
+            .lock()
+            .unwrap()
+            .extend(scripts.iter().cloned());
+        api.state().subscribed.extend(scripts.iter().cloned());
+        cache
+            .0
+            .lock()
+            .unwrap()
+            .entries
+            .extend(scripts.iter().cloned().map(|script| {
+                (
+                    script,
+                    HistoryCacheEntry {
+                        status: None,
+                        history: Vec::new(),
+                        last_revalidated: Instant::now(),
+                        dirty: false,
+                    },
+                )
+            }));
+        let started = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        {
+            let mut state = api.state();
+            state.unsubscribe_started = Some(Arc::clone(&started));
+            state.unsubscribe_release = Some(Arc::clone(&release));
+        }
+
+        let worker_adapter = Arc::clone(&adapter);
+        let worker_scripts = scripts.clone();
+        let worker = std::thread::spawn(move || worker_adapter.forget_scripts(&worker_scripts));
+        started.wait();
+        adapter.cancel_work();
+        release.wait();
+
+        assert!(worker.join().unwrap().is_err());
+        assert_eq!(api.state().unsubscribe_calls, 1);
+        assert_eq!(api.state().subscribed.len(), 1);
+        assert!(adapter.subscribed.lock().unwrap().is_empty());
+        assert!(cache.0.lock().unwrap().entries.is_empty());
     }
 
     #[test]

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -465,6 +465,13 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                     .iter()
                     .map(|&index| scripts[index].as_script()),
             )?;
+            if fetched.len() != fetch_indices.len() {
+                return Err(Error::Message(format!(
+                    "Electrum history batch returned {} results for {} scripts",
+                    fetched.len(),
+                    fetch_indices.len()
+                )));
+            }
             let mut cache = self.cache.0.lock().expect("history cache lock poisoned");
             for (index, history) in fetch_indices.into_iter().zip(fetched) {
                 let effective_status = if status_observed[index] {
@@ -721,6 +728,7 @@ mod tests {
         ping_calls: usize,
         fail_subscriptions: bool,
         fail_history_batches: usize,
+        history_response_len: Option<usize>,
     }
 
     #[derive(Clone, Default)]
@@ -900,10 +908,15 @@ mod tests {
                 .filter(|script| !state.subscribed.contains(*script))
                 .count();
             state.history_batches.push(scripts.clone());
-            Ok(scripts
+            let response_len = state.history_response_len.take();
+            let mut histories: Vec<_> = scripts
                 .iter()
                 .map(|script| state.histories.get(script).cloned().unwrap_or_default())
-                .collect())
+                .collect();
+            if let Some(response_len) = response_len {
+                histories.resize_with(response_len, Vec::new);
+            }
+            Ok(histories)
         }
 
         fn script_list_unspent(&self, _: &Script) -> Result<Vec<ListUnspentRes>, Error> {
@@ -1255,6 +1268,32 @@ mod tests {
             Some(status(13))
         );
         assert_eq!(api.state().history_batches[1], vec![scripts[2].clone()]);
+    }
+
+    #[test]
+    fn malformed_history_batch_lengths_return_errors() {
+        for response_len in [1, 3] {
+            let api = FakeApi::default();
+            let scripts = [script(41), script(42)];
+            {
+                let mut state = api.state();
+                state.history_response_len = Some(response_len);
+                for (seed, script) in [(41, &scripts[0]), (42, &scripts[1])] {
+                    state.statuses.insert(script.clone(), Some(status(seed)));
+                    state.histories.insert(script.clone(), history(seed));
+                }
+            }
+            let adapter = SubscriptionHistoryClient::new(api, SharedHistoryCache::default(), true);
+
+            let error = adapter
+                .batch_script_get_history(scripts.iter().map(ScriptBuf::as_script))
+                .unwrap_err();
+
+            assert!(error.to_string().contains(&format!(
+                "returned {response_len} results for {} scripts",
+                scripts.len()
+            )));
+        }
     }
 
     #[test]

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -222,7 +222,53 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
         let mut fetch_indices = Vec::new();
         let mut statuses = vec![None; scripts.len()];
         let mut status_observed = vec![false; scripts.len()];
+        let mut subscription_failed = vec![false; scripts.len()];
         let mut safety_revalidation = false;
+
+        let cold_indices: Vec<_> = {
+            let subscribed = self
+                .subscribed
+                .lock()
+                .expect("subscription set lock poisoned");
+            scripts
+                .iter()
+                .enumerate()
+                .filter_map(|(index, script)| (!subscribed.contains(script)).then_some(index))
+                .collect()
+        };
+        if !cold_indices.is_empty() {
+            self.ensure_work_active()?;
+            match self.inner.batch_script_subscribe(
+                cold_indices.iter().map(|&index| scripts[index].as_script()),
+            ) {
+                Ok(batch_statuses) if batch_statuses.len() == cold_indices.len() => {
+                    let mut subscribed = self
+                        .subscribed
+                        .lock()
+                        .expect("subscription set lock poisoned");
+                    for (index, status) in cold_indices.iter().copied().zip(batch_statuses) {
+                        subscribed.insert(scripts[index].clone());
+                        statuses[index] = status;
+                        status_observed[index] = true;
+                    }
+                }
+                Ok(batch_statuses) => {
+                    return Err(Error::Message(format!(
+                        "Electrum batch subscription returned {} statuses for {} scripts",
+                        batch_statuses.len(),
+                        cold_indices.len()
+                    )));
+                }
+                Err(error) => {
+                    warn!(
+                        "Electrum batch script subscription failed; polling history for this work item: {error}"
+                    );
+                    for index in cold_indices {
+                        subscription_failed[index] = true;
+                    }
+                }
+            }
+        }
 
         for (index, script) in scripts.iter().enumerate() {
             self.ensure_work_active()?;
@@ -235,48 +281,19 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                 .get(script)
                 .cloned();
             let mut should_fetch = cached.as_ref().is_none_or(|entry| entry.dirty);
-            let mut subscription_failed = false;
-            let known_subscribed = self
-                .subscribed
-                .lock()
-                .expect("subscription set lock poisoned")
-                .contains(script);
-
-            if !known_subscribed {
-                match self.inner.script_subscribe(script.as_script()) {
-                    Ok(status) => {
-                        self.subscribed
-                            .lock()
-                            .expect("subscription set lock poisoned")
-                            .insert(script.clone());
-                        statuses[index] = status;
-                        status_observed[index] = true;
-                        if let Some(entry) = &cached {
-                            self.cache
-                                .0
-                                .lock()
-                                .expect("history cache lock poisoned")
-                                .reconnect_resubscriptions += 1;
-                            should_fetch |= entry.status != status;
-                        }
-                    }
-                    Err(Error::AlreadySubscribed(_)) => {
-                        self.subscribed
-                            .lock()
-                            .expect("subscription set lock poisoned")
-                            .insert(script.clone());
-                    }
-                    Err(error) => {
-                        warn!(
-                            "Electrum script subscription failed; polling history for this work item: {error}"
-                        );
-                        subscription_failed = true;
-                        should_fetch = true;
-                    }
+            if status_observed[index] {
+                if let Some(entry) = &cached {
+                    self.cache
+                        .0
+                        .lock()
+                        .expect("history cache lock poisoned")
+                        .reconnect_resubscriptions += 1;
+                    should_fetch |= entry.status != statuses[index];
                 }
             }
+            should_fetch |= subscription_failed[index];
 
-            if !subscription_failed
+            if !subscription_failed[index]
                 && self
                     .subscribed
                     .lock()
@@ -639,6 +656,7 @@ mod tests {
         notifications: HashMap<ScriptBuf, VecDeque<ScriptStatus>>,
         subscribed: HashSet<ScriptBuf>,
         subscription_calls: usize,
+        subscription_batch_calls: usize,
         history_batches: Vec<Vec<ScriptBuf>>,
         unsubscribed_history_calls: usize,
         unsubscribe_calls: usize,
@@ -740,6 +758,7 @@ mod tests {
             I: IntoIterator + Clone,
             I::Item: Borrow<&'s Script>,
         {
+            self.state().subscription_batch_calls += 1;
             scripts
                 .into_iter()
                 .map(|script| self.script_subscribe(script.borrow()))
@@ -938,6 +957,31 @@ mod tests {
         assert_eq!(state.history_batches.len(), 1);
         assert_eq!(state.unsubscribed_history_calls, 0);
         assert_eq!(state.ping_calls, 2);
+    }
+
+    #[test]
+    fn large_cold_cache_subscribes_once_per_bdk_batch() {
+        let api = FakeApi::default();
+        let adapter =
+            SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
+        let scripts: Vec<_> = (0..512).map(indexed_script).collect();
+
+        for batch in scripts.chunks(20) {
+            adapter
+                .batch_script_get_history(batch.iter().map(|script| script.as_script()))
+                .unwrap();
+        }
+        for batch in scripts.chunks(20) {
+            adapter
+                .batch_script_get_history(batch.iter().map(|script| script.as_script()))
+                .unwrap();
+        }
+
+        let state = api.state();
+        assert_eq!(state.subscription_batch_calls, scripts.len().div_ceil(20));
+        assert_eq!(state.subscription_calls, scripts.len());
+        assert_eq!(state.history_batches.len(), scripts.len().div_ceil(20));
+        assert_eq!(state.unsubscribed_history_calls, 0);
     }
 
     #[test]

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -1,7 +1,7 @@
 use bdk_electrum::electrum_client::{
     Batch, BroadcastPackageRes, ElectrumApi, Error, EstimationMode, GetBalanceRes, GetHeadersRes,
     GetHistoryRes, GetMerkleRes, ListUnspentRes, MempoolInfoRes, Param, RawHeaderNotification,
-    ScriptStatus, ServerFeaturesRes, TxidFromPosRes,
+    ScriptStatus, ServerFeaturesRes, ToElectrumScriptHash, TxidFromPosRes,
 };
 use bdk_wallet::bitcoin::{Script, ScriptBuf, Txid};
 use std::borrow::Borrow;
@@ -108,6 +108,21 @@ impl<E> SubscriptionHistoryClient<E> {
 }
 
 impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
+    fn probe_script_status(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
+        let serialized_hash = serde_json::to_value(script.to_electrum_scripthash())?;
+        let script_hash = serialized_hash
+            .as_str()
+            .ok_or_else(|| Error::InvalidResponse(serialized_hash.clone()))?
+            .to_string();
+        let status = self.call(|inner| {
+            inner.raw_call(
+                "blockchain.scripthash.subscribe",
+                [Param::String(script_hash)],
+            )
+        })?;
+        serde_json::from_value(status).map_err(Error::JSON)
+    }
+
     pub(crate) fn start_work(&self) -> Result<(), Error> {
         if self.cancellation_enabled {
             if self.work_state.poisoned.load(Ordering::Acquire) {
@@ -295,17 +310,29 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                         }
                         Ok(None) => {
                             // The trait cannot distinguish an empty local queue from a backend
-                            // representing Electrum's null status as None. Empty cached histories
-                            // remain cache hits; non-empty histories are revalidated defensively
-                            // so mempool eviction or reorg cannot leave stale transactions behind.
+                            // representing Electrum's null status as None. Probe only scripts with
+                            // actual history: an unchanged status remains a history-cache hit,
+                            // while a null/changed status triggers the authoritative refresh.
                             if !status_observed[index]
                                 && cached
                                     .as_ref()
                                     .is_some_and(|entry| !entry.dirty && !entry.history.is_empty())
                             {
-                                statuses[index] = None;
-                                status_observed[index] = true;
-                                should_fetch = true;
+                                match self.probe_script_status(script.as_script()) {
+                                    Ok(status) => {
+                                        statuses[index] = status;
+                                        status_observed[index] = true;
+                                        should_fetch |= cached
+                                            .as_ref()
+                                            .is_none_or(|entry| entry.status != status);
+                                    }
+                                    Err(error) => {
+                                        warn!(
+                                            "Electrum status probe failed; polling history for this work item: {error}"
+                                        );
+                                        should_fetch = true;
+                                    }
+                                }
                             }
                             break;
                         }
@@ -631,6 +658,7 @@ mod tests {
         notifications: HashMap<ScriptBuf, VecDeque<ScriptStatus>>,
         subscribed: HashSet<ScriptBuf>,
         subscription_calls: usize,
+        status_probe_calls: usize,
         history_batches: Vec<Vec<ScriptBuf>>,
         unsubscribed_history_calls: usize,
         unsubscribe_calls: usize,
@@ -667,10 +695,27 @@ mod tests {
     impl ElectrumApi for FakeApi {
         fn raw_call(
             &self,
-            _: &str,
-            _: impl IntoIterator<Item = Param>,
+            method: &str,
+            params: impl IntoIterator<Item = Param>,
         ) -> Result<serde_json::Value, Error> {
-            unimplemented!()
+            assert_eq!(method, "blockchain.scripthash.subscribe");
+            let script_hash = match params.into_iter().next() {
+                Some(Param::String(script_hash)) => script_hash,
+                _ => panic!("status probe requires a script hash"),
+            };
+            let mut state = self.state();
+            state.status_probe_calls += 1;
+            let status = state
+                .statuses
+                .iter()
+                .find(|(script, _)| {
+                    serde_json::to_value(script.as_script().to_electrum_scripthash())
+                        .unwrap()
+                        .as_str()
+                        == Some(script_hash.as_str())
+                })
+                .and_then(|(_, status)| *status);
+            serde_json::to_value(status).map_err(Error::JSON)
         }
 
         fn batch_call(&self, _: &Batch) -> Result<Vec<serde_json::Value>, Error> {
@@ -888,8 +933,8 @@ mod tests {
         let script = script(1);
         {
             let mut state = api.state();
-            state.statuses.insert(script.clone(), None);
-            state.histories.insert(script.clone(), Vec::new());
+            state.statuses.insert(script.clone(), Some(status(1)));
+            state.histories.insert(script.clone(), history(1));
         }
         let adapter =
             SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
@@ -903,11 +948,12 @@ mod tests {
             .batch_script_get_history([script.as_script()])
             .unwrap();
 
-        assert!(first[0].is_empty());
-        assert!(second[0].is_empty());
+        assert_eq!(first[0][0].height, 1);
+        assert_eq!(second[0][0].height, 1);
         let state = api.state();
         assert_eq!(state.subscription_calls, 1);
         assert_eq!(state.history_batches.len(), 1);
+        assert_eq!(state.status_probe_calls, 1);
         assert_eq!(state.unsubscribed_history_calls, 0);
         assert_eq!(state.ping_calls, 2);
     }
@@ -1013,7 +1059,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_status_revalidates_non_empty_history_to_empty() {
+    fn null_status_probe_revalidates_non_empty_history_to_empty() {
         let api = FakeApi::default();
         let script = script(25);
         {
@@ -1027,13 +1073,18 @@ mod tests {
             .batch_script_get_history([script.as_script()])
             .unwrap();
 
-        api.state().histories.insert(script.clone(), Vec::new());
+        {
+            let mut state = api.state();
+            state.statuses.insert(script.clone(), None);
+            state.histories.insert(script.clone(), Vec::new());
+        }
         let refreshed = adapter
             .batch_script_get_history([script.as_script()])
             .unwrap();
 
         assert!(refreshed[0].is_empty());
         assert_eq!(api.state().history_batches.len(), 2);
+        assert_eq!(api.state().status_probe_calls, 1);
         assert_eq!(cache.0.lock().unwrap().entries[&script].status, None);
     }
 
@@ -1045,13 +1096,8 @@ mod tests {
             let mut state = api.state();
             for (offset, script) in scripts.iter().enumerate() {
                 let seed = 10 + offset as u8;
-                if offset == 2 {
-                    state.statuses.insert(script.clone(), Some(status(seed)));
-                    state.histories.insert(script.clone(), history(seed));
-                } else {
-                    state.statuses.insert(script.clone(), None);
-                    state.histories.insert(script.clone(), Vec::new());
-                }
+                state.statuses.insert(script.clone(), Some(status(seed)));
+                state.histories.insert(script.clone(), history(seed));
             }
         }
         let cache = SharedHistoryCache::default();

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -18,6 +18,7 @@ struct HistoryCacheEntry {
     status: Option<ScriptStatus>,
     history: Vec<GetHistoryRes>,
     last_revalidated: Instant,
+    dirty: bool,
 }
 
 #[derive(Debug, Default)]
@@ -149,7 +150,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                 .entries
                 .get(script)
                 .cloned();
-            let mut should_fetch = cached.is_none();
+            let mut should_fetch = cached.as_ref().is_none_or(|entry| entry.dirty);
             let mut subscription_failed = false;
             let known_subscribed = self
                 .subscribed
@@ -280,6 +281,20 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
 
         let reconciliation_start = Instant::now();
         if !fetch_indices.is_empty() {
+            // Notifications are consumed by script_pop before the history RPC. Persist a dirty
+            // marker (and the newest status) first so a transient history failure is retried on
+            // the next sync instead of serving the old cache until safety reconciliation.
+            {
+                let mut cache = self.cache.0.lock().expect("history cache lock poisoned");
+                for &index in &fetch_indices {
+                    if let Some(entry) = cache.entries.get_mut(&scripts[index]) {
+                        entry.dirty = true;
+                        if statuses[index].is_some() {
+                            entry.status = statuses[index];
+                        }
+                    }
+                }
+            }
             let fetched = self.inner.batch_script_get_history(
                 fetch_indices
                     .iter()
@@ -299,6 +314,7 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                         status: effective_status,
                         history: history.clone(),
                         last_revalidated: now,
+                        dirty: false,
                     },
                 );
                 cache.misses += 1;
@@ -526,6 +542,7 @@ mod tests {
         unsubscribe_calls: usize,
         ping_calls: usize,
         fail_subscriptions: bool,
+        fail_history_batches: usize,
     }
 
     #[derive(Clone, Default)]
@@ -667,6 +684,10 @@ mod tests {
                 .map(|script| ScriptBuf::from_bytes(script.borrow().as_bytes().to_vec()))
                 .collect();
             let mut state = self.state();
+            if state.fail_history_batches > 0 {
+                state.fail_history_batches -= 1;
+                return Err(Error::Message("transient history failure".to_string()));
+            }
             state.unsubscribed_history_calls += scripts
                 .iter()
                 .filter(|script| !state.subscribed.contains(*script))
@@ -827,6 +848,45 @@ mod tests {
             .unwrap();
         assert_eq!(refreshed[0][0].height, 3);
         assert_eq!(api.state().history_batches.len(), 2);
+    }
+
+    #[test]
+    fn consumed_notification_remains_dirty_after_failed_history_refresh() {
+        let api = FakeApi::default();
+        let script = script(23);
+        {
+            let mut state = api.state();
+            state.statuses.insert(script.clone(), Some(status(1)));
+            state.histories.insert(script.clone(), history(1));
+        }
+        let cache = SharedHistoryCache::default();
+        let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        {
+            let mut state = api.state();
+            state.histories.insert(script.clone(), history(2));
+            state
+                .notifications
+                .entry(script.clone())
+                .or_default()
+                .push_back(status(2));
+            state.fail_history_batches = 1;
+        }
+        assert!(adapter
+            .batch_script_get_history([script.as_script()])
+            .is_err());
+        assert!(cache.0.lock().unwrap().entries[&script].dirty);
+
+        let retried = adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+        assert_eq!(retried[0][0].height, 2);
+        let cache = cache.0.lock().unwrap();
+        assert!(!cache.entries[&script].dirty);
+        assert_eq!(cache.entries[&script].status, Some(status(2)));
     }
 
     #[test]

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -167,6 +167,9 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
     }
 
     pub(crate) fn forget_scripts(&self, scripts: &[ScriptBuf]) -> Result<(), Error> {
+        // Drop all local ownership up front. If cancellation interrupts server cleanup, the
+        // caller replaces this connection, which removes any remaining server-side subscriptions
+        // with the old socket; retaining stale local/cache entries would be less safe.
         let subscribed_scripts: Vec<_> = {
             let mut subscribed = self
                 .subscribed

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -1,0 +1,925 @@
+use bdk_electrum::electrum_client::{
+    Batch, BroadcastPackageRes, ElectrumApi, Error, EstimationMode, GetBalanceRes, GetHeadersRes,
+    GetHistoryRes, GetMerkleRes, ListUnspentRes, MempoolInfoRes, Param, RawHeaderNotification,
+    ScriptStatus, ServerFeaturesRes, TxidFromPosRes,
+};
+use bdk_wallet::bitcoin::{Script, ScriptBuf, Txid};
+use std::borrow::Borrow;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tracing::{debug, info, warn};
+
+pub(crate) const HISTORY_REVALIDATION_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+
+#[derive(Clone, Debug)]
+struct HistoryCacheEntry {
+    status: Option<ScriptStatus>,
+    history: Vec<GetHistoryRes>,
+    last_revalidated: Instant,
+}
+
+#[derive(Debug, Default)]
+struct HistoryCacheState {
+    entries: HashMap<ScriptBuf, HistoryCacheEntry>,
+    hits: u64,
+    misses: u64,
+    reconnect_resubscriptions: u64,
+}
+
+/// History cache shared by replacement Electrum connections.
+///
+/// Keeping this outside the socket-backed client lets a reconnect resubscribe and compare the
+/// server's current status with the history cached before the disconnect.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SharedHistoryCache(Arc<Mutex<HistoryCacheState>>);
+
+/// Electrum API adapter that turns script subscriptions into a cache invalidation signal.
+///
+/// BDK still asks for every revealed script on each recurring sync. This adapter preserves the
+/// ordered batch contract while fetching history only for new, changed, reconnected, or safety-
+/// revalidated scripts. Full scans intentionally use the underlying polling client directly.
+#[derive(Debug)]
+pub(crate) struct SubscriptionHistoryClient<E> {
+    inner: E,
+    cache: SharedHistoryCache,
+    subscribed: Mutex<HashSet<ScriptBuf>>,
+    enabled: bool,
+}
+
+impl<E> SubscriptionHistoryClient<E> {
+    pub(crate) fn new(inner: E, cache: SharedHistoryCache, enabled: bool) -> Self {
+        Self {
+            inner,
+            cache,
+            subscribed: Mutex::new(HashSet::new()),
+            enabled,
+        }
+    }
+
+    fn cache_diagnostics(&self) -> (usize, u64, u64, u64) {
+        let cache = self.cache.0.lock().expect("history cache lock poisoned");
+        let subscribed = self
+            .subscribed
+            .lock()
+            .expect("subscription set lock poisoned")
+            .len();
+        (
+            subscribed,
+            cache.hits,
+            cache.misses,
+            cache.reconnect_resubscriptions,
+        )
+    }
+}
+
+impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
+    pub(crate) fn prepare_recurring_work(&self) {
+        if self.enabled {
+            // electrum-client only processes queued notifications while an RPC reads the socket.
+            // The following sync call will surface any real transport failure.
+            if let Err(error) = self.inner.ping() {
+                debug!("Electrum notification ping failed before recurring work: {error}");
+            }
+        }
+    }
+
+    fn histories_at(
+        &self,
+        scripts: &[ScriptBuf],
+        now: Instant,
+    ) -> Result<Vec<Vec<GetHistoryRes>>, Error> {
+        if !self.enabled {
+            return self
+                .inner
+                .batch_script_get_history(scripts.iter().map(|script| script.as_script()));
+        }
+
+        let mut results = vec![None; scripts.len()];
+        let mut fetch_indices = Vec::new();
+        let mut statuses = vec![None; scripts.len()];
+        let mut safety_revalidation = false;
+
+        for (index, script) in scripts.iter().enumerate() {
+            let cached = self
+                .cache
+                .0
+                .lock()
+                .expect("history cache lock poisoned")
+                .entries
+                .get(script)
+                .cloned();
+            let mut should_fetch = cached.is_none();
+            let mut subscription_failed = false;
+            let known_subscribed = self
+                .subscribed
+                .lock()
+                .expect("subscription set lock poisoned")
+                .contains(script);
+
+            if !known_subscribed {
+                match self.inner.script_subscribe(script.as_script()) {
+                    Ok(status) => {
+                        self.subscribed
+                            .lock()
+                            .expect("subscription set lock poisoned")
+                            .insert(script.clone());
+                        statuses[index] = status;
+                        if let Some(entry) = &cached {
+                            self.cache
+                                .0
+                                .lock()
+                                .expect("history cache lock poisoned")
+                                .reconnect_resubscriptions += 1;
+                            should_fetch |= entry.status != status;
+                        }
+                    }
+                    Err(Error::AlreadySubscribed(_)) => {
+                        self.subscribed
+                            .lock()
+                            .expect("subscription set lock poisoned")
+                            .insert(script.clone());
+                    }
+                    Err(error) => {
+                        warn!(
+                            "Electrum script subscription failed; polling history for this work item: {error}"
+                        );
+                        subscription_failed = true;
+                        should_fetch = true;
+                    }
+                }
+            }
+
+            if !subscription_failed
+                && self
+                    .subscribed
+                    .lock()
+                    .expect("subscription set lock poisoned")
+                    .contains(script)
+            {
+                loop {
+                    match self.inner.script_pop(script.as_script()) {
+                        Ok(Some(status)) => {
+                            statuses[index] = Some(status);
+                            if cached
+                                .as_ref()
+                                .is_none_or(|entry| entry.status != Some(status))
+                            {
+                                should_fetch = true;
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(Error::NotSubscribed(_)) => {
+                            self.subscribed
+                                .lock()
+                                .expect("subscription set lock poisoned")
+                                .remove(script);
+                            match self.inner.script_subscribe(script.as_script()) {
+                                Ok(status) => {
+                                    self.subscribed
+                                        .lock()
+                                        .expect("subscription set lock poisoned")
+                                        .insert(script.clone());
+                                    statuses[index] = status;
+                                    self.cache
+                                        .0
+                                        .lock()
+                                        .expect("history cache lock poisoned")
+                                        .reconnect_resubscriptions += 1;
+                                    should_fetch |=
+                                        cached.as_ref().is_none_or(|entry| entry.status != status);
+                                }
+                                Err(error) => {
+                                    warn!(
+                                        "Electrum resubscription failed; polling history for this work item: {error}"
+                                    );
+                                    should_fetch = true;
+                                }
+                            }
+                            break;
+                        }
+                        Err(error) => {
+                            warn!(
+                                "Electrum notification read failed; polling history for this work item: {error}"
+                            );
+                            should_fetch = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if cached.as_ref().is_some_and(|entry| {
+                now.saturating_duration_since(entry.last_revalidated)
+                    >= HISTORY_REVALIDATION_INTERVAL
+            }) {
+                should_fetch = true;
+                safety_revalidation = true;
+            }
+
+            if should_fetch {
+                fetch_indices.push(index);
+            } else if let Some(entry) = cached {
+                results[index] = Some(entry.history);
+                self.cache
+                    .0
+                    .lock()
+                    .expect("history cache lock poisoned")
+                    .hits += 1;
+            }
+        }
+
+        let reconciliation_start = Instant::now();
+        if !fetch_indices.is_empty() {
+            let fetched = self.inner.batch_script_get_history(
+                fetch_indices
+                    .iter()
+                    .map(|&index| scripts[index].as_script()),
+            )?;
+            let mut cache = self.cache.0.lock().expect("history cache lock poisoned");
+            for (index, history) in fetch_indices.into_iter().zip(fetched) {
+                let effective_status = statuses[index].or_else(|| {
+                    cache
+                        .entries
+                        .get(&scripts[index])
+                        .and_then(|entry| entry.status)
+                });
+                cache.entries.insert(
+                    scripts[index].clone(),
+                    HistoryCacheEntry {
+                        status: effective_status,
+                        history: history.clone(),
+                        last_revalidated: now,
+                    },
+                );
+                cache.misses += 1;
+                results[index] = Some(history);
+            }
+        }
+
+        if safety_revalidation {
+            info!(
+                "Electrum history safety reconciliation completed in {:.2?}",
+                reconciliation_start.elapsed()
+            );
+        }
+        let (subscribed, hits, misses, reconnects) = self.cache_diagnostics();
+        debug!(
+            "Electrum history cache: subscribed_scripts={subscribed}, hits={hits}, misses={misses}, reconnect_resubscriptions={reconnects}"
+        );
+
+        Ok(results
+            .into_iter()
+            .map(|history| history.expect("every history result is populated"))
+            .collect())
+    }
+}
+
+impl<E: ElectrumApi> ElectrumApi for SubscriptionHistoryClient<E> {
+    fn raw_call(
+        &self,
+        method_name: &str,
+        params: impl IntoIterator<Item = Param>,
+    ) -> Result<serde_json::Value, Error> {
+        self.inner.raw_call(method_name, params)
+    }
+
+    fn batch_call(&self, batch: &Batch) -> Result<Vec<serde_json::Value>, Error> {
+        self.inner.batch_call(batch)
+    }
+
+    fn block_headers_subscribe_raw(&self) -> Result<RawHeaderNotification, Error> {
+        self.inner.block_headers_subscribe_raw()
+    }
+
+    fn block_headers_pop_raw(&self) -> Result<Option<RawHeaderNotification>, Error> {
+        self.inner.block_headers_pop_raw()
+    }
+
+    fn block_header_raw(&self, height: usize) -> Result<Vec<u8>, Error> {
+        self.inner.block_header_raw(height)
+    }
+
+    fn block_headers(&self, start_height: usize, count: usize) -> Result<GetHeadersRes, Error> {
+        self.inner.block_headers(start_height, count)
+    }
+
+    fn estimate_fee(&self, number: usize, mode: Option<EstimationMode>) -> Result<f64, Error> {
+        self.inner.estimate_fee(number, mode)
+    }
+
+    fn relay_fee(&self) -> Result<f64, Error> {
+        self.inner.relay_fee()
+    }
+
+    fn script_subscribe(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
+        self.inner.script_subscribe(script)
+    }
+
+    fn batch_script_subscribe<'s, I>(&self, scripts: I) -> Result<Vec<Option<ScriptStatus>>, Error>
+    where
+        I: IntoIterator + Clone,
+        I::Item: Borrow<&'s Script>,
+    {
+        self.inner.batch_script_subscribe(scripts)
+    }
+
+    fn script_unsubscribe(&self, script: &Script) -> Result<bool, Error> {
+        self.inner.script_unsubscribe(script)
+    }
+
+    fn script_pop(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
+        self.inner.script_pop(script)
+    }
+
+    fn script_get_balance(&self, script: &Script) -> Result<GetBalanceRes, Error> {
+        self.inner.script_get_balance(script)
+    }
+
+    fn batch_script_get_balance<'s, I>(&self, scripts: I) -> Result<Vec<GetBalanceRes>, Error>
+    where
+        I: IntoIterator + Clone,
+        I::Item: Borrow<&'s Script>,
+    {
+        self.inner.batch_script_get_balance(scripts)
+    }
+
+    fn script_get_history(&self, script: &Script) -> Result<Vec<GetHistoryRes>, Error> {
+        self.histories_at(&[script.to_owned()], Instant::now())
+            .map(|mut histories| histories.remove(0))
+    }
+
+    fn batch_script_get_history<'s, I>(&self, scripts: I) -> Result<Vec<Vec<GetHistoryRes>>, Error>
+    where
+        I: IntoIterator + Clone,
+        I::Item: Borrow<&'s Script>,
+    {
+        let scripts: Vec<ScriptBuf> = scripts
+            .into_iter()
+            .map(|script| ScriptBuf::from_bytes(script.borrow().as_bytes().to_vec()))
+            .collect();
+        self.histories_at(&scripts, Instant::now())
+    }
+
+    fn script_list_unspent(&self, script: &Script) -> Result<Vec<ListUnspentRes>, Error> {
+        self.inner.script_list_unspent(script)
+    }
+
+    fn batch_script_list_unspent<'s, I>(
+        &self,
+        scripts: I,
+    ) -> Result<Vec<Vec<ListUnspentRes>>, Error>
+    where
+        I: IntoIterator + Clone,
+        I::Item: Borrow<&'s Script>,
+    {
+        self.inner.batch_script_list_unspent(scripts)
+    }
+
+    fn transaction_get_raw(&self, txid: &Txid) -> Result<Vec<u8>, Error> {
+        self.inner.transaction_get_raw(txid)
+    }
+
+    fn batch_transaction_get_raw<'t, I>(&self, txids: I) -> Result<Vec<Vec<u8>>, Error>
+    where
+        I: IntoIterator + Clone,
+        I::Item: Borrow<&'t Txid>,
+    {
+        self.inner.batch_transaction_get_raw(txids)
+    }
+
+    fn batch_block_header_raw<I>(&self, heights: I) -> Result<Vec<Vec<u8>>, Error>
+    where
+        I: IntoIterator + Clone,
+        I::Item: Borrow<u32>,
+    {
+        self.inner.batch_block_header_raw(heights)
+    }
+
+    fn batch_estimate_fee<I>(&self, numbers: I) -> Result<Vec<f64>, Error>
+    where
+        I: IntoIterator + Clone,
+        I::Item: Borrow<usize>,
+    {
+        self.inner.batch_estimate_fee(numbers)
+    }
+
+    fn transaction_broadcast_raw(&self, raw_tx: &[u8]) -> Result<Txid, Error> {
+        self.inner.transaction_broadcast_raw(raw_tx)
+    }
+
+    fn transaction_broadcast_package_raw<T: AsRef<[u8]>>(
+        &self,
+        raw_txs: &[T],
+    ) -> Result<BroadcastPackageRes, Error> {
+        self.inner.transaction_broadcast_package_raw(raw_txs)
+    }
+
+    fn transaction_get_merkle(&self, txid: &Txid, height: usize) -> Result<GetMerkleRes, Error> {
+        self.inner.transaction_get_merkle(txid, height)
+    }
+
+    fn batch_transaction_get_merkle<I>(
+        &self,
+        txids_and_heights: I,
+    ) -> Result<Vec<GetMerkleRes>, Error>
+    where
+        I: IntoIterator + Clone,
+        I::Item: Borrow<(Txid, usize)>,
+    {
+        self.inner.batch_transaction_get_merkle(txids_and_heights)
+    }
+
+    fn txid_from_pos(&self, height: usize, tx_pos: usize) -> Result<Txid, Error> {
+        self.inner.txid_from_pos(height, tx_pos)
+    }
+
+    fn txid_from_pos_with_merkle(
+        &self,
+        height: usize,
+        tx_pos: usize,
+    ) -> Result<TxidFromPosRes, Error> {
+        self.inner.txid_from_pos_with_merkle(height, tx_pos)
+    }
+
+    fn server_features(&self) -> Result<ServerFeaturesRes, Error> {
+        self.inner.server_features()
+    }
+
+    fn mempool_get_info(&self) -> Result<MempoolInfoRes, Error> {
+        self.inner.mempool_get_info()
+    }
+
+    fn ping(&self) -> Result<(), Error> {
+        self.inner.ping()
+    }
+
+    fn calls_made(&self) -> Result<usize, Error> {
+        self.inner.calls_made()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bdk_electrum::electrum_client::ToElectrumScriptHash;
+    use std::collections::VecDeque;
+
+    #[derive(Default)]
+    struct FakeState {
+        histories: HashMap<ScriptBuf, Vec<GetHistoryRes>>,
+        statuses: HashMap<ScriptBuf, Option<ScriptStatus>>,
+        notifications: HashMap<ScriptBuf, VecDeque<ScriptStatus>>,
+        subscribed: HashSet<ScriptBuf>,
+        subscription_calls: usize,
+        history_batches: Vec<Vec<ScriptBuf>>,
+        unsubscribed_history_calls: usize,
+        ping_calls: usize,
+        fail_subscriptions: bool,
+    }
+
+    #[derive(Clone, Default)]
+    struct FakeApi(Arc<Mutex<FakeState>>);
+
+    impl FakeApi {
+        fn state(&self) -> std::sync::MutexGuard<'_, FakeState> {
+            self.0.lock().unwrap()
+        }
+    }
+
+    fn script(seed: u8) -> ScriptBuf {
+        ScriptBuf::from_bytes(vec![0x51, seed])
+    }
+
+    fn status(seed: u8) -> ScriptStatus {
+        serde_json::from_value(serde_json::Value::String(format!("{seed:02x}").repeat(32))).unwrap()
+    }
+
+    fn history(seed: u8) -> Vec<GetHistoryRes> {
+        vec![GetHistoryRes {
+            height: seed as i32,
+            tx_hash: format!("{seed:02x}").repeat(32).parse().unwrap(),
+            fee: None,
+        }]
+    }
+
+    impl ElectrumApi for FakeApi {
+        fn raw_call(
+            &self,
+            _: &str,
+            _: impl IntoIterator<Item = Param>,
+        ) -> Result<serde_json::Value, Error> {
+            unimplemented!()
+        }
+
+        fn batch_call(&self, _: &Batch) -> Result<Vec<serde_json::Value>, Error> {
+            unimplemented!()
+        }
+
+        fn block_headers_subscribe_raw(&self) -> Result<RawHeaderNotification, Error> {
+            unimplemented!()
+        }
+
+        fn block_headers_pop_raw(&self) -> Result<Option<RawHeaderNotification>, Error> {
+            unimplemented!()
+        }
+
+        fn block_header_raw(&self, _: usize) -> Result<Vec<u8>, Error> {
+            unimplemented!()
+        }
+
+        fn block_headers(&self, _: usize, _: usize) -> Result<GetHeadersRes, Error> {
+            unimplemented!()
+        }
+
+        fn estimate_fee(&self, _: usize, _: Option<EstimationMode>) -> Result<f64, Error> {
+            unimplemented!()
+        }
+
+        fn relay_fee(&self) -> Result<f64, Error> {
+            unimplemented!()
+        }
+
+        fn script_subscribe(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
+            let script = ScriptBuf::from_bytes(script.as_bytes().to_vec());
+            let mut state = self.state();
+            state.subscription_calls += 1;
+            if state.fail_subscriptions {
+                return Err(Error::Message("subscriptions unavailable".to_string()));
+            }
+            if !state.subscribed.insert(script.clone()) {
+                return Err(Error::AlreadySubscribed(
+                    script.as_script().to_electrum_scripthash(),
+                ));
+            }
+            Ok(state.statuses.get(&script).copied().flatten())
+        }
+
+        fn batch_script_subscribe<'s, I>(
+            &self,
+            scripts: I,
+        ) -> Result<Vec<Option<ScriptStatus>>, Error>
+        where
+            I: IntoIterator + Clone,
+            I::Item: Borrow<&'s Script>,
+        {
+            scripts
+                .into_iter()
+                .map(|script| self.script_subscribe(script.borrow()))
+                .collect()
+        }
+
+        fn script_unsubscribe(&self, _: &Script) -> Result<bool, Error> {
+            unimplemented!()
+        }
+
+        fn script_pop(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
+            let script = ScriptBuf::from_bytes(script.as_bytes().to_vec());
+            let mut state = self.state();
+            if !state.subscribed.contains(&script) {
+                return Err(Error::NotSubscribed(
+                    script.as_script().to_electrum_scripthash(),
+                ));
+            }
+            Ok(state.notifications.entry(script).or_default().pop_front())
+        }
+
+        fn script_get_balance(&self, _: &Script) -> Result<GetBalanceRes, Error> {
+            unimplemented!()
+        }
+
+        fn batch_script_get_balance<'s, I>(&self, _: I) -> Result<Vec<GetBalanceRes>, Error>
+        where
+            I: IntoIterator + Clone,
+            I::Item: Borrow<&'s Script>,
+        {
+            unimplemented!()
+        }
+
+        fn script_get_history(&self, script: &Script) -> Result<Vec<GetHistoryRes>, Error> {
+            self.batch_script_get_history([script])
+                .map(|mut result| result.remove(0))
+        }
+
+        fn batch_script_get_history<'s, I>(
+            &self,
+            scripts: I,
+        ) -> Result<Vec<Vec<GetHistoryRes>>, Error>
+        where
+            I: IntoIterator + Clone,
+            I::Item: Borrow<&'s Script>,
+        {
+            let scripts: Vec<_> = scripts
+                .into_iter()
+                .map(|script| ScriptBuf::from_bytes(script.borrow().as_bytes().to_vec()))
+                .collect();
+            let mut state = self.state();
+            state.unsubscribed_history_calls += scripts
+                .iter()
+                .filter(|script| !state.subscribed.contains(*script))
+                .count();
+            state.history_batches.push(scripts.clone());
+            Ok(scripts
+                .iter()
+                .map(|script| state.histories.get(script).cloned().unwrap_or_default())
+                .collect())
+        }
+
+        fn script_list_unspent(&self, _: &Script) -> Result<Vec<ListUnspentRes>, Error> {
+            unimplemented!()
+        }
+
+        fn batch_script_list_unspent<'s, I>(&self, _: I) -> Result<Vec<Vec<ListUnspentRes>>, Error>
+        where
+            I: IntoIterator + Clone,
+            I::Item: Borrow<&'s Script>,
+        {
+            unimplemented!()
+        }
+
+        fn transaction_get_raw(&self, _: &Txid) -> Result<Vec<u8>, Error> {
+            unimplemented!()
+        }
+
+        fn batch_transaction_get_raw<'t, I>(&self, _: I) -> Result<Vec<Vec<u8>>, Error>
+        where
+            I: IntoIterator + Clone,
+            I::Item: Borrow<&'t Txid>,
+        {
+            unimplemented!()
+        }
+
+        fn batch_block_header_raw<I>(&self, _: I) -> Result<Vec<Vec<u8>>, Error>
+        where
+            I: IntoIterator + Clone,
+            I::Item: Borrow<u32>,
+        {
+            unimplemented!()
+        }
+
+        fn batch_estimate_fee<I>(&self, _: I) -> Result<Vec<f64>, Error>
+        where
+            I: IntoIterator + Clone,
+            I::Item: Borrow<usize>,
+        {
+            unimplemented!()
+        }
+
+        fn transaction_broadcast_raw(&self, _: &[u8]) -> Result<Txid, Error> {
+            unimplemented!()
+        }
+
+        fn transaction_broadcast_package_raw<T: AsRef<[u8]>>(
+            &self,
+            _: &[T],
+        ) -> Result<BroadcastPackageRes, Error> {
+            unimplemented!()
+        }
+
+        fn transaction_get_merkle(&self, _: &Txid, _: usize) -> Result<GetMerkleRes, Error> {
+            unimplemented!()
+        }
+
+        fn batch_transaction_get_merkle<I>(&self, _: I) -> Result<Vec<GetMerkleRes>, Error>
+        where
+            I: IntoIterator + Clone,
+            I::Item: Borrow<(Txid, usize)>,
+        {
+            unimplemented!()
+        }
+
+        fn txid_from_pos(&self, _: usize, _: usize) -> Result<Txid, Error> {
+            unimplemented!()
+        }
+
+        fn txid_from_pos_with_merkle(&self, _: usize, _: usize) -> Result<TxidFromPosRes, Error> {
+            unimplemented!()
+        }
+
+        fn server_features(&self) -> Result<ServerFeaturesRes, Error> {
+            unimplemented!()
+        }
+
+        fn mempool_get_info(&self) -> Result<MempoolInfoRes, Error> {
+            unimplemented!()
+        }
+
+        fn ping(&self) -> Result<(), Error> {
+            self.state().ping_calls += 1;
+            Ok(())
+        }
+
+        fn calls_made(&self) -> Result<usize, Error> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn electrs_warning_condition_is_avoided_and_warm_history_is_cached() {
+        let api = FakeApi::default();
+        let script = script(1);
+        {
+            let mut state = api.state();
+            state.statuses.insert(script.clone(), Some(status(1)));
+            state.histories.insert(script.clone(), history(1));
+        }
+        let adapter =
+            SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
+
+        adapter.prepare_recurring_work();
+        let first = adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+        adapter.prepare_recurring_work();
+        let second = adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        assert_eq!(first[0][0].height, 1);
+        assert_eq!(second[0][0].height, 1);
+        let state = api.state();
+        assert_eq!(state.subscription_calls, 1);
+        assert_eq!(state.history_batches.len(), 1);
+        assert_eq!(state.unsubscribed_history_calls, 0);
+        assert_eq!(state.ping_calls, 2);
+    }
+
+    #[test]
+    fn changed_and_multiple_queued_notifications_refresh_once() {
+        let api = FakeApi::default();
+        let script = script(2);
+        {
+            let mut state = api.state();
+            state.statuses.insert(script.clone(), Some(status(1)));
+            state.histories.insert(script.clone(), history(1));
+        }
+        let adapter =
+            SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
+        adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+        {
+            let mut state = api.state();
+            state.histories.insert(script.clone(), history(3));
+            state.statuses.insert(script.clone(), Some(status(3)));
+            state
+                .notifications
+                .entry(script.clone())
+                .or_default()
+                .extend([status(2), status(3)]);
+        }
+
+        let refreshed = adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+        assert_eq!(refreshed[0][0].height, 3);
+        assert_eq!(api.state().history_batches.len(), 2);
+    }
+
+    #[test]
+    fn sparse_batch_refresh_keeps_status_with_its_original_script() {
+        let api = FakeApi::default();
+        let scripts = [script(10), script(11), script(12)];
+        {
+            let mut state = api.state();
+            for (offset, script) in scripts.iter().enumerate() {
+                let seed = 10 + offset as u8;
+                state.statuses.insert(script.clone(), Some(status(seed)));
+                state.histories.insert(script.clone(), history(seed));
+            }
+        }
+        let cache = SharedHistoryCache::default();
+        let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        adapter
+            .batch_script_get_history(scripts.iter().map(ScriptBuf::as_script))
+            .unwrap();
+
+        {
+            let mut state = api.state();
+            state.histories.insert(scripts[2].clone(), history(13));
+            state
+                .notifications
+                .entry(scripts[2].clone())
+                .or_default()
+                .push_back(status(13));
+        }
+        let refreshed = adapter
+            .batch_script_get_history(scripts.iter().map(ScriptBuf::as_script))
+            .unwrap();
+
+        assert_eq!(refreshed[2][0].height, 13);
+        assert_eq!(
+            cache.0.lock().unwrap().entries[&scripts[2]].status,
+            Some(status(13))
+        );
+        assert_eq!(api.state().history_batches[1], vec![scripts[2].clone()]);
+    }
+
+    #[test]
+    fn reconnect_resubscribes_without_refetching_unchanged_history() {
+        let cache = SharedHistoryCache::default();
+        let script = script(3);
+        let first_api = FakeApi::default();
+        {
+            let mut state = first_api.state();
+            state.statuses.insert(script.clone(), Some(status(3)));
+            state.histories.insert(script.clone(), history(3));
+        }
+        SubscriptionHistoryClient::new(first_api, cache.clone(), true)
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        let reconnected_api = FakeApi::default();
+        reconnected_api
+            .state()
+            .statuses
+            .insert(script.clone(), Some(status(3)));
+        let history = SubscriptionHistoryClient::new(reconnected_api.clone(), cache.clone(), true)
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        assert_eq!(history[0][0].height, 3);
+        assert_eq!(reconnected_api.state().subscription_calls, 1);
+        assert!(reconnected_api.state().history_batches.is_empty());
+        assert_eq!(cache.0.lock().unwrap().reconnect_resubscriptions, 1);
+    }
+
+    #[test]
+    fn not_subscribed_after_hidden_reconnect_resubscribes_and_compares_status() {
+        let cache = SharedHistoryCache::default();
+        let api = FakeApi::default();
+        let script = script(6);
+        {
+            let mut state = api.state();
+            state.statuses.insert(script.clone(), Some(status(6)));
+            state.histories.insert(script.clone(), history(6));
+        }
+        let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        // Simulate electrum-client replacing its RawClient internally while the adapter still
+        // remembers the script as subscribed.
+        api.state().subscribed.clear();
+        let cached = adapter
+            .batch_script_get_history([script.as_script()])
+            .unwrap();
+
+        assert_eq!(cached[0][0].height, 6);
+        let state = api.state();
+        assert_eq!(state.subscription_calls, 2);
+        assert_eq!(state.history_batches.len(), 1);
+        assert_eq!(cache.0.lock().unwrap().reconnect_resubscriptions, 1);
+    }
+
+    #[test]
+    fn six_hour_revalidation_and_polling_fallback_preserve_order() {
+        let api = FakeApi::default();
+        let first_script = script(4);
+        let second_script = script(5);
+        {
+            let mut state = api.state();
+            state.statuses.insert(first_script.clone(), Some(status(4)));
+            state
+                .statuses
+                .insert(second_script.clone(), Some(status(5)));
+            state.histories.insert(first_script.clone(), history(4));
+            state.histories.insert(second_script.clone(), history(5));
+        }
+        let adapter =
+            SubscriptionHistoryClient::new(api.clone(), SharedHistoryCache::default(), true);
+        let start = Instant::now();
+        adapter
+            .histories_at(&[first_script.clone(), second_script.clone()], start)
+            .unwrap();
+        let reconciled = adapter
+            .histories_at(
+                &[first_script.clone(), second_script.clone()],
+                start + HISTORY_REVALIDATION_INTERVAL,
+            )
+            .unwrap();
+        assert_eq!(reconciled[0][0].height, 4);
+        assert_eq!(reconciled[1][0].height, 5);
+        assert_eq!(api.state().history_batches.len(), 2);
+
+        let fallback_api = FakeApi::default();
+        {
+            let mut state = fallback_api.state();
+            state.fail_subscriptions = true;
+            state.histories.insert(first_script.clone(), history(4));
+        }
+        let fallback = SubscriptionHistoryClient::new(
+            fallback_api.clone(),
+            SharedHistoryCache::default(),
+            true,
+        );
+        fallback
+            .batch_script_get_history([first_script.as_script()])
+            .unwrap();
+        fallback
+            .batch_script_get_history([first_script.as_script()])
+            .unwrap();
+        assert_eq!(fallback_api.state().history_batches.len(), 2);
+    }
+}

--- a/backend/src/electrum_history.rs
+++ b/backend/src/electrum_history.rs
@@ -1,7 +1,7 @@
 use bdk_electrum::electrum_client::{
     Batch, BroadcastPackageRes, ElectrumApi, Error, EstimationMode, GetBalanceRes, GetHeadersRes,
     GetHistoryRes, GetMerkleRes, ListUnspentRes, MempoolInfoRes, Param, RawHeaderNotification,
-    ScriptStatus, ServerFeaturesRes, ToElectrumScriptHash, TxidFromPosRes,
+    ScriptStatus, ServerFeaturesRes, TxidFromPosRes,
 };
 use bdk_wallet::bitcoin::{Script, ScriptBuf, Txid};
 use std::borrow::Borrow;
@@ -108,21 +108,6 @@ impl<E> SubscriptionHistoryClient<E> {
 }
 
 impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
-    fn probe_script_status(&self, script: &Script) -> Result<Option<ScriptStatus>, Error> {
-        let serialized_hash = serde_json::to_value(script.to_electrum_scripthash())?;
-        let script_hash = serialized_hash
-            .as_str()
-            .ok_or_else(|| Error::InvalidResponse(serialized_hash.clone()))?
-            .to_string();
-        let status = self.call(|inner| {
-            inner.raw_call(
-                "blockchain.scripthash.subscribe",
-                [Param::String(script_hash)],
-            )
-        })?;
-        serde_json::from_value(status).map_err(Error::JSON)
-    }
-
     pub(crate) fn start_work(&self) -> Result<(), Error> {
         if self.cancellation_enabled {
             if self.work_state.poisoned.load(Ordering::Acquire) {
@@ -309,31 +294,10 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
                             }
                         }
                         Ok(None) => {
-                            // The trait cannot distinguish an empty local queue from a backend
-                            // representing Electrum's null status as None. Probe only scripts with
-                            // actual history: an unchanged status remains a history-cache hit,
-                            // while a null/changed status triggers the authoritative refresh.
-                            if !status_observed[index]
-                                && cached
-                                    .as_ref()
-                                    .is_some_and(|entry| !entry.dirty && !entry.history.is_empty())
-                            {
-                                match self.probe_script_status(script.as_script()) {
-                                    Ok(status) => {
-                                        statuses[index] = status;
-                                        status_observed[index] = true;
-                                        should_fetch |= cached
-                                            .as_ref()
-                                            .is_none_or(|entry| entry.status != status);
-                                    }
-                                    Err(error) => {
-                                        warn!(
-                                            "Electrum status probe failed; polling history for this work item: {error}"
-                                        );
-                                        should_fetch = true;
-                                    }
-                                }
-                            }
+                            // No queued notification means the warm history remains valid. A
+                            // backend-specific ambiguous null is bounded by the six-hour
+                            // authoritative history reconciliation below, without adding one RPC
+                            // per non-empty script to every recurring sync.
                             break;
                         }
                         Err(Error::NotSubscribed(_)) => {
@@ -423,6 +387,11 @@ impl<E: ElectrumApi> SubscriptionHistoryClient<E> {
             for (index, history) in fetch_indices.into_iter().zip(fetched) {
                 let effective_status = if status_observed[index] {
                     statuses[index]
+                } else if history.is_empty() {
+                    // An authoritative empty history has Electrum's null status. This also
+                    // resolves backends where a null notification is indistinguishable from an
+                    // empty local notification queue during the periodic reconciliation.
+                    None
                 } else {
                     cache
                         .entries
@@ -658,7 +627,6 @@ mod tests {
         notifications: HashMap<ScriptBuf, VecDeque<ScriptStatus>>,
         subscribed: HashSet<ScriptBuf>,
         subscription_calls: usize,
-        status_probe_calls: usize,
         history_batches: Vec<Vec<ScriptBuf>>,
         unsubscribed_history_calls: usize,
         unsubscribe_calls: usize,
@@ -695,27 +663,10 @@ mod tests {
     impl ElectrumApi for FakeApi {
         fn raw_call(
             &self,
-            method: &str,
-            params: impl IntoIterator<Item = Param>,
+            _: &str,
+            _: impl IntoIterator<Item = Param>,
         ) -> Result<serde_json::Value, Error> {
-            assert_eq!(method, "blockchain.scripthash.subscribe");
-            let script_hash = match params.into_iter().next() {
-                Some(Param::String(script_hash)) => script_hash,
-                _ => panic!("status probe requires a script hash"),
-            };
-            let mut state = self.state();
-            state.status_probe_calls += 1;
-            let status = state
-                .statuses
-                .iter()
-                .find(|(script, _)| {
-                    serde_json::to_value(script.as_script().to_electrum_scripthash())
-                        .unwrap()
-                        .as_str()
-                        == Some(script_hash.as_str())
-                })
-                .and_then(|(_, status)| *status);
-            serde_json::to_value(status).map_err(Error::JSON)
+            unimplemented!()
         }
 
         fn batch_call(&self, _: &Batch) -> Result<Vec<serde_json::Value>, Error> {
@@ -953,7 +904,6 @@ mod tests {
         let state = api.state();
         assert_eq!(state.subscription_calls, 1);
         assert_eq!(state.history_batches.len(), 1);
-        assert_eq!(state.status_probe_calls, 1);
         assert_eq!(state.unsubscribed_history_calls, 0);
         assert_eq!(state.ping_calls, 2);
     }
@@ -1059,7 +1009,7 @@ mod tests {
     }
 
     #[test]
-    fn null_status_probe_revalidates_non_empty_history_to_empty() {
+    fn safety_revalidation_clears_non_empty_history_after_ambiguous_null() {
         let api = FakeApi::default();
         let script = script(25);
         {
@@ -1069,8 +1019,9 @@ mod tests {
         }
         let cache = SharedHistoryCache::default();
         let adapter = SubscriptionHistoryClient::new(api.clone(), cache.clone(), true);
+        let start = Instant::now();
         adapter
-            .batch_script_get_history([script.as_script()])
+            .histories_at(std::slice::from_ref(&script), start)
             .unwrap();
 
         {
@@ -1079,12 +1030,14 @@ mod tests {
             state.histories.insert(script.clone(), Vec::new());
         }
         let refreshed = adapter
-            .batch_script_get_history([script.as_script()])
+            .histories_at(
+                std::slice::from_ref(&script),
+                start + HISTORY_REVALIDATION_INTERVAL,
+            )
             .unwrap();
 
         assert!(refreshed[0].is_empty());
         assert_eq!(api.state().history_batches.len(), 2);
-        assert_eq!(api.state().status_probe_calls, 1);
         assert_eq!(cache.0.lock().unwrap().entries[&script].status, None);
     }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -14,6 +14,7 @@ pub mod auth;
 pub mod btcpay_client;
 pub mod config;
 pub mod electrum;
+mod electrum_history;
 pub mod email_provider;
 pub mod email_queue;
 pub mod email_service;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -11,6 +11,7 @@ mod auth;
 mod btcpay_client;
 mod config;
 mod electrum;
+mod electrum_history;
 mod email_provider;
 mod email_queue;
 mod email_service;
@@ -42,7 +43,6 @@ use nostr_provider::{ensure_nostr_sender_keys, NostrProvider};
 use notifications::{contact_allows_notification, notification_log_type, NotificationManager};
 use ntfy_provider::{NtfyAuth, NtfyProvider};
 use std::sync::Arc;
-use std::time::Instant;
 use stripe_billing::StripeBilling;
 use subscription::SubscriptionTier;
 use tokio::sync::{broadcast, Mutex};
@@ -103,7 +103,7 @@ async fn main() -> anyhow::Result<()> {
     if config.is_self_hosted_mode() {
         let sync_interval = config.get_sync_interval();
         println!(
-            "  Sync interval: {}s (self-hosted mode, network: {:?})",
+            "  Per-wallet sync target: {}s (self-hosted mode, network: {:?})",
             sync_interval, config.network
         );
     } else {
@@ -616,32 +616,16 @@ async fn main() -> anyhow::Result<()> {
         let self_hosted_wallet_manager = Arc::clone(&wallet_manager);
 
         println!(
-            "🕐 Self-hosted sync interval: {}s (network: {:?})",
+            "🕐 Self-hosted per-wallet sync target: {}s (network: {:?})",
             sync_interval, config.network
         );
 
         tokio::spawn(async move {
-            let mut interval = interval(Duration::from_secs(sync_interval));
-
-            loop {
-                interval.tick().await;
-
-                // In self-hosted mode, sync all wallets together (no tier separation)
-                let sync_start = Instant::now();
-
-                // In self-hosted mode, all wallets belong to the hardcoded "team" tier user
-                // No need to sync Personal tier since no self-hosted wallets use that tier
-                if let Err(e) = self_hosted_wallet_manager
-                    .sync_tier_parallel(SubscriptionTier::Team)
-                    .await
-                {
-                    eprintln!("❌ Failed to sync self-hosted wallets: {}", e);
-                }
-
-                let sync_duration = sync_start.elapsed();
-                if sync_duration.as_millis() > 100 {
-                    println!("⚡ Self-hosted sync completed in {:?}", sync_duration);
-                }
+            if let Err(error) = self_hosted_wallet_manager
+                .run_self_hosted_sync_queue(sync_interval)
+                .await
+            {
+                eprintln!("❌ Self-hosted sync queue stopped: {error}");
             }
         });
     } else {

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -1700,7 +1700,10 @@ impl WalletSyncService {
     /// without any data migration since the stored descriptors are already in standard format.
     ///
     /// Resolve an `addr()` or `pk()` descriptor to the corresponding ScriptBuf.
-    fn script_from_watch_descriptor(descriptor: &str, network: Network) -> Result<ScriptBuf> {
+    pub(crate) fn script_from_watch_descriptor(
+        descriptor: &str,
+        network: Network,
+    ) -> Result<ScriptBuf> {
         if let Some(address_str) = extract_address_from_descriptor(descriptor) {
             let address = Address::from_str(&address_str)
                 .map_err(|e| anyhow!("Failed to parse address {}: {}", address_str, e))?;

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -2253,16 +2253,15 @@ impl WalletSyncService {
     /// notifications) to each watcher independently.
     pub(crate) async fn sync_address_watch_group(
         &self,
-        wallet_checksums: &[String],
+        watchers: &[(String, bool)],
         descriptor: &str,
         electrum_manager: Option<&ElectrumClientManager>,
-        suppress_notifications: bool,
     ) -> Result<AddressWatchSyncResult> {
         let sync_start = Instant::now();
         let network = self.config.network.to_bdk_network();
         info!(
             "Starting grouped address watch sync for {} watchers (descriptor: {})",
-            wallet_checksums.len(),
+            watchers.len(),
             descriptor
         );
 
@@ -2331,7 +2330,7 @@ impl WalletSyncService {
         let mut any_changes = false;
 
         // === Fan out to each watcher ===
-        for wallet_checksum in wallet_checksums {
+        for (wallet_checksum, suppress_notifications) in watchers {
             // Get existing transactions for THIS watcher
             let existing_transactions = self
                 .metadata_db
@@ -2409,7 +2408,7 @@ impl WalletSyncService {
                             )
                             .await?;
 
-                        if !suppress_notifications {
+                        if !*suppress_notifications {
                             if let Some(updated_tx) = self
                                 .metadata_db
                                 .get_transaction_by_txid(wallet_checksum, &txid_str)
@@ -2477,7 +2476,7 @@ impl WalletSyncService {
                 };
 
                 self.metadata_db.insert_transaction(&transaction).await?;
-                if !suppress_notifications {
+                if !*suppress_notifications {
                     self.send_new_transaction_notification(&transaction).await?;
                 }
 
@@ -2493,7 +2492,7 @@ impl WalletSyncService {
                     } else {
                         "pending"
                     },
-                    if suppress_notifications {
+                    if *suppress_notifications {
                         ", notifications suppressed"
                     } else {
                         ""
@@ -2507,7 +2506,7 @@ impl WalletSyncService {
                     &existing_transactions,
                     &cpfp_relationships,
                     &rbf_replacements,
-                    suppress_notifications,
+                    *suppress_notifications,
                 )
                 .await?
             {
@@ -2526,7 +2525,7 @@ impl WalletSyncService {
                 .await;
 
             // Check balance alerts for this watcher (skip during initial sync)
-            if !suppress_notifications {
+            if !*suppress_notifications {
                 if let Err(e) = self
                     .check_balance_alerts(wallet_checksum, total_balance)
                     .await
@@ -2545,13 +2544,13 @@ impl WalletSyncService {
             info!(
                 "Grouped address-based sync complete in {:.2}s for {} watchers; changes=true",
                 sync_duration.as_secs_f64(),
-                wallet_checksums.len(),
+                watchers.len(),
             );
         } else {
             debug!(
                 "Grouped address-based sync complete in {:.2}s for {} watchers; changes=false",
                 sync_duration.as_secs_f64(),
-                wallet_checksums.len(),
+                watchers.len(),
             );
         }
 

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -162,13 +162,10 @@ fn recovery_scan_gap(is_fresh_wallet: bool, requested: Option<&str>) -> usize {
     requested
         .filter(|value| *value != "auto")
         .and_then(|value| value.parse::<usize>().ok())
-        // Advanced recovery depths are inclusive address indices. BDK's stop_gap counts
-        // consecutive unused scripts, so index N requires a gap of N + 1 to be inspected.
-        .map(|depth| depth.saturating_add(1))
         .unwrap_or(if is_fresh_wallet {
             crate::electrum::STOP_GAP
         } else {
-            501
+            500
         })
 }
 
@@ -849,9 +846,9 @@ impl WalletManager {
             .persist(&mut db)
             .map_err(|e| anyhow!("Failed to persist wallet: {}", e))?;
 
-        // One BDK full scan owns discovery. Explicit advanced depths cover the selected index;
-        // automatic recovery preserves the former inclusive index-500 coverage for an existing
-        // wallet; fresh wallets keep the normal 20-script gap.
+        // One BDK full scan owns discovery. Advanced selections are stop gaps (consecutive
+        // unused scripts), existing-wallet automatic recovery uses gap 500, and fresh wallets
+        // keep the normal 20-script gap.
         if let Some(ref client) = ctx.electrum_client {
             let scan_gap = recovery_scan_gap(ctx.is_fresh_wallet, stop_gap);
 
@@ -2131,11 +2128,11 @@ mod tests {
     #[test]
     fn recovery_scan_gap_uses_bdk_full_scan_depths() {
         assert_eq!(recovery_scan_gap(true, Some("auto")), 20);
-        assert_eq!(recovery_scan_gap(false, Some("auto")), 501);
+        assert_eq!(recovery_scan_gap(false, Some("auto")), 500);
         for selected in [250usize, 500, 750, 1000] {
             assert_eq!(
                 recovery_scan_gap(false, Some(&selected.to_string())),
-                selected + 1
+                selected
             );
         }
     }

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -6,14 +6,17 @@ use crate::sync::{AddressWatchSyncResult, DescriptorWalletSyncResult};
 use crate::utils::{parse_multipath_descriptor, strip_key_origin};
 use anyhow::{anyhow, Result};
 use bdk_wallet::rusqlite::Connection;
-use bdk_wallet::{bitcoin::Network, KeychainKind, PersistedWallet, Wallet};
+use bdk_wallet::{bitcoin::Network, PersistedWallet, Wallet};
 use futures::future::join_all;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
-use tokio::sync::{broadcast, Mutex, Semaphore};
+use std::time::{Duration, Instant};
+use tokio::sync::{broadcast, Mutex, OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, error, info, warn};
+
+#[cfg(test)]
+use bdk_wallet::KeychainKind;
 
 /// Individual wallet entry containing BDK wallet and its SQLite connection
 type WalletEntry = Arc<Mutex<(PersistedWallet<Connection>, Connection)>>;
@@ -35,6 +38,136 @@ struct WalletCreationContext {
 
 /// Maximum number of wallets to sync in parallel
 const MAX_PARALLEL_SYNCS: usize = 10;
+
+#[derive(Debug, Clone)]
+enum SelfHostedWorkKind {
+    Descriptor(Box<WalletMetadata>),
+    AddressGroup {
+        descriptor: String,
+        watchers: Vec<WalletMetadata>,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct SelfHostedWorkItem {
+    key: String,
+    last_synced_at: Option<chrono::DateTime<chrono::Utc>>,
+    kind: SelfHostedWorkKind,
+}
+
+impl SelfHostedWorkItem {
+    fn due_at(
+        &self,
+        interval: Duration,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> chrono::DateTime<chrono::Utc> {
+        self.last_synced_at
+            .and_then(|synced| {
+                chrono::Duration::from_std(interval)
+                    .ok()
+                    .map(|interval| synced + interval)
+            })
+            .unwrap_or(now)
+    }
+}
+
+fn parse_last_synced_at(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
+        .ok()
+        .map(|timestamp| timestamp.and_utc())
+}
+
+fn build_self_hosted_queue(wallets: Vec<WalletMetadata>) -> Vec<SelfHostedWorkItem> {
+    let (address_watches, descriptor_wallets): (Vec<_>, Vec<_>) = wallets
+        .into_iter()
+        .partition(|wallet| wallet.wallet_type == "address");
+
+    let mut items: Vec<SelfHostedWorkItem> = descriptor_wallets
+        .into_iter()
+        .map(|wallet| SelfHostedWorkItem {
+            key: wallet.checksum.clone(),
+            last_synced_at: wallet
+                .last_synced_at
+                .as_deref()
+                .and_then(parse_last_synced_at),
+            kind: SelfHostedWorkKind::Descriptor(Box::new(wallet)),
+        })
+        .collect();
+
+    let mut address_groups: HashMap<String, Vec<WalletMetadata>> = HashMap::new();
+    for watch in address_watches {
+        address_groups
+            .entry(watch.descriptor.clone())
+            .or_default()
+            .push(watch);
+    }
+    for (descriptor, mut watchers) in address_groups {
+        watchers.sort_by(|left, right| left.checksum.cmp(&right.checksum));
+        let stable_checksum = watchers
+            .first()
+            .expect("address group is never empty")
+            .checksum
+            .clone();
+        let timestamps: Vec<_> = watchers
+            .iter()
+            .map(|watch| {
+                watch
+                    .last_synced_at
+                    .as_deref()
+                    .and_then(parse_last_synced_at)
+            })
+            .collect();
+        let last_synced_at = if timestamps.iter().any(Option::is_none) {
+            None
+        } else {
+            timestamps.into_iter().flatten().min()
+        };
+        items.push(SelfHostedWorkItem {
+            key: format!("address:{stable_checksum}"),
+            last_synced_at,
+            kind: SelfHostedWorkKind::AddressGroup {
+                descriptor,
+                watchers,
+            },
+        });
+    }
+
+    // Never-synced first, then oldest completion time, then a stable key.
+    items.sort_by(|left, right| {
+        left.last_synced_at
+            .is_some()
+            .cmp(&right.last_synced_at.is_some())
+            .then_with(|| left.last_synced_at.cmp(&right.last_synced_at))
+            .then_with(|| left.key.cmp(&right.key))
+    });
+    items
+}
+
+fn select_due_self_hosted_item<'a>(
+    queue: &'a [SelfHostedWorkItem],
+    interval: Duration,
+    now_wall: chrono::DateTime<chrono::Utc>,
+    now_instant: Instant,
+    failure_deferred_until: &HashMap<String, Instant>,
+) -> Option<&'a SelfHostedWorkItem> {
+    queue.iter().find(|item| {
+        item.due_at(interval, now_wall) <= now_wall
+            && failure_deferred_until
+                .get(&item.key)
+                .is_none_or(|until| *until <= now_instant)
+    })
+}
+
+fn recovery_scan_gap(is_fresh_wallet: bool, requested: Option<&str>) -> usize {
+    requested
+        .filter(|value| *value != "auto")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(if is_fresh_wallet {
+            crate::electrum::STOP_GAP
+        } else {
+            500
+        })
+}
 
 /// Generate a unique 8-character alphanumeric ID for use as a wallet checksum PK.
 /// Used when multiple users watch the same address and need distinct wallet records.
@@ -178,8 +311,19 @@ impl WalletCreationService {
         let config = self.wallet_manager.config.clone();
         let descriptor_clone = descriptor.to_string();
         let checksum_clone = checksum.clone();
+        let electrum_work_gate = self.wallet_manager.electrum_work_gate.clone();
 
         tokio::spawn(async move {
+            let _work_permit = match electrum_work_gate {
+                Some(gate) => match gate.acquire_owned().await {
+                    Ok(permit) => Some(permit),
+                    Err(error) => {
+                        error!("[{checksum_clone}] Electrum work gate closed: {error}");
+                        return;
+                    }
+                },
+                None => None,
+            };
             let sync_service = crate::sync::WalletSyncService::new(
                 metadata_db.clone(),
                 notification_sender,
@@ -515,6 +659,8 @@ pub struct WalletManager {
     pub notification_sender: broadcast::Sender<TransactionNotification>,
     network: Network,
     config: AppConfig,
+    /// Fair one-at-a-time gate for script-heavy work against a self-hosted endpoint.
+    electrum_work_gate: Option<Arc<Semaphore>>,
 }
 
 impl WalletManager {
@@ -531,7 +677,10 @@ impl WalletManager {
         }
 
         // Initialize electrum client manager with automatic reconnection support
-        let electrum_client_manager = match ElectrumClientManager::new(electrum_url) {
+        let electrum_client_manager = match ElectrumClientManager::new_with_subscriptions(
+            electrum_url,
+            config.is_self_hosted_mode(),
+        ) {
             Ok(manager) => {
                 let manager = Arc::new(manager);
                 if manager.is_connected().await {
@@ -575,6 +724,9 @@ impl WalletManager {
             notification_sender,
             network,
             config: config.clone(),
+            electrum_work_gate: config
+                .is_self_hosted_mode()
+                .then(|| Arc::new(Semaphore::new(1))),
         };
 
         // Load active wallets on startup (only wallets with active subscriptions)
@@ -615,6 +767,17 @@ impl WalletManager {
         match &self.electrum_client_manager {
             Some(manager) => manager.get_client().await,
             None => None,
+        }
+    }
+
+    async fn acquire_electrum_work(&self) -> Result<Option<OwnedSemaphorePermit>> {
+        match &self.electrum_work_gate {
+            Some(gate) => {
+                Ok(Some(gate.clone().acquire_owned().await.map_err(
+                    |error| anyhow!("Electrum work gate closed: {error}"),
+                )?))
+            }
+            None => Ok(None),
         }
     }
 
@@ -668,47 +831,13 @@ impl WalletManager {
             .persist(&mut db)
             .map_err(|e| anyhow!("Failed to persist wallet: {}", e))?;
 
-        // Apply stop gap if specified
-        if let Some(stop_gap_str) = stop_gap {
-            if stop_gap_str != "auto" {
-                if let Ok(max_index) = stop_gap_str.parse::<u32>() {
-                    debug!(
-                        "[{}] Applying custom stop gap: {} addresses",
-                        ctx.checksum, max_index
-                    );
-
-                    // Reveal addresses up to the specified index
-                    let _external_addresses: Vec<_> = wallet
-                        .reveal_addresses_to(KeychainKind::External, max_index)
-                        .collect();
-                    let _internal_addresses: Vec<_> = wallet
-                        .reveal_addresses_to(KeychainKind::Internal, max_index)
-                        .collect();
-
-                    // Persist the revealed addresses
-                    if let Err(e) = wallet.persist(&mut db) {
-                        error!(
-                            "[{}] Warning: Failed to persist revealed addresses: {}",
-                            ctx.checksum, e
-                        );
-                    }
-                }
-            }
-        }
-
-        // Full scan with electrum (using custom stop gap if specified)
+        // One BDK full scan owns discovery. Explicit advanced depths are used as requested;
+        // automatic recovery uses 500 for an existing wallet and the normal 20 for a fresh one.
         if let Some(ref client) = ctx.electrum_client {
-            let custom_stop_gap = if let Some(stop_gap_str) = stop_gap {
-                if stop_gap_str != "auto" {
-                    stop_gap_str.parse::<usize>().ok()
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
+            let scan_gap = recovery_scan_gap(ctx.is_fresh_wallet, stop_gap);
 
-            if let Err(e) = client.full_scan_wallet(&mut wallet, custom_stop_gap).await {
+            let _work_permit = wallet_manager.acquire_electrum_work().await?;
+            if let Err(e) = client.full_scan_wallet(&mut wallet, scan_gap).await {
                 return Err(anyhow!(
                     "[{}] Failed to full scan wallet during background creation: {}",
                     ctx.checksum,
@@ -725,71 +854,6 @@ impl WalletManager {
                     ctx.checksum,
                     e
                 ));
-            }
-
-            // Deep scanning for existing wallets with no funds (only if stop_gap is auto)
-            if !ctx.is_fresh_wallet
-                && wallet.balance().total().to_sat() == 0
-                && stop_gap.unwrap_or("auto") == "auto"
-            {
-                debug!(
-                    "[{}] No funds found in initial scan, starting deep scan...",
-                    ctx.checksum
-                );
-
-                // Deep scan in batches up to 500 addresses (only for auto mode)
-                for batch in 1..=5 {
-                    let reveal_to = batch * 100;
-                    debug!(
-                        "[{}] Deep scan batch {}: checking addresses up to index {}",
-                        ctx.checksum, batch, reveal_to
-                    );
-
-                    // Reveal more addresses for both keychains
-                    let ext_revealed: Vec<_> = wallet
-                        .reveal_addresses_to(bdk_wallet::KeychainKind::External, reveal_to)
-                        .collect();
-                    let int_revealed: Vec<_> = wallet
-                        .reveal_addresses_to(bdk_wallet::KeychainKind::Internal, reveal_to)
-                        .collect();
-
-                    debug!(
-                        "[{}] Revealed {} external, {} internal addresses (total: {} each)",
-                        ctx.checksum,
-                        ext_revealed.len(),
-                        int_revealed.len(),
-                        reveal_to + 1
-                    );
-
-                    // The deep scan is speculative after the initial full scan has completed.
-                    // Keep the wallet usable if this optional pass is interrupted.
-                    if let Err(e) = client.sync_wallet(&mut wallet).await {
-                        error!(
-                            "[{}] Warning: Failed to sync during deep scan batch {}: {}",
-                            ctx.checksum, batch, e
-                        );
-                        break;
-                    }
-
-                    // Check if we found any activity - if so, we should continue scanning
-                    let current_balance = wallet.balance().total().to_sat();
-                    if current_balance > 0 {
-                        debug!(
-                            "[{}] Found activity during deep scan! Balance: {} sats",
-                            ctx.checksum, current_balance
-                        );
-                        // Continue scanning to find all transactions
-                    }
-                }
-
-                // Final persistence after deep scanning
-                if let Err(e) = wallet.persist(&mut db) {
-                    return Err(anyhow!(
-                        "[{}] Failed to persist after deep scan: {}",
-                        ctx.checksum,
-                        e
-                    ));
-                }
             }
         }
 
@@ -964,6 +1028,226 @@ impl WalletManager {
         }
 
         Ok(())
+    }
+
+    async fn sync_self_hosted_work_item(&self, item: &SelfHostedWorkItem) -> Result<()> {
+        use crate::sync::WalletSyncService;
+
+        let _work_permit = self.acquire_electrum_work().await?;
+        match &item.kind {
+            SelfHostedWorkKind::AddressGroup {
+                descriptor,
+                watchers,
+            } => {
+                let sync_service = WalletSyncService::new(
+                    self.metadata_db.clone(),
+                    self.notification_sender.clone(),
+                    self.config.clone(),
+                );
+                let checksums: Vec<_> = watchers
+                    .iter()
+                    .map(|watch| watch.checksum.clone())
+                    .collect();
+                let suppress_notifications = watchers.iter().any(|watch| watch.status == "pending");
+                let result = if watchers.len() == 1 {
+                    sync_service
+                        .sync_address_watch(
+                            &checksums[0],
+                            descriptor,
+                            self.electrum_client_manager.as_deref(),
+                            suppress_notifications,
+                        )
+                        .await
+                } else {
+                    sync_service
+                        .sync_address_watch_group(
+                            &checksums,
+                            descriptor,
+                            self.electrum_client_manager.as_deref(),
+                            suppress_notifications,
+                        )
+                        .await
+                }?;
+
+                if matches!(result, AddressWatchSyncResult::SkippedNoClient) {
+                    return Err(anyhow!("No Electrum client available"));
+                }
+                for watcher in watchers.iter().filter(|watch| watch.status == "pending") {
+                    self.metadata_db
+                        .update_wallet_status_if_not_deleted(&watcher.checksum, "ready")
+                        .await?;
+                }
+            }
+            SelfHostedWorkKind::Descriptor(metadata) => {
+                let wallet_entry = if let Some(entry) =
+                    self.wallets.lock().await.get(&metadata.checksum).cloned()
+                {
+                    entry
+                } else {
+                    let wallet_path = self
+                        .wallet_dir
+                        .join(format!("{}.sqlite", metadata.checksum));
+                    let (wallet, connection) = Self::load_wallet_from_disk(
+                        &wallet_path,
+                        &metadata.descriptor,
+                        self.network,
+                    )
+                    .await?;
+                    let entry = Arc::new(Mutex::new((wallet, connection)));
+                    self.wallets
+                        .lock()
+                        .await
+                        .insert(metadata.checksum.clone(), entry.clone());
+                    entry
+                };
+
+                let mut wallet_data = wallet_entry.lock().await;
+                let (wallet, connection) = &mut *wallet_data;
+                let sync_service = WalletSyncService::new(
+                    self.metadata_db.clone(),
+                    self.notification_sender.clone(),
+                    self.config.clone(),
+                );
+                match sync_service
+                    .sync_wallet_by_checksum(
+                        wallet,
+                        &metadata.checksum,
+                        self.electrum_client_manager.as_deref(),
+                    )
+                    .await?
+                {
+                    DescriptorWalletSyncResult::Completed => {
+                        wallet.persist(connection).map_err(|error| {
+                            anyhow!("Failed to persist wallet {}: {error}", metadata.name)
+                        })?;
+                        if metadata.status == "pending" {
+                            self.metadata_db
+                                .update_wallet_status_if_not_deleted(&metadata.checksum, "ready")
+                                .await?;
+                        }
+                    }
+                    DescriptorWalletSyncResult::SkippedNoClient => {
+                        return Err(anyhow!("No Electrum client available"));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Run the self-hosted oldest-first due-time queue.
+    ///
+    /// Each successful completion establishes the next target time. Failures are deferred by one
+    /// interval so a broken wallet cannot starve healthy wallets. The shared semaphore is acquired
+    /// for one item only, allowing wallet creation to join the same fair queue between recurring
+    /// items.
+    pub async fn run_self_hosted_sync_queue(&self, sync_interval_secs: u64) -> Result<()> {
+        let sync_interval = Duration::from_secs(sync_interval_secs.max(1));
+        let mut failure_deferred_until: HashMap<String, Instant> = HashMap::new();
+
+        loop {
+            if let Err(error) = self.cleanup_deleted_wallets().await {
+                warn!("Self-hosted wallet cleanup failed; retrying in {sync_interval:?}: {error}");
+                tokio::time::sleep(sync_interval).await;
+                continue;
+            }
+            let network_config = NetworkConfig::from_network(self.network);
+            let wallets = match self
+                .metadata_db
+                .get_wallets_for_tier_sync(
+                    &crate::subscription::SubscriptionTier::Team,
+                    &network_config,
+                )
+                .await
+            {
+                Ok(wallets) => wallets,
+                Err(error) => {
+                    warn!(
+                        "Could not refresh self-hosted Electrum queue; retrying in {sync_interval:?}: {error}"
+                    );
+                    tokio::time::sleep(sync_interval).await;
+                    continue;
+                }
+            };
+            let queue = build_self_hosted_queue(wallets);
+
+            if queue.is_empty() {
+                debug!("Self-hosted Electrum queue is empty");
+                tokio::time::sleep(sync_interval).await;
+                continue;
+            }
+
+            let now_wall = chrono::Utc::now();
+            let now_instant = Instant::now();
+            let selected = select_due_self_hosted_item(
+                &queue,
+                sync_interval,
+                now_wall,
+                now_instant,
+                &failure_deferred_until,
+            );
+
+            let Some(item) = selected else {
+                let wait = queue
+                    .iter()
+                    .map(|item| {
+                        let due_wait = (item.due_at(sync_interval, now_wall) - now_wall)
+                            .to_std()
+                            .unwrap_or(Duration::ZERO);
+                        let failure_wait = failure_deferred_until
+                            .get(&item.key)
+                            .map(|until| until.saturating_duration_since(now_instant))
+                            .unwrap_or(Duration::ZERO);
+                        due_wait.max(failure_wait)
+                    })
+                    .min()
+                    .unwrap_or(sync_interval);
+                debug!(
+                    "Self-hosted Electrum queue depth={}, next item due in {:.2?}",
+                    queue.len(),
+                    wait
+                );
+                tokio::time::sleep(wait).await;
+                continue;
+            };
+
+            let oldest_lateness = queue
+                .iter()
+                .map(|queued| {
+                    (now_wall - queued.due_at(sync_interval, now_wall))
+                        .to_std()
+                        .unwrap_or(Duration::ZERO)
+                })
+                .max()
+                .unwrap_or(Duration::ZERO);
+            info!(
+                "Self-hosted Electrum queue depth={}, oldest_item_lateness={:.2?}, starting={}",
+                queue.len(),
+                oldest_lateness,
+                item.key
+            );
+            let work_start = Instant::now();
+            match self.sync_self_hosted_work_item(item).await {
+                Ok(()) => {
+                    failure_deferred_until.remove(&item.key);
+                    info!(
+                        "Self-hosted Electrum work item {} completed in {:.2?}",
+                        item.key,
+                        work_start.elapsed()
+                    );
+                }
+                Err(error) => {
+                    failure_deferred_until.insert(item.key.clone(), Instant::now() + sync_interval);
+                    warn!(
+                        "Self-hosted Electrum work item {} failed after {:.2?}; deferred for {:.2?}: {}",
+                        item.key,
+                        work_start.elapsed(),
+                        sync_interval,
+                        error
+                    );
+                }
+            }
+        }
     }
 
     /// Sync all wallets for a specific subscription tier in parallel
@@ -1650,9 +1934,137 @@ impl WalletManager {
 mod tests {
     use super::*;
     use bdk_wallet::rusqlite::OptionalExtension;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     const TWO_PATH_DESCRIPTOR: &str = "wpkh(tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1>/*)";
     const THREE_PATH_DESCRIPTOR: &str = "wpkh(tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1;2>/*)";
+
+    fn queue_wallet(checksum: &str, last_synced_at: Option<&str>) -> WalletMetadata {
+        WalletMetadata {
+            checksum: checksum.to_string(),
+            name: checksum.to_string(),
+            descriptor: format!("descriptor-{checksum}"),
+            hex_color: "#000000".to_string(),
+            created_at: "2026-08-10 00:00:00".to_string(),
+            balance_total: Some(0),
+            last_activity: None,
+            status: "ready".to_string(),
+            contact_count: None,
+            user_id: "foss-user".to_string(),
+            is_active: true,
+            balance_fiat: None,
+            fiat_currency: None,
+            wallet_type: "descriptor".to_string(),
+            last_synced_at: last_synced_at.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn self_hosted_queue_orders_never_synced_then_oldest_with_stable_tie_breaker() {
+        let queue = build_self_hosted_queue(vec![
+            queue_wallet("new-b", None),
+            queue_wallet("recent", Some("2026-08-10 12:00:00.000")),
+            queue_wallet("old-b", Some("2026-08-10 10:00:00.000")),
+            queue_wallet("new-a", None),
+            queue_wallet("old-a", Some("2026-08-10 10:00:00.000")),
+        ]);
+        let keys: Vec<_> = queue.iter().map(|item| item.key.as_str()).collect();
+        assert_eq!(keys, ["new-a", "new-b", "old-a", "old-b", "recent"]);
+    }
+
+    #[test]
+    fn self_hosted_queue_scales_oldest_first_for_reported_wallet_counts() {
+        for count in [1usize, 9, 20] {
+            let wallets = (0..count)
+                .rev()
+                .map(|index| {
+                    queue_wallet(
+                        &format!("wallet-{index:02}"),
+                        Some(&format!("2026-08-10 10:{index:02}:00.000")),
+                    )
+                })
+                .collect();
+            let queue = build_self_hosted_queue(wallets);
+            let keys: Vec<_> = queue.iter().map(|item| item.key.clone()).collect();
+            let expected: Vec<_> = (0..count)
+                .map(|index| format!("wallet-{index:02}"))
+                .collect();
+            assert_eq!(keys, expected);
+        }
+    }
+
+    #[test]
+    fn self_hosted_due_time_is_measured_from_completion() {
+        let completed = queue_wallet("wallet", Some("2026-08-10 10:00:30.000"));
+        let item = build_self_hosted_queue(vec![completed]).remove(0);
+        let now = parse_last_synced_at("2026-08-10 10:00:45.000").unwrap();
+        assert_eq!(
+            item.due_at(Duration::from_secs(60), now),
+            parse_last_synced_at("2026-08-10 10:01:30.000").unwrap()
+        );
+    }
+
+    #[test]
+    fn recovery_scan_gap_uses_bdk_full_scan_depths() {
+        assert_eq!(recovery_scan_gap(true, Some("auto")), 20);
+        assert_eq!(recovery_scan_gap(false, Some("auto")), 500);
+        for selected in [250usize, 500, 750, 1000] {
+            assert_eq!(
+                recovery_scan_gap(false, Some(&selected.to_string())),
+                selected
+            );
+        }
+    }
+
+    #[test]
+    fn deferred_failure_does_not_starve_healthy_wallets() {
+        let queue = build_self_hosted_queue(vec![
+            queue_wallet("failed-oldest", None),
+            queue_wallet("healthy", None),
+        ]);
+        let now_wall = chrono::Utc::now();
+        let now_instant = Instant::now();
+        let mut deferred = HashMap::new();
+        deferred.insert(
+            "failed-oldest".to_string(),
+            now_instant + Duration::from_secs(60),
+        );
+
+        let selected = select_due_self_hosted_item(
+            &queue,
+            Duration::from_secs(60),
+            now_wall,
+            now_instant,
+            &deferred,
+        )
+        .unwrap();
+        assert_eq!(selected.key, "healthy");
+    }
+
+    #[tokio::test]
+    async fn self_hosted_work_gate_keeps_peak_concurrency_at_one() {
+        let gate = Arc::new(Semaphore::new(1));
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+
+        for _ in 0..20 {
+            let gate = gate.clone();
+            let active = active.clone();
+            let peak = peak.clone();
+            tasks.push(tokio::spawn(async move {
+                let _permit = gate.acquire_owned().await.unwrap();
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(current, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        assert_eq!(peak.load(Ordering::SeqCst), 1);
+    }
 
     fn create_persisted_test_wallet(path: &Path) {
         let mut conn = Connection::open(path).unwrap();

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -172,6 +172,14 @@ fn recovery_scan_gap(is_fresh_wallet: bool, requested: Option<&str>) -> usize {
         })
 }
 
+fn active_address_watch_descriptors(wallets: &[WalletMetadata]) -> HashSet<&str> {
+    wallets
+        .iter()
+        .filter(|wallet| wallet.wallet_type == "address" && wallet.status != "deleted")
+        .map(|wallet| wallet.descriptor.as_str())
+        .collect()
+}
+
 /// Generate a unique 8-character alphanumeric ID for use as a wallet checksum PK.
 /// Used when multiple users watch the same address and need distinct wallet records.
 fn generate_unique_wallet_id() -> String {
@@ -954,17 +962,17 @@ impl WalletManager {
         // Get ready wallets from database (source of truth)
         let ready_wallets = self.metadata_db.get_ready_wallets().await?;
 
+        // Pending address watches already own the same endpoint subscription that their initial
+        // sync will use. Keep shared scripts until every non-deleted watcher is gone.
+        let non_deleted_wallets = self.metadata_db.get_all_wallets().await?;
+
         // Get wallets marked as deleted in database
         let deleted_wallets = self.metadata_db.get_deleted_wallets().await?;
 
         // Create set of valid checksums from database
         let valid_checksums: HashSet<String> =
             ready_wallets.iter().map(|w| w.checksum.clone()).collect();
-        let active_watch_descriptors: HashSet<&str> = ready_wallets
-            .iter()
-            .filter(|wallet| wallet.wallet_type == "address")
-            .map(|wallet| wallet.descriptor.as_str())
-            .collect();
+        let active_watch_descriptors = active_address_watch_descriptors(&non_deleted_wallets);
 
         // Collect wallets that need to be removed
         let mut wallets_to_remove = Vec::new();
@@ -2030,6 +2038,35 @@ mod tests {
             wallet_type: "descriptor".to_string(),
             last_synced_at: last_synced_at.map(str::to_string),
         }
+    }
+
+    #[test]
+    fn pending_address_watches_keep_shared_subscriptions_active() {
+        let mut ready = queue_wallet("ready", None);
+        ready.wallet_type = "address".to_string();
+        ready.descriptor = "addr(ready-address)".to_string();
+
+        let mut pending = queue_wallet("pending", None);
+        pending.wallet_type = "address".to_string();
+        pending.status = "pending".to_string();
+        pending.descriptor = "addr(shared-address)".to_string();
+
+        let mut deleted = queue_wallet("deleted", None);
+        deleted.wallet_type = "address".to_string();
+        deleted.status = "deleted".to_string();
+        deleted.descriptor = "addr(shared-address)".to_string();
+
+        let mut deleted_only = queue_wallet("deleted-only", None);
+        deleted_only.wallet_type = "address".to_string();
+        deleted_only.status = "deleted".to_string();
+        deleted_only.descriptor = "addr(deleted-address)".to_string();
+
+        let wallets = [ready, pending, deleted, deleted_only];
+        let active = active_address_watch_descriptors(&wallets);
+
+        assert!(active.contains("addr(ready-address)"));
+        assert!(active.contains("addr(shared-address)"));
+        assert!(!active.contains("addr(deleted-address)"));
     }
 
     #[test]

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -180,6 +180,13 @@ fn active_address_watch_descriptors(wallets: &[WalletMetadata]) -> HashSet<&str>
         .collect()
 }
 
+fn address_watch_sync_targets(watchers: &[WalletMetadata]) -> Vec<(String, bool)> {
+    watchers
+        .iter()
+        .map(|watcher| (watcher.checksum.clone(), watcher.status == "pending"))
+        .collect()
+}
+
 /// Generate a unique 8-character alphanumeric ID for use as a wallet checksum PK.
 /// Used when multiple users watch the same address and need distinct wallet records.
 fn generate_unique_wallet_id() -> String {
@@ -1123,27 +1130,22 @@ impl WalletManager {
                     self.notification_sender.clone(),
                     self.config.clone(),
                 );
-                let checksums: Vec<_> = watchers
-                    .iter()
-                    .map(|watch| watch.checksum.clone())
-                    .collect();
-                let suppress_notifications = watchers.iter().any(|watch| watch.status == "pending");
+                let targets = address_watch_sync_targets(watchers);
                 let result = if watchers.len() == 1 {
                     sync_service
                         .sync_address_watch(
-                            &checksums[0],
+                            &targets[0].0,
                             descriptor,
                             self.electrum_client_manager.as_deref(),
-                            suppress_notifications,
+                            targets[0].1,
                         )
                         .await
                 } else {
                     sync_service
                         .sync_address_watch_group(
-                            &checksums,
+                            &targets,
                             descriptor,
                             self.electrum_client_manager.as_deref(),
-                            suppress_notifications,
                         )
                         .await
                 }?;
@@ -1447,35 +1449,34 @@ impl WalletManager {
                             config,
                         );
 
-                        let checksums: Vec<String> =
-                            watchers.iter().map(|w| w.checksum.clone()).collect();
+                        let targets = address_watch_sync_targets(&watchers);
 
                         if watcher_count == 1 {
-                            let is_pending = watchers[0].status == "pending";
+                            let (checksum, is_pending) = &targets[0];
                             // Single watcher — suppress notifications on first sync to avoid
                             // alerting on historical transactions
                             match sync_service
                                 .sync_address_watch(
-                                    &checksums[0],
+                                    checksum,
                                     &descriptor,
                                     electrum_manager.as_deref(),
-                                    is_pending, // suppress on first sync for pending wallets
+                                    *is_pending, // suppress on first sync for pending wallets
                                 )
                                 .await
                             {
                                 Ok(AddressWatchSyncResult::Completed { .. }) => {
                                     // Promote pending watcher to ready
-                                    if is_pending {
+                                    if *is_pending {
                                         if let Err(e) = metadata_db
                                             .update_wallet_status_if_not_deleted(
-                                                &checksums[0],
+                                                checksum,
                                                 "ready",
                                             )
                                             .await
                                         {
                                             warn!(
                                                 "Failed to promote address watch {} to ready: {}",
-                                                checksums[0], e
+                                                checksum, e
                                             );
                                         }
                                     }
@@ -1483,21 +1484,18 @@ impl WalletManager {
                                 }
                                 Ok(AddressWatchSyncResult::SkippedNoClient) => Ok(watcher_count),
                                 Err(e) => {
-                                    warn!("Failed to sync address watch {}: {}", checksums[0], e);
+                                    warn!("Failed to sync address watch {}: {}", checksum, e);
                                     Err(e)
                                 }
                             }
                         } else {
-                            let has_pending =
-                                watchers.iter().any(|w| w.status == "pending");
-                            // Multiple watchers — suppress notifications if any are pending
-                            // to avoid alerting on historical transactions
+                            // Multiple watchers share Electrum queries, but notification
+                            // suppression remains specific to each pending watcher.
                             match sync_service
                                 .sync_address_watch_group(
-                                    &checksums,
+                                    &targets,
                                     &descriptor,
                                     electrum_manager.as_deref(),
-                                    has_pending, // suppress on first sync for pending wallets
                                 )
                                 .await
                             {
@@ -2067,6 +2065,22 @@ mod tests {
         assert!(active.contains("addr(ready-address)"));
         assert!(active.contains("addr(shared-address)"));
         assert!(!active.contains("addr(deleted-address)"));
+    }
+
+    #[test]
+    fn mixed_address_watch_group_suppresses_only_pending_watcher() {
+        let mut ready = queue_wallet("ready", None);
+        ready.wallet_type = "address".to_string();
+        ready.descriptor = "addr(shared-address)".to_string();
+
+        let mut pending = ready.clone();
+        pending.checksum = "pending".to_string();
+        pending.status = "pending".to_string();
+
+        assert_eq!(
+            address_watch_sync_targets(&[ready, pending]),
+            vec![("ready".to_string(), false), ("pending".to_string(), true)]
+        );
     }
 
     #[test]

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -6,9 +6,9 @@ use crate::sync::{AddressWatchSyncResult, DescriptorWalletSyncResult};
 use crate::utils::{parse_multipath_descriptor, strip_key_origin};
 use anyhow::{anyhow, Result};
 use bdk_wallet::rusqlite::Connection;
-use bdk_wallet::{bitcoin::Network, PersistedWallet, Wallet};
+use bdk_wallet::{bitcoin::Network, bitcoin::ScriptBuf, PersistedWallet, Wallet};
 use futures::future::join_all;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -947,8 +947,6 @@ impl WalletManager {
 
     /// Clean up deleted wallets - remove from memory, disk, and database
     async fn cleanup_deleted_wallets(&self) -> Result<()> {
-        use std::collections::HashSet;
-
         // Get ready wallets from database (source of truth)
         let ready_wallets = self.metadata_db.get_ready_wallets().await?;
 
@@ -958,6 +956,11 @@ impl WalletManager {
         // Create set of valid checksums from database
         let valid_checksums: HashSet<String> =
             ready_wallets.iter().map(|w| w.checksum.clone()).collect();
+        let active_watch_descriptors: HashSet<&str> = ready_wallets
+            .iter()
+            .filter(|wallet| wallet.wallet_type == "address")
+            .map(|wallet| wallet.descriptor.as_str())
+            .collect();
 
         // Collect wallets that need to be removed
         let mut wallets_to_remove = Vec::new();
@@ -979,17 +982,31 @@ impl WalletManager {
             }
         }
 
+        let mut scripts_to_forget = HashSet::<ScriptBuf>::new();
+
         // Clean up each removed wallet: memory, disk, and database
         for checksum in wallets_to_remove {
             debug!("Cleaning up wallet {} (deleted or expired)", checksum);
+            let deleted_metadata = deleted_wallets
+                .iter()
+                .find(|wallet| wallet.checksum == checksum);
+            let wallet_path = self.wallet_dir.join(format!("{}.sqlite", checksum));
+            let mut removed_from_memory = false;
 
             // Remove from memory (if it was loaded)
             {
                 let mut wallets_map = self.wallets.lock().await;
                 if let Some(wallet_arc) = wallets_map.remove(&checksum) {
+                    removed_from_memory = true;
                     // Persist final state before removal
                     let mut wallet_data = wallet_arc.lock().await;
                     let (wallet, conn) = &mut *wallet_data;
+                    scripts_to_forget.extend(
+                        wallet
+                            .spk_index()
+                            .revealed_spks(..)
+                            .map(|(_, script)| script),
+                    );
                     if let Err(e) = wallet.persist(conn) {
                         warn!("Failed to persist wallet before removal: {}", e);
                     }
@@ -997,9 +1014,47 @@ impl WalletManager {
                 }
             }
 
+            if let Some(metadata) = deleted_metadata {
+                if metadata.wallet_type == "address" {
+                    // Multiple users may share one address-watch subscription. Keep it until the
+                    // last active watcher is gone.
+                    if !active_watch_descriptors.contains(metadata.descriptor.as_str()) {
+                        match crate::sync::WalletSyncService::script_from_watch_descriptor(
+                            &metadata.descriptor,
+                            self.network,
+                        ) {
+                            Ok(script) => {
+                                scripts_to_forget.insert(script);
+                            }
+                            Err(error) => warn!(
+                                "Could not resolve deleted address watch {} for Electrum cleanup: {error}",
+                                metadata.checksum
+                            ),
+                        }
+                    }
+                } else if !removed_from_memory && wallet_path.exists() {
+                    match Self::load_wallet_from_disk(
+                        &wallet_path,
+                        &metadata.descriptor,
+                        self.network,
+                    )
+                    .await
+                    {
+                        Ok((wallet, _)) => scripts_to_forget.extend(
+                            wallet
+                                .spk_index()
+                                .revealed_spks(..)
+                                .map(|(_, script)| script),
+                        ),
+                        Err(error) => warn!(
+                            "Could not load deleted wallet {} for Electrum cleanup: {error}",
+                            metadata.checksum
+                        ),
+                    }
+                }
+            }
+
             // Delete wallet file from disk (only for descriptor-type wallets; address watches have no file)
-            let wallet_filename = format!("{}.sqlite", checksum);
-            let wallet_path = self.wallet_dir.join(&wallet_filename);
             if wallet_path.exists() {
                 if let Err(e) = std::fs::remove_file(&wallet_path) {
                     error!(
@@ -1024,6 +1079,18 @@ impl WalletManager {
                 );
             } else {
                 debug!("Hard deleted wallet {} from database", checksum);
+            }
+        }
+
+        if !scripts_to_forget.is_empty() && self.electrum_work_gate.is_some() {
+            let _work_permit = self.acquire_electrum_work().await?;
+            if let Some(manager) = &self.electrum_client_manager {
+                if let Err(error) = manager
+                    .forget_scripts(scripts_to_forget.into_iter().collect())
+                    .await
+                {
+                    warn!("Failed to clean up deleted Electrum subscriptions: {error}");
+                }
             }
         }
 
@@ -1170,6 +1237,8 @@ impl WalletManager {
                 }
             };
             let queue = build_self_hosted_queue(wallets);
+            let active_keys: HashSet<_> = queue.iter().map(|item| item.key.as_str()).collect();
+            failure_deferred_until.retain(|key, _| active_keys.contains(key.as_str()));
 
             if queue.is_empty() {
                 debug!("Self-hosted Electrum queue is empty");

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -165,14 +165,23 @@ fn select_due_self_hosted_item<'a>(
 }
 
 fn recovery_scan_gap(is_fresh_wallet: bool, requested: Option<&str>) -> usize {
-    requested
-        .filter(|value| *value != "auto")
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(if is_fresh_wallet {
-            crate::electrum::STOP_GAP
-        } else {
-            500
-        })
+    let default = if is_fresh_wallet {
+        crate::electrum::STOP_GAP
+    } else {
+        500
+    };
+    match requested {
+        None | Some("auto") => default,
+        Some(value) => match value.parse::<usize>() {
+            Ok(gap) => gap,
+            Err(error) => {
+                warn!(
+                    "Could not parse requested wallet recovery gap '{value}'; using {default}: {error}"
+                );
+                default
+            }
+        },
+    }
 }
 
 fn active_address_watch_descriptors(wallets: &[WalletMetadata]) -> HashSet<&str> {
@@ -2135,6 +2144,7 @@ mod tests {
     fn recovery_scan_gap_uses_bdk_full_scan_depths() {
         assert_eq!(recovery_scan_gap(true, Some("auto")), 20);
         assert_eq!(recovery_scan_gap(false, Some("auto")), 500);
+        assert_eq!(recovery_scan_gap(false, Some("invalid")), 500);
         for selected in [250usize, 500, 750, 1000] {
             assert_eq!(
                 recovery_scan_gap(false, Some(&selected.to_string())),

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -162,6 +162,9 @@ fn recovery_scan_gap(is_fresh_wallet: bool, requested: Option<&str>) -> usize {
     requested
         .filter(|value| *value != "auto")
         .and_then(|value| value.parse::<usize>().ok())
+        // Advanced recovery depths are inclusive address indices. BDK's stop_gap counts
+        // consecutive unused scripts, so index N requires a gap of N + 1 to be inspected.
+        .map(|depth| depth.saturating_add(1))
         .unwrap_or(if is_fresh_wallet {
             crate::electrum::STOP_GAP
         } else {
@@ -2080,7 +2083,7 @@ mod tests {
         for selected in [250usize, 500, 750, 1000] {
             assert_eq!(
                 recovery_scan_gap(false, Some(&selected.to_string())),
-                selected
+                selected + 1
             );
         }
     }

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -72,9 +72,15 @@ impl SelfHostedWorkItem {
 }
 
 fn parse_last_synced_at(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
-        .ok()
-        .map(|timestamp| timestamp.and_utc())
+    match chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f") {
+        Ok(timestamp) => Some(timestamp.and_utc()),
+        Err(error) => {
+            warn!(
+                "Could not parse persisted wallet last_synced_at timestamp '{value}'; treating it as never synced: {error}"
+            );
+            None
+        }
+    }
 }
 
 fn build_self_hosted_queue(wallets: Vec<WalletMetadata>) -> Vec<SelfHostedWorkItem> {

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -168,7 +168,7 @@ fn recovery_scan_gap(is_fresh_wallet: bool, requested: Option<&str>) -> usize {
         .unwrap_or(if is_fresh_wallet {
             crate::electrum::STOP_GAP
         } else {
-            500
+            501
         })
 }
 
@@ -834,8 +834,9 @@ impl WalletManager {
             .persist(&mut db)
             .map_err(|e| anyhow!("Failed to persist wallet: {}", e))?;
 
-        // One BDK full scan owns discovery. Explicit advanced depths are used as requested;
-        // automatic recovery uses 500 for an existing wallet and the normal 20 for a fresh one.
+        // One BDK full scan owns discovery. Explicit advanced depths cover the selected index;
+        // automatic recovery preserves the former inclusive index-500 coverage for an existing
+        // wallet; fresh wallets keep the normal 20-script gap.
         if let Some(ref client) = ctx.electrum_client {
             let scan_gap = recovery_scan_gap(ctx.is_fresh_wallet, stop_gap);
 
@@ -2079,7 +2080,7 @@ mod tests {
     #[test]
     fn recovery_scan_gap_uses_bdk_full_scan_depths() {
         assert_eq!(recovery_scan_gap(true, Some("auto")), 20);
-        assert_eq!(recovery_scan_gap(false, Some("auto")), 500);
+        assert_eq!(recovery_scan_gap(false, Some("auto")), 501);
         for selected in [250usize, 500, 750, 1000] {
             assert_eq!(
                 recovery_scan_gap(false, Some(&selected.to_string())),

--- a/backend/system_tests/common/docker_environment.rs
+++ b/backend/system_tests/common/docker_environment.rs
@@ -366,7 +366,7 @@ impl IsolatedTestEnvironment {
                 &test_user_id,
                 false,
                 Some("auto"),
-                Some("250"),
+                Some("auto"),
             )
             .await?;
 
@@ -723,7 +723,7 @@ rpcpassword = test
 tcp = 0.0.0.0:50001
 datadir = /data
 worker_threads = 1
-utxo-cache = 1024
+db_mem = 1024
 debug = 1
 "#,
             bitcoin_container_name

--- a/backend/system_tests/common/docker_environment.rs
+++ b/backend/system_tests/common/docker_environment.rs
@@ -296,7 +296,7 @@ impl IsolatedTestEnvironment {
         // Setup all test wallets including Charlie for high index tests
         Self::setup_test_wallets(&compose_dir, &test_id).await?;
 
-        // Fund Alice and Charlie (Charlie at high index 250)
+        // Fund Alice and Charlie (Charlie at high index 249)
         Self::fund_test_wallets(&compose_dir, &test_id).await?;
 
         // Create wallet manager (connects to Fulcrum)
@@ -1097,12 +1097,12 @@ volumes:
             &["-rpcwallet=miner", "sendtoaddress", &alice_address, "1.0"],
         )?;
 
-        // Fund Charlie at high index (250) - same as docker-utils.sh
-        println!("💰 Funding Charlie at index 250 for high-index testing...");
+        // Fund Charlie at the last index inside the selected 250-script stop gap.
+        println!("💰 Funding Charlie at index 249 for high-index testing...");
 
-        // Generate addresses up to index 250 (0-250 = 251 addresses)
-        let mut charlie_addr_250 = String::new();
-        for i in 0..=250 {
+        // Generate addresses up to index 249 (0-249 = 250 addresses).
+        let mut charlie_addr_249 = String::new();
+        for i in 0..=249 {
             let addr = Self::bitcoin_cli(
                 &bitcoin_container_name,
                 &["-rpcwallet=charlie", "getnewaddress"],
@@ -1111,9 +1111,9 @@ volumes:
             .trim_matches('"')
             .to_string();
 
-            if i == 250 {
-                charlie_addr_250 = addr;
-                println!("   🎯 Charlie address at index 250: {}", charlie_addr_250);
+            if i == 249 {
+                charlie_addr_249 = addr;
+                println!("   🎯 Charlie address at index 249: {}", charlie_addr_249);
             }
 
             // Show progress every 50 addresses
@@ -1122,13 +1122,13 @@ volumes:
             }
         }
 
-        // Send 0.5 BTC to Charlie's address at index 250
+        // Send 0.5 BTC to Charlie's address at index 249
         Self::bitcoin_cli(
             &bitcoin_container_name,
             &[
                 "-rpcwallet=miner",
                 "sendtoaddress",
-                &charlie_addr_250,
+                &charlie_addr_249,
                 "0.5",
             ],
         )?;
@@ -1140,7 +1140,7 @@ volumes:
         )?;
 
         println!("✅ Alice funded with 1.0 BTC (index 0)");
-        println!("✅ Charlie funded with 0.5 BTC (index 250)");
+        println!("✅ Charlie funded with 0.5 BTC (index 249)");
         println!("✅ Bob unfunded (for testing receive scenarios)");
 
         // Wait for Fulcrum to sync with Bitcoin Core before proceeding

--- a/backend/system_tests/common/docker_environment.rs
+++ b/backend/system_tests/common/docker_environment.rs
@@ -366,7 +366,7 @@ impl IsolatedTestEnvironment {
                 &test_user_id,
                 false,
                 Some("auto"),
-                Some("auto"),
+                Some("250"),
             )
             .await?;
 

--- a/backend/system_tests/high_index_scanning.rs
+++ b/backend/system_tests/high_index_scanning.rs
@@ -1,3 +1,5 @@
+use bdk_wallet::rusqlite::Connection;
+use bdk_wallet::{KeychainKind, Wallet};
 use canary::metadata::EventType;
 
 mod common;
@@ -46,6 +48,32 @@ async fn test_high_index_fund_detection() {
     assert!(
         !charlie_receive_transactions.is_empty(),
         "Charlie should have receive transactions from funding at index 250"
+    );
+
+    // Recovery scans to the selected depth, but BDK's last_active_indices should persist only
+    // Canary's normal 20-address lookahead beyond the highest used address.
+    let charlie_metadata = env
+        .wallet_manager
+        .metadata_db
+        .get_wallet_by_checksum(&env.charlie_checksum)
+        .await
+        .expect("Failed to read Charlie metadata")
+        .expect("Charlie metadata missing");
+    let wallet_path = env
+        .wallet_manager
+        .wallet_dir
+        .join(format!("{}.sqlite", env.charlie_checksum));
+    let mut connection = Connection::open(wallet_path).expect("Failed to open Charlie wallet");
+    let charlie_wallet = Wallet::load()
+        .two_path_descriptor(charlie_metadata.descriptor)
+        .check_network(env.wallet_manager.get_network())
+        .load_wallet(&mut connection)
+        .expect("Failed to load Charlie wallet")
+        .expect("Charlie wallet missing");
+    assert_eq!(
+        charlie_wallet.derivation_index(KeychainKind::External),
+        Some(270),
+        "index 250 activity should retain a 20-address lookahead, not the scan depth"
     );
 
     println!(

--- a/backend/system_tests/high_index_scanning.rs
+++ b/backend/system_tests/high_index_scanning.rs
@@ -5,11 +5,11 @@ use canary::metadata::EventType;
 mod common;
 use common::docker_environment::IsolatedTestEnvironment;
 
-/// Test 1: High Index Fund Detection (Index 250)
+/// Test 1: High Index Fund Detection (Index 249)
 /// Purpose: Verify that wallets can detect funds at high address indexes
 ///
 /// These tests verify that wallets can detect funds and transactions at high
-/// address indexes (250+) which is critical for wallet recovery scenarios.
+/// address indexes near the selected 250-script stop gap, which is critical for wallet recovery.
 
 #[tokio::test]
 #[ignore] // System test - requires Docker
@@ -18,7 +18,7 @@ async fn test_high_index_fund_detection() {
         .await
         .expect("Failed to create test environment");
 
-    // Initial sync should detect both Alice (index 0) and Charlie (index 250) funding
+    // Initial sync should detect both Alice (index 0) and Charlie (index 249) funding
     env.sync_and_wait().await.expect("Failed to sync");
 
     let alice_transactions = env
@@ -40,14 +40,14 @@ async fn test_high_index_fund_detection() {
         "Alice should have receive transactions from funding at index 0"
     );
 
-    // Charlie should have transactions (funded at high index 250)
+    // Charlie should have transactions (funded at high index 249)
     let charlie_receive_transactions: Vec<_> = charlie_transactions
         .iter()
         .filter(|t| t.transaction_type == EventType::Receive)
         .collect();
     assert!(
         !charlie_receive_transactions.is_empty(),
-        "Charlie should have receive transactions from funding at index 250"
+        "Charlie should have receive transactions from funding at index 249"
     );
 
     // Recovery scans to the selected depth, but BDK's last_active_indices should persist only
@@ -72,8 +72,8 @@ async fn test_high_index_fund_detection() {
         .expect("Charlie wallet missing");
     assert_eq!(
         charlie_wallet.derivation_index(KeychainKind::External),
-        Some(270),
-        "index 250 activity should retain a 20-address lookahead, not the scan depth"
+        Some(269),
+        "index 249 activity should retain a 20-address lookahead, not the scan depth"
     );
 
     println!(
@@ -81,11 +81,11 @@ async fn test_high_index_fund_detection() {
         alice_receive_transactions.len()
     );
     println!(
-        "📊 Charlie transactions (index 250): {}",
+        "📊 Charlie transactions (index 249): {}",
         charlie_receive_transactions.len()
     );
 
     println!("✅ High-index fund detection test passed!");
     println!("   - Alice funded at index 0: detected ✓");
-    println!("   - Charlie funded at index 250: detected ✓");
+    println!("   - Charlie funded at index 249: detected ✓");
 }


### PR DESCRIPTION
Closes #446

## Summary

- serialize script-heavy work against self-hosted Electrum endpoints with a shared fair gate and oldest-first per-wallet due queue
- cache recurring script histories behind Electrum subscriptions, including notification draining, reconnect resubscription, six-hour reconciliation, and polling fallback
- keep recovery full scans serialized and subscription-free, populate BDK transaction and anchor caches, and rely on BDK full-scan semantics with a normal 20-address persisted lookahead
- cooperatively cancel timed-out Electrum workers, bound wallet-deletion unsubscribe work, force connection replacement if a worker remains unresponsive, and serialize every operation sharing a connection's socket/cancellation state
- keep the Claude review workflow prompt below Linux's per-argument limit with explicit UTF-8 byte budgets and truncation reporting
- document `CANARY_SYNC_INTERVAL` as a per-wallet freshness target and add queue/cache diagnostics

Cloud scheduling and downstream package intervals are unchanged. This does not add a parallel-sync tuning variable.

## Verification

- `.agent-loop/checks.sh quick`
  - Rust fmt and strict all-target clippy
  - 301 library tests (300 passed, 1 ignored) and 171 binary tests
  - backend integration suites
  - 45 frontend suites / 394 tests
  - Next.js production build
  - Claude review workflow YAML parse and an enforced 108,000-byte patch budget with explicit truncation reporting
- Docker-backed high-index recovery test: `cargo test --test high_index_scanning test_high_index_fund_detection -- --ignored --nocapture`
  - explicitly selects stop gap 250 and discovers activity at external index 249, the last address inside that gap
  - persists the normal 20-address lookahead at external index 269 rather than retaining the deep scan gap
- focused subscription adapter tests cover per-BDK-batch cold subscriptions across 512 scripts, partial batch-success reconciliation, strict short/long history-response length validation, warm non-empty-history cache hits without recurring status probes, changed, queued, and null statuses, failed-refresh retries, sparse ordered batches, reconnects, `NotSubscribed`, six-hour authoritative reconciliation, polling fallback, bounded notification draining, and deletion-time unsubscribe/cache eviction
- cleanup tests cover a 512-script legacy wallet, cancellation between per-script unsubscribe RPCs, and ordinary unsubscribe errors; incomplete cleanup evicts local/cache state and forces connection replacement
- timeout tests cover cooperative worker cancellation, work-gate release, shared full-scan/recurring poison state, and forced connection replacement classification
- connection-boundary audit confirms syncs, full scans, address-watch RPCs, header/height lookups, transaction fetches, cleanup, and active verification all share the same internal operation gate
- cleanup coverage confirms pending duplicate address watches retain their shared Electrum subscription
- grouped-watch coverage confirms pending/ready duplicates share Electrum queries while suppressing notifications only for the pending watcher
- scheduler tests cover 1, 9, and 20 wallets, completion-based cadence, failed-wallet deferral, and peak script-heavy concurrency of one
- recovery-gap unit coverage confirms the UI's consecutive-unused selections 250/500/750/1000 are passed directly to BDK

## Remaining target-environment validation

The reported Start9/electrs 0.11.1 environment is not available locally. Before release, soak-test the nine legacy/deep-scanned wallet setup and a 20-wallet fixture at a 60-second target, confirming electrs remains responsive, warm recurring syncs do not repeat `get_history called for unsubscribed scripthash`, and queue lateness is visible.
