### PR TITLE
ci: harden AI review workflows

### DIFF
--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -10,31 +10,37 @@ concurrency:
 
 jobs:
   claude-review:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Pre-fetch base and head refs
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git fetch --no-tags origin \
-            +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} \
-            +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head
+            "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head:refs/remotes/origin/pr-head"
 
       - name: Get changed files
         id: changed_files
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          BASE_SHA=$(git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD)
+          BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
           FILES_FILE="$RUNNER_TEMP/claude-changed-files.txt"
           PATCH_FILE="$RUNNER_TEMP/claude-pr.patch"
 
@@ -102,7 +108,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@9c41ed18ca8b2b2a17eaef4723d5092ccdebc814
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -155,7 +161,7 @@ jobs:
 
       - name: Extract and post review
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           github-token: ${{ github.token }}
           script: |
@@ -280,7 +286,7 @@ jobs:
 
       - name: Notify on failure
         if: failure() || (always() && steps.claude-review.outcome == 'failure')
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/codex-pull-request-code-review.yml
+++ b/.github/workflows/codex-pull-request-code-review.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   codex:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,29 +19,36 @@ jobs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Pre-fetch base and head refs
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git fetch --no-tags origin \
-            +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} \
-            +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head
+            "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head:refs/remotes/origin/pr-head"
 
       - name: Get changed files
         id: changed_files
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          BASE_SHA=$(git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD)
-          echo "files<<EOF" >> $GITHUB_OUTPUT
+          BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
+          DELIMITER="CODEX_FILES_$(openssl rand -hex 16)"
+          echo "files<<$DELIMITER" >> "$GITHUB_OUTPUT"
           git diff --name-only $BASE_SHA HEAD
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$DELIMITER" >> "$GITHUB_OUTPUT"
           echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
 
       - name: Run Codex
         id: run_codex
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@b11346a6fa031e2e164ab4b7c7ea201afffd7d59
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt: |
@@ -64,7 +72,7 @@ jobs:
 
             Be constructive and helpful. Only report findings relevant to this PR's changes.
           safety-strategy: drop-sudo
-          sandbox: workspace-write
+          sandbox: read-only
 
   post_feedback:
     runs-on: ubuntu-latest
@@ -75,7 +83,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Post Codex feedback
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/codex-pull-request-code-review.yml
+++ b/.github/workflows/codex-pull-request-code-review.yml
@@ -42,7 +42,7 @@ jobs:
           BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
           DELIMITER="CODEX_FILES_$(openssl rand -hex 16)"
           echo "files<<$DELIMITER" >> "$GITHUB_OUTPUT"
-          git diff --name-only $BASE_SHA HEAD
+          git diff --name-only "$BASE_SHA" HEAD >> "$GITHUB_OUTPUT"
           echo "$DELIMITER" >> "$GITHUB_OUTPUT"
           echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   gemini-review:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -19,14 +20,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get PR info
         id: pr_info
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          BASE_SHA=$(git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD)
+          BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
           echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
 
           # Get changed files
@@ -41,25 +45,27 @@ jobs:
           if [ $DIFF_SIZE -gt $MAX_SIZE ]; then
             echo "truncated=true" >> $GITHUB_OUTPUT
             {
-              echo "diff<<DIFF_EOF"
+              DELIMITER="GEMINI_DIFF_$(openssl rand -hex 16)"
+              echo "diff<<$DELIMITER"
               echo "$FULL_DIFF" | head -c $MAX_SIZE
               echo ""
-              echo "DIFF_EOF"
+              echo "$DELIMITER"
             } >> $GITHUB_OUTPUT
           else
             echo "truncated=false" >> $GITHUB_OUTPUT
             {
-              echo "diff<<DIFF_EOF"
+              DELIMITER="GEMINI_DIFF_$(openssl rand -hex 16)"
+              echo "diff<<$DELIMITER"
               echo "$FULL_DIFF"
-              echo "DIFF_EOF"
+              echo "$DELIMITER"
             } >> $GITHUB_OUTPUT
           fi
 
       - name: Run Gemini PR Review
         id: gemini
-        uses: google-github-actions/run-gemini-cli@v0
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489
         env:
-          GEMINI_CLI_TRUST_WORKSPACE: "true"
+          GEMINI_CLI_TRUST_WORKSPACE: "false"
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           prompt: |
@@ -83,7 +89,7 @@ jobs:
 
       - name: Post Gemini feedback
         if: always() && steps.gemini.outputs.summary != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           github-token: ${{ github.token }}
           script: |
@@ -129,7 +135,7 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           settings: >-
-            {"security":{"disableYoloMode":true,"toolSandboxing":true,"environmentVariableRedaction":{"enabled":true}},"tools":{"sandboxNetworkAccess":false}}
+            {"security":{"toolSandboxing":true,"environmentVariableRedaction":{"enabled":true}},"tools":{"sandboxNetworkAccess":false}}
           prompt: |
             Review the changes in this pull request.
 

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -65,9 +65,11 @@ jobs:
         id: gemini
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489
         env:
-          GEMINI_CLI_TRUST_WORKSPACE: "false"
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          settings: >-
+            {"security":{"disableYoloMode":true,"toolSandboxing":true,"environmentVariableRedaction":{"enabled":true}},"tools":{"sandboxNetworkAccess":false}}
           prompt: |
             Review the changes in this pull request.
 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -10,21 +10,13 @@ permissions:
 
 jobs:
   dependency-scan:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
-        with:
-          persist-credentials: false
-      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
-        with:
-          scan-type: fs
-          scan-ref: .
-          scanners: vuln
-          format: table
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: CRITICAL,HIGH
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@8deb546fdb875b9996d27d4950be7312dac076a1
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      fail-on-vuln: true
 
   secret-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@8deb546fdb875b9996d27d4950be7312dac076a1
     permissions:
+      actions: read
       contents: read
       security-events: write
     with:

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -14,9 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
-      - uses: actions/dependency-review-action@dcedce43c6f43de0b836d1fe38946645c9c638dc
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
 
   secret-scan:
     runs-on: ubuntu-latest
@@ -26,6 +25,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   container-scan:
     runs-on: ubuntu-latest
@@ -34,7 +35,7 @@ jobs:
         with:
           persist-credentials: false
       - run: docker build --tag canary-backend:scan backend
-      - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: canary-backend:scan
           format: table

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -1,0 +1,43 @@
+name: Security Scans
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/dependency-review-action@dcedce43c6f43de0b836d1fe38946645c9c638dc
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+
+  container-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          persist-credentials: false
+      - run: docker build --tag canary-backend:scan backend
+      - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          image-ref: canary-backend:scan
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -9,16 +9,26 @@ permissions:
   contents: read
 
 jobs:
-  dependency-review:
-    if: github.event_name == 'pull_request'
+  dependency-scan:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    timeout-minutes: 10
     steps:
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          persist-credentials: false
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
 
   secret-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
@@ -30,6 +40,7 @@ jobs:
 
   container-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:


### PR DESCRIPTION
## Summary

- prevent AI review jobs that consume provider secrets from running on fork PRs; remove credential persistence and unnecessary OIDC access
- restrict Codex to a read-only sandbox, disable Gemini workspace trust, randomize output delimiters, and pass refs through environment variables
- pin actions in all affected workflows by immutable commit SHA
- add least-privileged dependency, secret, and container vulnerability scanning gates

PR #459 independently implements the dedicated non-root backend container user required by #457.

Addresses #457

## Validation

- YAML syntax validation for all workflows
- `git diff --check`
- `./.agent-loop/checks.sh quick` started but exceeded the local two-minute tool limit during initial Rust dependency compilation