### PR TITLE
fix: address cloud security blockers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,8 +38,14 @@ COPY --from=rust-builder /app/target/release/canary /app/canary
 # Copy migrations with correct ownership for non-root user
 COPY --from=rust-builder --chown=1000:1000 /app/migrations /app/migrations
 
-# Create data directory with correct ownership for non-root user
-RUN mkdir -p /app/data && chown 1000:1000 /app/data
+# Create a dedicated runtime user with owner-only application data.
+RUN groupadd --gid 1000 canary \
+    && useradd --uid 1000 --gid canary --create-home --shell /usr/sbin/nologin canary \
+    && mkdir -p /app/data \
+    && chown -R canary:canary /app \
+    && chmod 700 /app/data
+
+USER canary
 
 # Expose port
 EXPOSE 3000

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,15 +35,15 @@ RUN apt-get update && apt-get install -y \
 # Copy the Rust binary from builder stage
 COPY --from=rust-builder /app/target/release/canary /app/canary
 
-# Copy migrations with correct ownership for non-root user
-COPY --from=rust-builder --chown=1000:1000 /app/migrations /app/migrations
+# Migrations and application artifacts remain read-only to the runtime user.
+COPY --from=rust-builder /app/migrations /app/migrations
 
 # Create a dedicated runtime user with owner-only application data.
 RUN groupadd --gid 1000 canary \
     && useradd --uid 1000 --gid canary --create-home --shell /usr/sbin/nologin canary \
-    && mkdir -p /app/data \
-    && chown -R canary:canary /app \
-    && chmod 700 /app/data
+    && mkdir -p /app/data /app/logs \
+    && chown canary:canary /app/data /app/logs \
+    && chmod 700 /app/data /app/logs
 
 USER canary
 

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -379,13 +379,14 @@ pub async fn handle_stripe_webhook(
     };
 
     // Handle the webhook
-    tracing::info!("🎣 Processing Stripe webhook with signature: {}", signature);
+    tracing::info!("🎣 Processing Stripe webhook");
     match stripe_billing
         .handle_webhook(body.as_bytes(), signature)
         .await
     {
         Ok(webhook_result) => {
             // Process any subscription updates - no mutex blocking!
+            let mut persistence_failed = false;
             for update in webhook_result.subscription_updates {
                 tracing::info!(
                     "Processing subscription update for user {}: {} -> {}",
@@ -448,6 +449,7 @@ pub async fn handle_stripe_webhook(
                                     customer_id,
                                     e
                                 );
+                                persistence_failed = true;
                                 continue; // Skip this update
                             }
                         }
@@ -508,6 +510,7 @@ pub async fn handle_stripe_webhook(
                             actual_user_id,
                             e
                         );
+                        persistence_failed = true;
                     } else {
                         tracing::info!(
                             "✅ Updated user {} subscription status to {} (keeping current tier)",
@@ -535,6 +538,7 @@ pub async fn handle_stripe_webhook(
                             actual_user_id,
                             e
                         );
+                        persistence_failed = true;
                     } else {
                         tracing::info!(
                             "✅ Updated user {} subscription to {} ({})",
@@ -567,6 +571,7 @@ pub async fn handle_stripe_webhook(
                                         actual_user_id,
                                         e
                                     );
+                                    persistence_failed = true;
                                 } else if user_record.is_admin {
                                     tracing::info!(
                                         "✅ Applied unlimited limits for admin user {}",
@@ -592,10 +597,20 @@ pub async fn handle_stripe_webhook(
                                     actual_user_id,
                                     e
                                 );
+                                persistence_failed = true;
                             }
                         }
                     }
                 }
+            }
+
+            if persistence_failed {
+                tracing::error!("Webhook state update failed; returning an error for Stripe retry");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("Webhook state update failed")),
+                )
+                    .into_response();
             }
 
             tracing::info!("✅ Webhook processed successfully");
@@ -617,7 +632,8 @@ pub async fn handle_stripe_webhook(
 
 /// Get checkout session details
 pub async fn get_checkout_session_details(
-    AuthenticatedUser(_user): AuthenticatedUser,
+    AuthenticatedUser(user): AuthenticatedUser,
+    State(app_services): State<AppServicesState>,
     State(stripe_billing): State<StripeBillingState>,
     Path(session_id): Path<String>,
 ) -> Response {
@@ -638,7 +654,28 @@ pub async fn get_checkout_session_details(
         .get_checkout_session_details(&session_id)
         .await
     {
-        Ok(details) => (StatusCode::OK, Json(details)).into_response(),
+        Ok(details) => {
+            let owns_session = match details.customer_id.as_deref() {
+                Some(customer_id) => {
+                    match app_services.metadata_db.get_user_by_id(&user.user_id).await {
+                        Ok(Some(current_user)) => {
+                            current_user.stripe_customer_id.as_deref() == Some(customer_id)
+                        }
+                        _ => false,
+                    }
+                }
+                None => false,
+            };
+            if owns_session {
+                (StatusCode::OK, Json(details)).into_response()
+            } else {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse::new("Session not found")),
+                )
+                    .into_response()
+            }
+        }
         Err(e) => (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new(format!("Session not found: {}", e))),

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -526,6 +526,48 @@ pub async fn handle_stripe_webhook(
                             actual_user_id,
                             update.subscription_status
                         );
+
+                        match app_services
+                            .metadata_db
+                            .get_user_by_id(&actual_user_id)
+                            .await
+                        {
+                            Ok(Some(user_record)) => {
+                                if let Err(e) = app_services
+                                    .apply_subscription_limits(
+                                        &actual_user_id,
+                                        user_record.subscription_tier.as_str(),
+                                        &update.subscription_status,
+                                        user_record.is_admin,
+                                        user_record.trial_ends_at.clone(),
+                                        user_record.subscription_ends_at.clone(),
+                                    )
+                                    .await
+                                {
+                                    tracing::error!(
+                                        "Failed to apply subscription limits for user {}: {}",
+                                        actual_user_id,
+                                        e
+                                    );
+                                    persistence_failed = true;
+                                }
+                            }
+                            Ok(None) => {
+                                tracing::error!(
+                                    "User {} not found when applying limits",
+                                    actual_user_id
+                                );
+                                persistence_failed = true;
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to fetch user {} when applying limits: {}",
+                                    actual_user_id,
+                                    e
+                                );
+                                persistence_failed = true;
+                            }
+                        }
                     }
                 } else {
                     // Regular subscription update (tier + status) - no mutex blocking!

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -485,6 +485,7 @@ pub async fn handle_stripe_webhook(
                                     customer_id,
                                     e
                                 );
+                                persistence_failed = true;
                                 continue; // Skip this update
                             }
                         }
@@ -495,16 +496,24 @@ pub async fn handle_stripe_webhook(
 
                 // Handle special "keep_current" tier for cancellations
                 if update.subscription_tier == "keep_current" {
-                    // For cancellations, just update the status, not the tier - no mutex blocking!
-                    if let Err(e) = app_services
-                        .metadata_db
-                        .update_user_subscription_status(
-                            &actual_user_id,
-                            &update.subscription_status,
-                            update.stripe_subscription_id.as_deref(),
-                        )
-                        .await
+                    let update_result = if update.subscription_status == "expired"
+                        && update.stripe_subscription_id.is_none()
                     {
+                        app_services
+                            .metadata_db
+                            .expire_user_subscription(&actual_user_id)
+                            .await
+                    } else {
+                        app_services
+                            .metadata_db
+                            .update_user_subscription_status(
+                                &actual_user_id,
+                                &update.subscription_status,
+                                update.stripe_subscription_id.as_deref(),
+                            )
+                            .await
+                    };
+                    if let Err(e) = update_result {
                         tracing::error!(
                             "Failed to update user {} subscription status: {}",
                             actual_user_id,
@@ -590,6 +599,7 @@ pub async fn handle_stripe_webhook(
                                     "User {} not found when applying limits",
                                     actual_user_id
                                 );
+                                persistence_failed = true;
                             }
                             Err(e) => {
                                 tracing::error!(

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -431,6 +431,15 @@ pub async fn handle_stripe_webhook(
                                         tracing::info!("🚮 Ignoring deletion of old subscription {} for user {} (current: {})", deleted_subscription_id, user.id, current_subscription_id);
                                         continue; // Skip this update - it's an old subscription
                                     }
+                                } else if user.subscription_status == "expired" {
+                                    // Retry an earlier deletion webhook whose database expiry succeeded
+                                    // but applying wallet/contact limits failed.
+                                    tracing::info!(
+                                        "🔄 Retrying expiry limits for subscription {} and user {}",
+                                        deleted_subscription_id,
+                                        user.id
+                                    );
+                                    user.id
                                 } else {
                                     tracing::info!("🚮 Ignoring deletion of subscription {} for user {} (no current subscription)", deleted_subscription_id, user.id);
                                     continue; // Skip this update - user has no current subscription

--- a/backend/src/handlers/contact_verification.rs
+++ b/backend/src/handlers/contact_verification.rs
@@ -3,7 +3,7 @@
 use crate::api::AppServicesState;
 use crate::auth::{load_twilio_config_from_env, AuthService};
 use crate::config::AppConfig;
-use crate::extractors::AuthenticatedUser;
+use crate::extractors::{require_non_demo, AuthenticatedUser};
 use crate::handlers::helpers::{verify_wallet_access, DatabaseErrorMessage};
 use crate::metadata::Language;
 use crate::models::{
@@ -27,6 +27,10 @@ pub async fn send_contact_verification(
     Json(request): Json<SendContactVerificationRequest>,
 ) -> Response {
     let start_time = std::time::Instant::now();
+
+    if let Err(response) = require_non_demo(&user) {
+        return response;
+    }
 
     // Get user's preferred language for verification emails
     let user_language = app_services
@@ -531,6 +535,10 @@ pub async fn verify_contact(
     Json(request): Json<VerifyContactRequest>,
 ) -> Response {
     let start_time = std::time::Instant::now();
+
+    if let Err(response) = require_non_demo(&user) {
+        return response;
+    }
 
     // Check if wallet exists and user has access - no mutex blocking!
     if let Err(response) = verify_wallet_access(

--- a/backend/src/handlers/user_preferences.rs
+++ b/backend/src/handlers/user_preferences.rs
@@ -261,6 +261,16 @@ pub async fn update_user_preferences(
         let url_to_store = if ntfy_url.is_empty() {
             None
         } else {
+            if config.is_cloud_mode() {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse::coded(
+                        "custom_ntfy_server_unsupported",
+                        "Custom ntfy servers are only available in self-hosted mode",
+                    )),
+                )
+                    .into_response();
+            }
             // Basic URL validation
             if !ntfy_url.starts_with("http://") && !ntfy_url.starts_with("https://") {
                 return (

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -949,9 +949,15 @@ async fn main() -> anyhow::Result<()> {
                             // For ntfy, use user's preferred server URL and auth if set
                             let results = if provider_name == "ntfy" {
                                 // Determine the ntfy server URL: user preference > detected local > env var > default
-                                let ntfy_server = user_ntfy_server_url
-                                    .clone()
-                                    .unwrap_or_else(|| notification_config.ntfy_server_url());
+                                let ntfy_server = if notification_config.is_cloud_mode() {
+                                    // Cloud users cannot configure outbound ntfy hosts. This also
+                                    // prevents legacy stored preferences from becoming SSRF targets.
+                                    notification_config.ntfy_server_url()
+                                } else {
+                                    user_ntfy_server_url
+                                        .clone()
+                                        .unwrap_or_else(|| notification_config.ntfy_server_url())
+                                };
                                 let should_use_ntfy_auth = notification_config
                                     .should_use_ntfy_auth_for_url(
                                         &ntfy_server,

--- a/backend/src/metadata/pool.rs
+++ b/backend/src/metadata/pool.rs
@@ -74,7 +74,10 @@ impl MetadataDb {
                     &path,
                     std::os::unix::fs::PermissionsExt::from_mode(0o600),
                 ) {
-                    warn!("Failed to restrict SQLite file permissions for {}: {}", path, e);
+                    warn!(
+                        "Failed to restrict SQLite file permissions for {}: {}",
+                        path, e
+                    );
                 }
             }
         }

--- a/backend/src/metadata/pool.rs
+++ b/backend/src/metadata/pool.rs
@@ -64,10 +64,19 @@ impl MetadataDb {
         drop(conn);
 
         #[cfg(unix)]
-        if let Err(e) =
-            std::fs::set_permissions(db_path, std::os::unix::fs::PermissionsExt::from_mode(0o600))
-        {
-            warn!("Failed to restrict database file permissions: {}", e);
+        for path in [
+            db_path.to_string(),
+            format!("{db_path}-wal"),
+            format!("{db_path}-shm"),
+        ] {
+            if std::path::Path::new(&path).exists() {
+                if let Err(e) = std::fs::set_permissions(
+                    &path,
+                    std::os::unix::fs::PermissionsExt::from_mode(0o600),
+                ) {
+                    warn!("Failed to restrict SQLite file permissions for {}: {}", path, e);
+                }
+            }
         }
 
         // Create connection pool with foreign key enforcement

--- a/backend/src/metadata/pool.rs
+++ b/backend/src/metadata/pool.rs
@@ -34,6 +34,13 @@ impl MetadataDb {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 warn!("Failed to create database directory: {}", e);
             }
+            #[cfg(unix)]
+            if let Err(e) = std::fs::set_permissions(
+                parent,
+                std::os::unix::fs::PermissionsExt::from_mode(0o700),
+            ) {
+                warn!("Failed to restrict database directory permissions: {}", e);
+            }
         }
 
         // Run migrations first
@@ -62,6 +69,13 @@ impl MetadataDb {
         conn.execute_batch("PRAGMA journal_mode = WAL;")
             .context("Failed to initialize SQLite journal mode")?;
         drop(conn);
+
+        #[cfg(unix)]
+        if let Err(e) =
+            std::fs::set_permissions(db_path, std::os::unix::fs::PermissionsExt::from_mode(0o600))
+        {
+            warn!("Failed to restrict database file permissions: {}", e);
+        }
 
         // Create connection pool with foreign key enforcement
         let manager = SqliteConnectionManager::file(db_path);

--- a/backend/src/metadata/pool.rs
+++ b/backend/src/metadata/pool.rs
@@ -34,13 +34,6 @@ impl MetadataDb {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 warn!("Failed to create database directory: {}", e);
             }
-            #[cfg(unix)]
-            if let Err(e) = std::fs::set_permissions(
-                parent,
-                std::os::unix::fs::PermissionsExt::from_mode(0o700),
-            ) {
-                warn!("Failed to restrict database directory permissions: {}", e);
-            }
         }
 
         // Run migrations first

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -190,7 +190,7 @@ impl MetadataDb {
         let preferred_currency = preferred_currency.map(|c| c.to_string());
         let preferred_language = preferred_language.map(|l| l.to_string());
 
-        let result = spawn_blocking(move || -> Result<(String, bool)> {
+        let result = spawn_blocking(move || -> Result<String> {
             let mut conn = pool.get()?;
             let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
@@ -205,41 +205,22 @@ impl MetadataDb {
                 return Err(anyhow::anyhow!("User with this email already exists"));
             }
 
-            // Determine if this user should be admin (first user becomes admin)
-            let admin_count: i64 = tx.query_row(
-                "SELECT COUNT(*) FROM users WHERE is_admin = 1",
-                [],
-                |row| row.get(0)
-            )?;
-
-            let final_is_admin = admin_count == 0;
-
-            if final_is_admin {
-                println!("Creating first admin user: {}", email);
-            } else {
-                println!("Creating regular user: {} (existing admins: {})", email, admin_count);
-            }
-
             let user_name = name;
 
             // Generate UUID for new user
             let user_id = Uuid::new_v4().to_string();
 
-            println!("DEBUG: Creating user {} with name {:?}, is_admin={}", email, user_name, final_is_admin);
-
             // Create new user
             tx.execute(
                 "INSERT INTO users (id, email, password_hash, name, is_admin, is_demo, email_verified, subscription_tier, subscription_status, preferred_fiat_currency, preferred_language) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-                params![&user_id, &email, &password_hash, user_name, final_is_admin, false, email_verified, "team", "pending", preferred_currency.as_deref().unwrap_or("USD"), preferred_language.as_deref().unwrap_or("en-US")],
+                params![&user_id, &email, &password_hash, user_name, false, false, email_verified, "team", "pending", preferred_currency.as_deref().unwrap_or("USD"), preferred_language.as_deref().unwrap_or("en-US")],
             )?;
 
             tx.commit()?;
-            Ok((user_id, final_is_admin))
+            Ok(user_id)
         }).await??; // First ? for JoinError, second ? for inner Result
 
-        let (user_id, _was_admin) = result;
-
-        Ok(user_id)
+        Ok(result)
     }
 
     pub async fn get_user_by_email(&self, email: &str) -> Result<Option<UserRecord>> {

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -478,6 +478,21 @@ impl MetadataDb {
         .await?
     }
 
+    pub async fn expire_user_subscription(&self, user_id: &str) -> Result<()> {
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+
+        spawn_blocking(move || -> Result<()> {
+            let conn = pool.get()?;
+            conn.execute(
+                "UPDATE users SET subscription_status = 'expired', stripe_subscription_id = NULL WHERE id = ?1",
+                params![user_id],
+            )?;
+            Ok(())
+        })
+        .await?
+    }
+
     pub async fn update_user_subscription(
         &self,
         user_id: &str,

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -56,6 +56,7 @@ impl NtfyProvider {
             .get_or_init(|| {
                 reqwest::Client::builder()
                     .timeout(NTFY_REQUEST_TIMEOUT)
+                    .redirect(reqwest::redirect::Policy::none())
                     .build()
                     .expect("failed to build ntfy HTTP client")
             })

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -753,15 +753,13 @@ impl StripeBilling {
                                     (customer_id, new_subscription_id)
                                 {
                                     // Handle duplicate subscription cleanup
-                                    if let Ok(cleanup_update) = self
+                                    let cleanup_update = self
                                         .handle_checkout_completion(
                                             customer_id,
                                             new_subscription_id,
                                         )
-                                        .await
-                                    {
-                                        updates.push(cleanup_update);
-                                    }
+                                        .await?;
+                                    updates.push(cleanup_update);
                                 }
                             }
                         }

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -1039,7 +1039,7 @@ impl StripeBilling {
                                             "stripe_customer:{}:{}",
                                             customer_id, deleted_subscription_id
                                         ),
-                                        subscription_tier: "team".to_string(), // Keep current tier
+                                        subscription_tier: "keep_current".to_string(),
                                         subscription_status: "expired".to_string(),
                                         stripe_subscription_id: None, // Clear subscription ID
                                         subscription_started_at: None,
@@ -1242,24 +1242,23 @@ impl StripeBilling {
                         }
                     }
                 } else {
-                    // Cancel other trial subscriptions
-                    if let Some(status) = &subscription.status {
-                        if status == "trialing" {
-                            tracing::info!("🗑️ Cancelling trial subscription: {}", sub_id);
-                            match self.client.cancel_subscription(sub_id).await {
-                                Ok(_) => {
-                                    tracing::info!(
-                                        "✅ Successfully cancelled trial subscription: {}",
-                                        sub_id
-                                    );
-                                }
-                                Err(e) => {
-                                    tracing::error!(
-                                        "❌ Failed to cancel trial subscription {}: {}",
-                                        sub_id,
-                                        e
-                                    );
-                                }
+                    // A replacement checkout must retire any billable prior subscription.
+                    if matches!(subscription.status.as_deref(), Some("trialing" | "active")) {
+                        tracing::info!("🗑️ Cancelling prior subscription: {}", sub_id);
+                        match self.client.cancel_subscription(sub_id).await {
+                            Ok(_) => {
+                                tracing::info!(
+                                    "✅ Successfully cancelled prior subscription: {}",
+                                    sub_id
+                                );
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "❌ Failed to cancel prior subscription {}: {}",
+                                    sub_id,
+                                    e
+                                );
+                                return Err(e);
                             }
                         }
                     }

--- a/backend/src/stripe_client_service.rs
+++ b/backend/src/stripe_client_service.rs
@@ -342,7 +342,7 @@ impl StripeClientService {
 
         // Create expected signature
         let signed_payload = format!("{}.{}", timestamp, payload);
-        let expected_sig = {
+        let signature_valid = {
             use hmac::{Hmac, Mac};
             use sha2::Sha256;
             type HmacSha256 = Hmac<Sha256>;
@@ -350,15 +350,12 @@ impl StripeClientService {
             let mut mac = HmacSha256::new_from_slice(webhook_secret.as_bytes())
                 .map_err(|e| anyhow::anyhow!("Invalid webhook secret: {}", e))?;
             mac.update(signed_payload.as_bytes());
-            hex::encode(mac.finalize().into_bytes())
+            signatures.iter().any(|signature| {
+                hex::decode(signature)
+                    .ok()
+                    .is_some_and(|signature| mac.clone().verify_slice(&signature).is_ok())
+            })
         };
-
-        // Verify signature
-        let signature_valid = signatures.iter().any(|sig| {
-            // Constant-time comparison
-            sig.len() == expected_sig.len()
-                && sig.chars().zip(expected_sig.chars()).all(|(a, b)| a == b)
-        });
 
         if !signature_valid {
             return Err(anyhow::anyhow!("Invalid webhook signature"));

--- a/backend/src/tests/auth.rs
+++ b/backend/src/tests/auth.rs
@@ -237,3 +237,23 @@ async fn authenticate_user_rejects_token_with_expired_session() {
         "unexpected error: {err}"
     );
 }
+
+#[tokio::test]
+async fn cloud_registration_never_grants_admin_by_order() {
+    let (db, _temp_dir) = create_cloud_test_db().await;
+
+    let first_user_id = db
+        .create_user(
+            "first@example.com",
+            "hashedpassword",
+            Some("First User"),
+            true,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let user = db.get_user_by_id(&first_user_id).await.unwrap().unwrap();
+    assert!(!user.is_admin);
+}

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -1,7 +1,7 @@
 use crate::config::{AppConfig, NetworkConfig, OperatingMode};
 use crate::metadata::{
     BalanceAlertType, ContactNotificationSettings, CreateBalanceAlertInput, EventType, Language,
-    MetadataDb, ProviderType, TransactionInsert,
+    MetadataDb, ProviderType, SubscriptionUpdateParams, TransactionInsert,
 };
 use tempfile::tempdir;
 
@@ -2212,4 +2212,41 @@ async fn test_auth_rate_limit_resets_after_window_expires() {
         .check_auth_rate_limit("register", "person@example.com", 3, 60)
         .await
         .unwrap());
+}
+
+#[tokio::test]
+async fn expiring_subscription_clears_stripe_id_without_changing_tier() {
+    let (db, _temp_dir) = create_test_db().await;
+    let user_id = db
+        .create_user(
+            "subscriber@example.com",
+            "hashedpassword",
+            Some("Subscriber"),
+            true,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    db.update_user_subscription(
+        &user_id,
+        &SubscriptionUpdateParams {
+            subscription_tier: "personal",
+            subscription_status: "active",
+            stripe_subscription_id: Some("sub_current"),
+            subscription_started_at: None,
+            subscription_ends_at: None,
+            trial_ends_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    db.expire_user_subscription(&user_id).await.unwrap();
+
+    let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
+    assert_eq!(user.subscription_tier.as_str(), "personal");
+    assert_eq!(user.subscription_status, "expired");
+    assert_eq!(user.stripe_subscription_id, None);
 }

--- a/backend/src/utils/descriptor.rs
+++ b/backend/src/utils/descriptor.rs
@@ -3,7 +3,6 @@
 use miniscript::{descriptor::Wildcard, Descriptor, DescriptorPublicKey, ForEachKey}; // ForEachKey enables .for_any_key().
 use regex::Regex;
 use std::{error::Error, fmt, sync::LazyLock};
-use tracing::debug;
 
 static KEY_ORIGIN_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[([0-9a-fA-F]{8})(/\d+[h'H]?)*\]").unwrap());
@@ -66,7 +65,6 @@ pub fn strip_key_origin(descriptor_str: &str) -> Result<String, DescriptorError>
     // Strip key origin if present
     let stripped_without_checksum = if KEY_ORIGIN_PATTERN.is_match(without_checksum) {
         let result = KEY_ORIGIN_PATTERN.replace_all(without_checksum, "");
-        debug!("Stripped key origin: {} -> {}", without_checksum, result);
         result.to_string()
     } else {
         // No key origin found, return without checksum
@@ -82,8 +80,6 @@ pub fn strip_key_origin(descriptor_str: &str) -> Result<String, DescriptorError>
 
     // Convert back to string with new checksum
     let final_descriptor = descriptor.to_string();
-    debug!("Final normalized descriptor: {}", final_descriptor);
-
     Ok(final_descriptor)
 }
 
@@ -124,9 +120,6 @@ pub fn parse_multipath_descriptor(
 
     let receive_descriptor = descriptors[0].to_string();
     let change_descriptor = descriptors[1].to_string();
-
-    debug!("Receive descriptor: {}", receive_descriptor);
-    debug!("Change descriptor: {}", change_descriptor);
 
     Ok((receive_descriptor, change_descriptor))
 }

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -423,9 +423,7 @@ impl WalletCreationService {
     ) -> Result<WalletMetadata> {
         use crate::xpub_converter::XpubConverter;
 
-        debug!("Creating wallet from multipath descriptor:");
-        debug!(" Name: {}", name);
-        debug!(" Input descriptor: {}", descriptor_str);
+        debug!("Creating wallet from multipath descriptor");
 
         // Validate network compatibility (defense-in-depth)
         XpubConverter::validate_descriptor_network(descriptor_str, self.network)?;
@@ -572,8 +570,6 @@ impl WalletCreationService {
         // Create converter and generate descriptor
         let converter = XpubConverter::new(self.network, self.electrum_client.as_ref());
         let descriptor = converter.generate_descriptor_for_type(xpub, &script_type)?;
-
-        debug!("Generated descriptor: {}", descriptor);
 
         // Strip key origin for consistency
         let normalized_descriptor = strip_key_origin(&descriptor)?;

--- a/backend/src/xpub_converter.rs
+++ b/backend/src/xpub_converter.rs
@@ -54,11 +54,6 @@ impl XpubConverter {
 
         let descriptor_with_checksum = format!("{}#{}", descriptor_without_checksum, checksum);
 
-        println!(
-            "Generated descriptor (no key origin): {}",
-            descriptor_with_checksum
-        );
-
         Ok(descriptor_with_checksum)
     }
 

--- a/backend/tests/auth_flow_tests.rs
+++ b/backend/tests/auth_flow_tests.rs
@@ -124,8 +124,62 @@ async fn create_user(
         .unwrap()
 }
 
+async fn demo_token(app: &axum::Router) -> String {
+    let request = Request::builder()
+        .uri("/api/auth/demo-login")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(json!({}).to_string()))
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    body_to_json(response.into_body()).await["token"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
 fn extract_auth_cookie(set_cookie: &str) -> &str {
     set_cookie.split(';').next().unwrap()
+}
+
+#[tokio::test]
+async fn demo_session_cannot_send_or_verify_contact_otp() {
+    let test_app = create_test_app(OperatingMode::Cloud).await;
+    let token = demo_token(&test_app.router).await;
+
+    for (path, payload) in [
+        (
+            "/api/wallets/any-wallet/contacts/send-verification",
+            json!({
+                "name": "Demo Contact",
+                "email_address": "contact@example.com"
+            }),
+        ),
+        (
+            "/api/wallets/any-wallet/contacts/verify",
+            json!({
+                "email_address": "contact@example.com",
+                "code": "123456"
+            }),
+        ),
+    ] {
+        let request = Request::builder()
+            .uri(path)
+            .method("POST")
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", "application/json")
+            .body(Body::from(payload.to_string()))
+            .unwrap();
+
+        let response = test_app.router.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{path}");
+
+        let response_body = body_to_json(response.into_body()).await;
+        assert_eq!(response_body["error_code"], "demo_read_only");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- restrict custom ntfy server URLs to self-hosted mode and ignore legacy cloud overrides
- prevent first cloud registrants from becoming administrators and block demo contact verification
- preserve Stripe tiers on deletion, retire prior active subscriptions, return retryable webhook write failures, and scope checkout sessions to their owner
- use constant-time Stripe signature verification and stop logging signature headers
- remove descriptor/xpub logs; harden metadata permissions and backend container runtime user

Closes #451
Closes #452
Addresses #453, #455, and #458.

## Validation

- `./.agent-loop/checks.sh quick`
- Docker image build could not be run locally because the Docker daemon was unresponsive.