### PR TITLE
fix: protect admin notification privacy

### DIFF
--- a/backend/src/admin_notifications.rs
+++ b/backend/src/admin_notifications.rs
@@ -67,13 +67,9 @@ impl AdminNotifications {
         true
     }
 
-    pub async fn notify_user_signup(&self, email: &str, name: Option<&str>) {
+    pub async fn notify_user_signup(&self) {
         if let Some(topic) = &self.topic {
-            let display_name = name.unwrap_or("Unknown");
-            let message = format!(
-                "🆕 New user registered\n📧 Email: {}\n👤 Name: {}",
-                email, display_name
-            );
+            let message = "🆕 New user registered";
 
             self.send_notification(
                 topic,
@@ -85,17 +81,9 @@ impl AdminNotifications {
         }
     }
 
-    pub async fn notify_wallet_creation(
-        &self,
-        wallet_name: &str,
-        user_email: &str,
-        checksum: &str,
-    ) {
+    pub async fn notify_wallet_creation(&self, checksum: &str) {
         if let Some(topic) = &self.topic {
-            let message = format!(
-                "💼 New wallet created\n📝 Name: {}\n👤 User: {}\n🔑 ID: {}",
-                wallet_name, user_email, checksum
-            );
+            let message = format!("💼 New wallet created\n🔑 ID: {}", checksum);
 
             self.send_notification(topic, "New Wallet Created", &message, "wallet")
                 .await;

--- a/backend/src/admin_notifications.rs
+++ b/backend/src/admin_notifications.rs
@@ -7,6 +7,14 @@ use reqwest::Client;
 const ADMIN_NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(10);
 static ADMIN_NOTIFICATION_CLIENT: OnceLock<Client> = OnceLock::new();
 
+fn user_signup_message() -> &'static str {
+    "🆕 New user registered"
+}
+
+fn wallet_creation_message(checksum: &str) -> String {
+    format!("💼 New wallet created\n🔑 ID: {checksum}")
+}
+
 pub struct AdminNotifications {
     client: Client,
     topic: Option<String>,
@@ -69,12 +77,12 @@ impl AdminNotifications {
 
     pub async fn notify_user_signup(&self) {
         if let Some(topic) = &self.topic {
-            let message = "🆕 New user registered";
+            let message = user_signup_message();
 
             self.send_notification(
                 topic,
                 "New User Registration",
-                &message,
+                message,
                 "bust_in_silhouette",
             )
             .await;
@@ -83,7 +91,7 @@ impl AdminNotifications {
 
     pub async fn notify_wallet_creation(&self, checksum: &str) {
         if let Some(topic) = &self.topic {
-            let message = format!("💼 New wallet created\n🔑 ID: {}", checksum);
+            let message = wallet_creation_message(checksum);
 
             self.send_notification(topic, "New Wallet Created", &message, "wallet")
                 .await;
@@ -199,7 +207,7 @@ impl AdminNotifications {
 
 #[cfg(test)]
 mod tests {
-    use super::AdminNotifications;
+    use super::{user_signup_message, wallet_creation_message, AdminNotifications};
     use std::time::Duration;
     use tokio::sync::Mutex;
 
@@ -239,6 +247,15 @@ mod tests {
         } else {
             std::env::remove_var(key);
         }
+    }
+
+    #[test]
+    fn admin_notification_messages_exclude_user_pii() {
+        assert_eq!(user_signup_message(), "🆕 New user registered");
+        assert_eq!(
+            wallet_creation_message("wallet-id"),
+            "💼 New wallet created\n🔑 ID: wallet-id"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -318,14 +318,10 @@ pub async fn register(
 
     // Send admin notification for new user signup (fire-and-forget)
     {
-        let email = request.email.clone();
-        let name = request.name.clone();
         AdminNotifications::spawn_if_enabled(
             config.ntfy_server_url(),
             move |admin_notifications| async move {
-                admin_notifications
-                    .notify_user_signup(&email, Some(&name))
-                    .await;
+                admin_notifications.notify_user_signup().await;
             },
         );
     }

--- a/backend/src/handlers/wallet.rs
+++ b/backend/src/handlers/wallet.rs
@@ -381,26 +381,15 @@ pub async fn create_wallet_non_blocking(
             // Send admin notification for new wallet creation (fire-and-forget)
             {
                 if AdminNotifications::is_enabled_for_env() {
-                    let wallet_name = wallet_metadata.name.clone();
                     let wallet_checksum = wallet_metadata.checksum.clone();
-                    // Get user email for notification
-                    if let Ok(Some(user_record)) =
-                        app_services.metadata_db.get_user_by_id(&user.user_id).await
-                    {
-                        let user_email = user_record.email;
-                        AdminNotifications::spawn_if_enabled(
-                            config.ntfy_server_url(),
-                            move |admin_notifications| async move {
-                                admin_notifications
-                                    .notify_wallet_creation(
-                                        &wallet_name,
-                                        &user_email,
-                                        &wallet_checksum,
-                                    )
-                                    .await;
-                            },
-                        );
-                    }
+                    AdminNotifications::spawn_if_enabled(
+                        config.ntfy_server_url(),
+                        move |admin_notifications| async move {
+                            admin_notifications
+                                .notify_wallet_creation(&wallet_checksum)
+                                .await;
+                        },
+                    );
                 }
             }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -72,6 +72,14 @@ async fn main() -> anyhow::Result<()> {
         // Set up file appender - writes to logs/backend.log with daily rotation
         use tracing_appender::rolling::{RollingFileAppender, Rotation};
         let log_dir = std::env::current_dir()?.join("logs");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+
+            let mut builder = std::fs::DirBuilder::new();
+            builder.recursive(true).mode(0o700).create(&log_dir)?;
+        }
+        #[cfg(not(unix))]
         std::fs::create_dir_all(&log_dir)?;
         #[cfg(unix)]
         std::fs::set_permissions(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -73,6 +73,11 @@ async fn main() -> anyhow::Result<()> {
         use tracing_appender::rolling::{RollingFileAppender, Rotation};
         let log_dir = std::env::current_dir()?.join("logs");
         std::fs::create_dir_all(&log_dir)?;
+        #[cfg(unix)]
+        std::fs::set_permissions(
+            &log_dir,
+            std::os::unix::fs::PermissionsExt::from_mode(0o700),
+        )?;
         let file_appender = RollingFileAppender::new(Rotation::DAILY, &log_dir, "backend.log");
 
         // Initialize tracing with both stdout and file output

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -213,6 +213,19 @@ fn generate_unique_wallet_id() -> String {
         .collect()
 }
 
+#[cfg(unix)]
+fn restrict_permissions(path: &std::path::Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+
+    if let Err(e) = std::fs::set_permissions(path, PermissionsExt::from_mode(mode)) {
+        warn!(
+            "Failed to restrict permissions for {}: {}",
+            path.display(),
+            e
+        );
+    }
+}
+
 /// Standalone wallet creation function that doesn't require WalletManager mutex
 /// This allows wallet creation to be non-blocking and concurrent
 pub struct WalletCreationService {
@@ -705,6 +718,8 @@ impl WalletManager {
         if let Err(e) = std::fs::create_dir_all(&wallet_dir) {
             warn!("Failed to create wallet directory: {}", e);
         }
+        #[cfg(unix)]
+        restrict_permissions(&wallet_dir, 0o700);
 
         // Initialize electrum client manager with automatic reconnection support
         let electrum_client_manager = match ElectrumClientManager::new_with_subscriptions(
@@ -846,6 +861,8 @@ impl WalletManager {
                 e
             )
         })?;
+        #[cfg(unix)]
+        restrict_permissions(&ctx.wallet_path, 0o600);
         // If a later creation step fails, keep the partial BDK SQLite file with the
         // failed wallet record so the normal delete cleanup path can remove both.
 
@@ -860,6 +877,16 @@ impl WalletManager {
         wallet
             .persist(&mut db)
             .map_err(|e| anyhow!("Failed to persist wallet: {}", e))?;
+        #[cfg(unix)]
+        for path in [
+            ctx.wallet_path.clone(),
+            ctx.wallet_path.with_extension("sqlite-wal"),
+            ctx.wallet_path.with_extension("sqlite-shm"),
+        ] {
+            if path.exists() {
+                restrict_permissions(&path, 0o600);
+            }
+        }
 
         // One BDK full scan owns discovery. Advanced selections are stop gaps (consecutive
         // unused scripts), existing-wallet automatic recovery uses gap 500, and fresh wallets

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -2057,6 +2057,32 @@ mod tests {
     const TWO_PATH_DESCRIPTOR: &str = "wpkh(tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1>/*)";
     const THREE_PATH_DESCRIPTOR: &str = "wpkh(tpubDDnGNapGEY6AZAdQbfRJgMg9fvz8pUBrLwvyvUqEgcUfgzM6zc2eVK4vY9x9L5FJWdX8WumXuLEDV5zDZnTfbn87vLe9XceCFwTu9so9Kks/<0;1;2>/*)";
 
+    #[cfg(unix)]
+    #[test]
+    fn restrict_permissions_sets_owner_only_modes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("wallet.sqlite");
+        std::fs::File::create(&file_path).unwrap();
+
+        restrict_permissions(temp_dir.path(), 0o700);
+        restrict_permissions(&file_path, 0o600);
+
+        assert_eq!(
+            std::fs::metadata(temp_dir.path())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(&file_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
     fn queue_wallet(checksum: &str, last_synced_at: Option<&str>) -> WalletMetadata {
         WalletMetadata {
             checksum: checksum.to_string(),

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -214,16 +214,17 @@ fn generate_unique_wallet_id() -> String {
 }
 
 #[cfg(unix)]
-fn restrict_permissions(path: &std::path::Path, mode: u32) {
+fn restrict_permissions(path: &std::path::Path, mode: u32) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    if let Err(e) = std::fs::set_permissions(path, PermissionsExt::from_mode(mode)) {
-        warn!(
-            "Failed to restrict permissions for {}: {}",
-            path.display(),
-            e
-        );
-    }
+    std::fs::set_permissions(path, PermissionsExt::from_mode(mode))
+}
+
+#[cfg(unix)]
+fn sqlite_sidecar_path(path: &std::path::Path, suffix: &str) -> PathBuf {
+    let mut sidecar = path.as_os_str().to_os_string();
+    sidecar.push(suffix);
+    PathBuf::from(sidecar)
 }
 
 /// Standalone wallet creation function that doesn't require WalletManager mutex
@@ -715,11 +716,11 @@ impl WalletManager {
         electrum_url: &str,
         config: &AppConfig,
     ) -> Self {
-        if let Err(e) = std::fs::create_dir_all(&wallet_dir) {
-            warn!("Failed to create wallet directory: {}", e);
-        }
+        std::fs::create_dir_all(&wallet_dir)
+            .unwrap_or_else(|e| panic!("Failed to create wallet directory: {e}"));
         #[cfg(unix)]
-        restrict_permissions(&wallet_dir, 0o700);
+        restrict_permissions(&wallet_dir, 0o700)
+            .unwrap_or_else(|e| panic!("Failed to restrict wallet directory permissions: {e}"));
 
         // Initialize electrum client manager with automatic reconnection support
         let electrum_client_manager = match ElectrumClientManager::new_with_subscriptions(
@@ -862,7 +863,7 @@ impl WalletManager {
             )
         })?;
         #[cfg(unix)]
-        restrict_permissions(&ctx.wallet_path, 0o600);
+        restrict_permissions(&ctx.wallet_path, 0o600)?;
         // If a later creation step fails, keep the partial BDK SQLite file with the
         // failed wallet record so the normal delete cleanup path can remove both.
 
@@ -880,11 +881,11 @@ impl WalletManager {
         #[cfg(unix)]
         for path in [
             ctx.wallet_path.clone(),
-            ctx.wallet_path.with_extension("sqlite-wal"),
-            ctx.wallet_path.with_extension("sqlite-shm"),
+            sqlite_sidecar_path(&ctx.wallet_path, "-wal"),
+            sqlite_sidecar_path(&ctx.wallet_path, "-shm"),
         ] {
             if path.exists() {
-                restrict_permissions(&path, 0o600);
+                restrict_permissions(&path, 0o600)?;
             }
         }
 
@@ -2066,8 +2067,8 @@ mod tests {
         let file_path = temp_dir.path().join("wallet.sqlite");
         std::fs::File::create(&file_path).unwrap();
 
-        restrict_permissions(temp_dir.path(), 0o700);
-        restrict_permissions(&file_path, 0o600);
+        restrict_permissions(temp_dir.path(), 0o700).unwrap();
+        restrict_permissions(&file_path, 0o600).unwrap();
 
         assert_eq!(
             std::fs::metadata(temp_dir.path())
@@ -2081,6 +2082,8 @@ mod tests {
             std::fs::metadata(&file_path).unwrap().permissions().mode() & 0o777,
             0o600
         );
+
+        assert!(restrict_permissions(&temp_dir.path().join("missing"), 0o600).is_err());
     }
 
     fn queue_wallet(checksum: &str, last_synced_at: Option<&str>) -> WalletMetadata {

--- a/backend/src/wallet.rs
+++ b/backend/src/wallet.rs
@@ -221,6 +221,27 @@ fn restrict_permissions(path: &std::path::Path, mode: u32) -> std::io::Result<()
 }
 
 #[cfg(unix)]
+fn create_private_dir(path: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700).create(path)?;
+    restrict_permissions(path, 0o700)
+}
+
+#[cfg(unix)]
+fn create_private_file(path: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
 fn sqlite_sidecar_path(path: &std::path::Path, suffix: &str) -> PathBuf {
     let mut sidecar = path.as_os_str().to_os_string();
     sidecar.push(suffix);
@@ -716,11 +737,12 @@ impl WalletManager {
         electrum_url: &str,
         config: &AppConfig,
     ) -> Self {
+        #[cfg(unix)]
+        create_private_dir(&wallet_dir)
+            .unwrap_or_else(|e| panic!("Failed to create wallet directory: {e}"));
+        #[cfg(not(unix))]
         std::fs::create_dir_all(&wallet_dir)
             .unwrap_or_else(|e| panic!("Failed to create wallet directory: {e}"));
-        #[cfg(unix)]
-        restrict_permissions(&wallet_dir, 0o700)
-            .unwrap_or_else(|e| panic!("Failed to restrict wallet directory permissions: {e}"));
 
         // Initialize electrum client manager with automatic reconnection support
         let electrum_client_manager = match ElectrumClientManager::new_with_subscriptions(
@@ -854,6 +876,9 @@ impl WalletManager {
             ctx.checksum, stop_gap
         );
 
+        #[cfg(unix)]
+        create_private_file(&ctx.wallet_path)?;
+
         // Create SQLite connection
         let mut db = Connection::open(&ctx.wallet_path).map_err(|e| {
             anyhow!(
@@ -862,8 +887,6 @@ impl WalletManager {
                 e
             )
         })?;
-        #[cfg(unix)]
-        restrict_permissions(&ctx.wallet_path, 0o600)?;
         // If a later creation step fails, keep the partial BDK SQLite file with the
         // failed wallet record so the normal delete cleanup path can remove both.
 
@@ -2064,14 +2087,14 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let temp_dir = tempfile::tempdir().unwrap();
-        let file_path = temp_dir.path().join("wallet.sqlite");
-        std::fs::File::create(&file_path).unwrap();
+        let directory_path = temp_dir.path().join("wallets");
+        let file_path = directory_path.join("wallet.sqlite");
 
-        restrict_permissions(temp_dir.path(), 0o700).unwrap();
-        restrict_permissions(&file_path, 0o600).unwrap();
+        create_private_dir(&directory_path).unwrap();
+        create_private_file(&file_path).unwrap();
 
         assert_eq!(
-            std::fs::metadata(temp_dir.path())
+            std::fs::metadata(&directory_path)
                 .unwrap()
                 .permissions()
                 .mode()


### PR DESCRIPTION
## Summary

- remove user and wallet PII from cloud admin ntfy notifications
- restrict wallet data directories and SQLite files to owner-only permissions on Unix
- restrict optional file logging directories to owner-only permissions

Completes the remaining non-overlapping privacy work from #453 not covered by #459.

## Validation

- git diff --check
- cargo check and focused backend tests are currently blocked by unrelated in-progress webhook/auth compilation errors in the shared worktree.