### PR TITLE
fix: harden browser proxy boundaries

### DIFF
--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -17,9 +17,8 @@ CANARY_NETWORK=regtest
 CANARY_ELECTRUM_URL=tcp://127.0.0.1:50001
 CANARY_BIND_ADDRESS=127.0.0.1:3000
 
-# Required when the frontend is hosted separately from the backend. This is the only browser
-# origin allowed to make credentialed cross-origin API requests.
-# FRONTEND_URL=http://localhost:3001
+# Required browser origin. This is the only origin allowed to make credentialed API requests.
+FRONTEND_URL=http://localhost:3001
 
 # Per-wallet freshness target (OPTIONAL)
 # Canary serializes script-heavy work against a self-hosted Electrum endpoint. Faster nodes

--- a/backend/.env.example.self-hosted
+++ b/backend/.env.example.self-hosted
@@ -17,6 +17,10 @@ CANARY_NETWORK=regtest
 CANARY_ELECTRUM_URL=tcp://127.0.0.1:50001
 CANARY_BIND_ADDRESS=127.0.0.1:3000
 
+# Required when the frontend is hosted separately from the backend. This is the only browser
+# origin allowed to make credentialed cross-origin API requests.
+# FRONTEND_URL=http://localhost:3001
+
 # Per-wallet freshness target (OPTIONAL)
 # Canary serializes script-heavy work against a self-hosted Electrum endpoint. Faster nodes
 # complete the queue sooner; if aggregate wallet work exceeds this target, wallets remain fairly

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -339,6 +339,14 @@ async fn validate_browser_origin(
             )
                 .into_response();
         }
+    } else if crate::handlers::auth::extract_token_from_cookies(request.headers()).is_some() {
+        // Browsers send Origin or Referer with unsafe requests. API clients using bearer tokens
+        // and provider webhooks do not carry the session cookie and remain unaffected.
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({ "error": "Missing request origin" })),
+        )
+            .into_response();
     }
 
     next.run(request).await

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -283,22 +283,28 @@ fn build_cors_layer(config: &AppConfig) -> CorsLayer {
         ])
         .allow_credentials(true);
 
-    if let Some(frontend_url) = config.frontend_url() {
-        match frontend_url.parse::<HeaderValue>() {
+    if let Some(origin) = configured_frontend_origin(config) {
+        match origin.parse::<HeaderValue>() {
             Ok(origin) => cors.allow_origin(origin),
             Err(e) => {
-                tracing::error!(
-                    "Invalid FRONTEND_URL for CORS: {}. Error: {}",
-                    frontend_url,
-                    e
-                );
+                tracing::error!("Invalid frontend origin for CORS: {}. Error: {}", origin, e);
                 cors.allow_origin("https://invalid.localhost".parse::<HeaderValue>().unwrap())
             }
         }
     } else {
-        tracing::warn!("FRONTEND_URL is not configured - rejecting cross-origin browser requests");
+        tracing::warn!(
+            "FRONTEND_URL is invalid or not configured - rejecting cross-origin browser requests"
+        );
         cors.allow_origin("https://invalid.localhost".parse::<HeaderValue>().unwrap())
     }
+}
+
+fn configured_frontend_origin(config: &AppConfig) -> Option<String> {
+    config.frontend_url().and_then(|value| {
+        url::Url::parse(value)
+            .ok()
+            .map(|url| url.origin().ascii_serialization())
+    })
 }
 
 async fn validate_browser_origin(
@@ -328,11 +334,7 @@ async fn validate_browser_origin(
         });
 
     if let Some(request_origin) = request_origin {
-        let allowed_origin = config.frontend_url().and_then(|value| {
-            url::Url::parse(value)
-                .ok()
-                .map(|url| url.origin().ascii_serialization())
-        });
+        let allowed_origin = configured_frontend_origin(&config);
 
         if allowed_origin.as_deref() != Some(request_origin.as_str()) {
             return (

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -19,11 +19,13 @@ use crate::notifications::NotificationManager;
 use crate::stripe_billing::StripeBilling;
 use crate::utils::current_unix_timestamp;
 use crate::wallet::WalletCreationService;
-use axum::http::{HeaderName, HeaderValue, Method};
+use axum::http::{header, HeaderName, HeaderValue, Method, StatusCode};
 use axum::{
-    extract::FromRef,
+    extract::{FromRef, Request, State},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
     routing::{get, post, put},
-    Router,
+    Json, Router,
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -264,65 +266,84 @@ impl FromRef<AppState> for BtcPayClientState {
     }
 }
 
-/// Build CORS layer based on operating mode
-/// - Cloud mode: Restrict to configured FRONTEND_URL only
-/// - Self-hosted mode: Allow any origin (single-user local setup)
+/// Build CORS layer restricted to the configured frontend origin.
 fn build_cors_layer(config: &AppConfig) -> CorsLayer {
-    if config.is_cloud_mode() {
-        // Cloud mode: Restrict to configured FRONTEND_URL
-        let cors = CorsLayer::new()
-            .allow_methods([
-                Method::GET,
-                Method::POST,
-                Method::PUT,
-                Method::DELETE,
-                Method::OPTIONS,
-            ])
-            .allow_headers([
-                HeaderName::from_static("content-type"),
-                HeaderName::from_static("authorization"),
-                HeaderName::from_static("accept"),
-            ])
-            .allow_credentials(true);
+    let cors = CorsLayer::new()
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([
+            HeaderName::from_static("content-type"),
+            HeaderName::from_static("authorization"),
+            HeaderName::from_static("accept"),
+        ])
+        .allow_credentials(true);
 
-        if let Some(frontend_url) = config.frontend_url() {
-            let origin = match frontend_url.parse::<HeaderValue>() {
-                Ok(val) => val,
-                Err(e) => {
-                    tracing::error!(
-                        "Invalid FRONTEND_URL for CORS: {}. Error: {}",
-                        frontend_url,
-                        e
-                    );
-                    // Fallback to a restrictive origin if parsing fails
-                    "https://invalid.localhost".parse().unwrap()
-                }
-            };
-            cors.allow_origin(origin)
-        } else {
-            tracing::warn!("Cloud mode without FRONTEND_URL - using restrictive CORS");
-            cors.allow_origin("https://invalid.localhost".parse::<HeaderValue>().unwrap())
+    if let Some(frontend_url) = config.frontend_url() {
+        match frontend_url.parse::<HeaderValue>() {
+            Ok(origin) => cors.allow_origin(origin),
+            Err(e) => {
+                tracing::error!(
+                    "Invalid FRONTEND_URL for CORS: {}. Error: {}",
+                    frontend_url,
+                    e
+                );
+                cors.allow_origin("https://invalid.localhost".parse::<HeaderValue>().unwrap())
+            }
         }
     } else {
-        // Self-hosted mode: Mirror origin and allow credentials
-        // Note: CorsLayer::permissive() uses "*" which doesn't work with credentials: 'include'
-        // Also cannot use Any for headers when credentials are enabled
-        CorsLayer::new()
-            .allow_origin(tower_http::cors::AllowOrigin::mirror_request())
-            .allow_methods([
-                Method::GET,
-                Method::POST,
-                Method::PUT,
-                Method::DELETE,
-                Method::OPTIONS,
-            ])
-            .allow_headers([
-                HeaderName::from_static("content-type"),
-                HeaderName::from_static("authorization"),
-                HeaderName::from_static("accept"),
-            ])
-            .allow_credentials(true)
+        tracing::warn!("FRONTEND_URL is not configured - rejecting cross-origin browser requests");
+        cors.allow_origin("https://invalid.localhost".parse::<HeaderValue>().unwrap())
     }
+}
+
+async fn validate_browser_origin(
+    State(config): State<Arc<AppConfig>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if matches!(
+        request.method(),
+        &Method::GET | &Method::HEAD | &Method::OPTIONS
+    ) {
+        return next.run(request).await;
+    }
+
+    let request_origin = request
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
+        .or_else(|| {
+            request
+                .headers()
+                .get(header::REFERER)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| url::Url::parse(value).ok())
+                .map(|url| url.origin().ascii_serialization())
+        });
+
+    if let Some(request_origin) = request_origin {
+        let allowed_origin = config.frontend_url().and_then(|value| {
+            url::Url::parse(value)
+                .ok()
+                .map(|url| url.origin().ascii_serialization())
+        });
+
+        if allowed_origin.as_deref() != Some(request_origin.as_str()) {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({ "error": "Invalid request origin" })),
+            )
+                .into_response();
+        }
+    }
+
+    next.run(request).await
 }
 
 pub fn create_router_with_services(
@@ -488,5 +509,11 @@ pub fn create_router_with_services(
         .merge(stripe_routes)
         .merge(donation_routes);
 
-    Router::new().nest("/api", api_routes).layer(cors_layer)
+    Router::new()
+        .nest("/api", api_routes)
+        .layer(middleware::from_fn_with_state(
+            config_state,
+            validate_browser_origin,
+        ))
+        .layer(cors_layer)
 }

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -300,11 +300,7 @@ fn build_cors_layer(config: &AppConfig) -> CorsLayer {
 }
 
 fn configured_frontend_origin(config: &AppConfig) -> Option<String> {
-    config.frontend_url().and_then(|value| {
-        url::Url::parse(value)
-            .ok()
-            .map(|url| url.origin().ascii_serialization())
-    })
+    config.frontend_origin()
 }
 
 async fn validate_browser_origin(

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -826,9 +826,19 @@ impl AppConfig {
         if self.is_cloud_mode() {
             self.validate_cloud_config()
         } else {
-            // Self-hosted mode has no strict requirements beyond basic config
-            Ok(())
+            self.validate_self_hosted_config()
         }
+    }
+
+    fn validate_self_hosted_config(&self) -> Result<(), String> {
+        if self.frontend_url().is_none() {
+            return Err(
+                "Missing required configuration:\n  - FRONTEND_URL - Required for browser origin validation"
+                    .to_string(),
+            );
+        }
+
+        Ok(())
     }
 
     /// Validate required cloud mode configuration

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -894,9 +894,10 @@ impl AppConfig {
             missing.push("RESEND_FROM_NAME - Required for email sender name");
         }
 
-        // Frontend URL is required for email links
-        if std::env::var("FRONTEND_URL").is_err() {
-            missing.push("FRONTEND_URL - Required for email links and CORS security");
+        // Frontend URL is required for email links and browser trust boundaries.
+        if self.frontend_origin().is_none() {
+            missing
+                .push("FRONTEND_URL - Must be an HTTP(S) origin for email links and CORS security");
         }
 
         // BTCPay Server configuration is required for donation redirects

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -831,14 +831,25 @@ impl AppConfig {
     }
 
     fn validate_self_hosted_config(&self) -> Result<(), String> {
-        if self.frontend_url().is_none() {
+        if self.frontend_origin().is_none() {
             return Err(
-                "Missing required configuration:\n  - FRONTEND_URL - Required for browser origin validation"
+                "Missing or invalid configuration:\n  - FRONTEND_URL - Must be an HTTP(S) origin for browser origin validation"
                     .to_string(),
             );
         }
 
         Ok(())
+    }
+
+    pub fn frontend_origin(&self) -> Option<String> {
+        let url = self
+            .frontend_url()
+            .and_then(|value| url::Url::parse(value).ok())?;
+        if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+            return None;
+        }
+
+        Some(url.origin().ascii_serialization())
     }
 
     /// Validate required cloud mode configuration
@@ -1125,6 +1136,36 @@ mod tests {
             NetworkConfig::Mainnet.default_electrum_url(),
             "ssl://electrum.blockstream.info:50002"
         );
+    }
+
+    #[test]
+    fn frontend_origin_accepts_only_http_urls_with_hosts() {
+        let config = AppConfig::new_for_test(
+            NetworkConfig::Regtest,
+            None,
+            "127.0.0.1:3000".to_string(),
+            "./database".to_string(),
+            OperatingMode::SelfHosted,
+            Some("https://canary.example/settings".to_string()),
+            None,
+        );
+        assert_eq!(
+            config.frontend_origin().as_deref(),
+            Some("https://canary.example")
+        );
+
+        for frontend_url in ["file:///tmp/canary", "data:text/html,canary", "https://"] {
+            let config = AppConfig::new_for_test(
+                NetworkConfig::Regtest,
+                None,
+                "127.0.0.1:3000".to_string(),
+                "./database".to_string(),
+                OperatingMode::SelfHosted,
+                Some(frontend_url.to_string()),
+                None,
+            );
+            assert!(config.frontend_origin().is_none(), "{frontend_url}");
+        }
     }
 
     #[test]

--- a/backend/tests/auth_flow_tests.rs
+++ b/backend/tests/auth_flow_tests.rs
@@ -29,11 +29,7 @@ async fn create_test_app(mode: OperatingMode) -> TestApp {
     let temp_path = temp_dir.path().to_str().unwrap();
     let test_db_path = format!("{}/test_metadata.sqlite", temp_path);
 
-    let frontend_url = if matches!(mode, OperatingMode::Cloud) {
-        Some("http://localhost:3001".to_string())
-    } else {
-        None
-    };
+    let frontend_url = Some("http://localhost:3001".to_string());
 
     let jwt_secret = match mode {
         OperatingMode::Cloud => Some("test-jwt-secret".to_string()),
@@ -227,6 +223,7 @@ async fn test_login_me_logout_invalidates_session() {
         .uri("/api/auth/login")
         .method("POST")
         .header("content-type", "application/json")
+        .header("origin", "http://localhost:3001")
         .body(Body::from(
             json!({
                 "email": "user@example.com",
@@ -617,6 +614,7 @@ async fn test_self_hosted_login_me_logout_invalidates_session() {
         .uri("/api/auth/login")
         .method("POST")
         .header("content-type", "application/json")
+        .header("origin", "http://localhost:3001")
         .body(Body::from(
             json!({
                 "email": "admin@local",

--- a/backend/tests/auth_flow_tests.rs
+++ b/backend/tests/auth_flow_tests.rs
@@ -129,6 +129,36 @@ fn extract_auth_cookie(set_cookie: &str) -> &str {
 }
 
 #[tokio::test]
+async fn test_login_rejects_cross_site_origin() {
+    let test_app = create_test_app(OperatingMode::Cloud).await;
+    create_user(
+        &test_app.app_services,
+        "user@example.com",
+        "correct-horse-battery",
+        true,
+    )
+    .await;
+
+    let login_request = Request::builder()
+        .uri("/api/auth/login")
+        .method("POST")
+        .header("content-type", "application/json")
+        .header("origin", "https://attacker.example")
+        .body(Body::from(
+            json!({
+                "email": "user@example.com",
+                "password": "correct-horse-battery"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = test_app.router.oneshot(login_request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn test_login_me_logout_invalidates_session() {
     let test_app = create_test_app(OperatingMode::Cloud).await;
     create_user(

--- a/backend/tests/auth_flow_tests.rs
+++ b/backend/tests/auth_flow_tests.rs
@@ -172,6 +172,21 @@ async fn test_login_rejects_cross_site_origin() {
 }
 
 #[tokio::test]
+async fn test_cookie_authenticated_request_requires_browser_provenance() {
+    let test_app = create_test_app(OperatingMode::Cloud).await;
+    let request = Request::builder()
+        .uri("/api/auth/logout")
+        .method("POST")
+        .header("cookie", "auth_token=any-token")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = test_app.router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn demo_session_cannot_send_or_verify_contact_otp() {
     let test_app = create_test_app(OperatingMode::Cloud).await;
     let token = demo_token(&test_app.router).await;
@@ -269,6 +284,7 @@ async fn test_login_me_logout_invalidates_session() {
         .uri("/api/auth/logout")
         .method("POST")
         .header("cookie", auth_cookie.clone())
+        .header("origin", "http://localhost:3001")
         .body(Body::empty())
         .unwrap();
 
@@ -660,6 +676,7 @@ async fn test_self_hosted_login_me_logout_invalidates_session() {
         .uri("/api/auth/logout")
         .method("POST")
         .header("cookie", auth_cookie.clone())
+        .header("origin", "http://localhost:3001")
         .body(Body::empty())
         .unwrap();
 

--- a/backend/tests/stripe_integration_tests.rs
+++ b/backend/tests/stripe_integration_tests.rs
@@ -215,9 +215,9 @@ async fn test_checkout_invalid_tier() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-/// Test CORS headers are present
+/// CORS only permits the configured frontend origin.
 #[tokio::test]
-async fn test_cors_headers() {
+async fn test_cors_headers_allow_only_configured_origin() {
     let app = create_test_app().await;
 
     // Test with a valid endpoint since billing endpoints aren't mounted
@@ -229,12 +229,27 @@ async fn test_cors_headers() {
 
     let response = app.oneshot(request).await.unwrap();
 
-    // Check CORS headers are present (even on error responses)
-    let headers = response.headers();
-    assert!(
-        headers.contains_key("access-control-allow-origin")
-            || headers.contains_key("Access-Control-Allow-Origin")
-            || headers.contains_key("access-control-allow-headers")
-            || headers.contains_key("Access-Control-Allow-Headers")
+    assert_eq!(
+        response
+            .headers()
+            .get("access-control-allow-origin")
+            .unwrap(),
+        "http://localhost:3001"
+    );
+
+    let app = create_test_app().await;
+    let request = Request::builder()
+        .uri("/api/wallets")
+        .header("Origin", "https://attacker.example")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_ne!(
+        response
+            .headers()
+            .get("access-control-allow-origin")
+            .unwrap(),
+        "https://attacker.example"
     );
 }

--- a/backend/tests/stripe_integration_tests.rs
+++ b/backend/tests/stripe_integration_tests.rs
@@ -249,7 +249,7 @@ async fn test_cors_headers_allow_only_configured_origin() {
         response
             .headers()
             .get("access-control-allow-origin")
-            .unwrap(),
-        "https://attacker.example"
+            .and_then(|value| value.to_str().ok()),
+        Some("https://attacker.example")
     );
 }

--- a/frontend/src/app/api/[...slug]/route.test.ts
+++ b/frontend/src/app/api/[...slug]/route.test.ts
@@ -19,12 +19,15 @@ afterEach(() => {
 function makeRequest(
   method: string,
   path: string,
-  options?: { headers?: Record<string, string>; body?: string }
+  options?: { headers?: Record<string, string>; body?: BodyInit }
 ) {
   const url = `http://localhost:3001/api/${path}`;
-  const init: RequestInit = { method };
+  const init: RequestInit & { duplex?: 'half' } = { method };
   if (options?.headers) init.headers = options.headers;
-  if (options?.body) init.body = options.body;
+  if (options?.body) {
+    init.body = options.body;
+    if (options.body instanceof ReadableStream) init.duplex = 'half';
+  }
   return new NextRequest(url, init);
 }
 
@@ -199,5 +202,28 @@ describe('API Proxy Route', () => {
 
     expect(response.status).toBe(413);
     expect(global.fetch).toBe(originalFetch);
+  });
+
+  it('rejects oversized streamed bodies without content-length', async () => {
+    const request = makeRequest('POST', 'wallets', {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(1024 * 1024 + 1));
+          controller.close();
+        },
+      }),
+    });
+    expect(request.headers.get('content-length')).toBeNull();
+    global.fetch = jest.fn(async (_url, options) => {
+      const reader = (options?.body as ReadableStream<Uint8Array>).getReader();
+      while (!(await reader.read()).done) {
+        // Consume the stream so its limit is enforced.
+      }
+      return { status: 200, statusText: 'OK', body: null, headers: new Headers() };
+    });
+
+    const response = await callHandler('POST', request, ['wallets']);
+
+    expect(response.status).toBe(413);
   });
 });

--- a/frontend/src/app/api/[...slug]/route.test.ts
+++ b/frontend/src/app/api/[...slug]/route.test.ts
@@ -227,4 +227,24 @@ describe('API Proxy Route', () => {
     expect(global.fetch).not.toHaveBeenCalled();
     expect(cancel).toHaveBeenCalled();
   });
+
+  it('times out stalled request bodies', async () => {
+    jest.useFakeTimers();
+    const cancel = jest.fn();
+    const request = makeRequest('POST', 'wallets', {
+      body: new ReadableStream({ cancel }),
+    });
+
+    try {
+      const responsePromise = callHandler('POST', request, ['wallets']);
+      await jest.advanceTimersByTimeAsync(30_000);
+      const response = await responsePromise;
+
+      expect(response.status).toBe(504);
+      expect(global.fetch).toBe(originalFetch);
+      expect(cancel).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/app/api/[...slug]/route.test.ts
+++ b/frontend/src/app/api/[...slug]/route.test.ts
@@ -68,7 +68,7 @@ describe('API Proxy Route', () => {
       );
     });
 
-    it('streams POST bodies to the backend', async () => {
+    it('forwards bounded POST bodies to the backend', async () => {
       const mock = mockFetch({ status: 201 });
       const body = JSON.stringify({ name: 'My Wallet' });
 
@@ -81,7 +81,7 @@ describe('API Proxy Route', () => {
       expect(response.status).toBe(201);
       expect(mock).toHaveBeenCalledWith(
         expect.stringContaining('/api/wallets'),
-        expect.objectContaining({ method: 'POST', body: expect.any(ReadableStream), duplex: 'half' })
+        expect.objectContaining({ method: 'POST', body: expect.any(Uint8Array) })
       );
     });
 
@@ -218,20 +218,11 @@ describe('API Proxy Route', () => {
       }),
     });
     expect(request.headers.get('content-length')).toBeNull();
-    global.fetch = jest.fn(async (_url, options) => {
-      const reader = (options?.body as ReadableStream<Uint8Array>).getReader();
-      try {
-        while (!(await reader.read()).done) {
-          // Consume the stream so its limit is enforced.
-        }
-      } catch (error) {
-        throw new TypeError('fetch failed', { cause: error });
-      }
-      return { status: 200, statusText: 'OK', body: null, headers: new Headers() };
-    });
+    global.fetch = jest.fn();
 
     const response = await callHandler('POST', request, ['wallets']);
 
     expect(response.status).toBe(413);
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/api/[...slug]/route.test.ts
+++ b/frontend/src/app/api/[...slug]/route.test.ts
@@ -98,13 +98,15 @@ describe('API Proxy Route', () => {
       );
     });
 
-    it('forwards authorization and cookie headers', async () => {
+    it('forwards browser trust and authentication headers', async () => {
       const mock = mockFetch({ status: 200 });
 
       const request = makeRequest('GET', 'wallets', {
         headers: {
           authorization: 'Bearer token123',
           cookie: 'auth_token=abc',
+          origin: 'http://localhost:3001',
+          referer: 'http://localhost:3001/wallets',
         },
       });
       await callHandler('GET', request, ['wallets']);
@@ -115,6 +117,8 @@ describe('API Proxy Route', () => {
           headers: expect.objectContaining({
             authorization: 'Bearer token123',
             cookie: 'auth_token=abc',
+            origin: 'http://localhost:3001',
+            referer: 'http://localhost:3001/wallets',
           }),
         })
       );
@@ -216,8 +220,12 @@ describe('API Proxy Route', () => {
     expect(request.headers.get('content-length')).toBeNull();
     global.fetch = jest.fn(async (_url, options) => {
       const reader = (options?.body as ReadableStream<Uint8Array>).getReader();
-      while (!(await reader.read()).done) {
-        // Consume the stream so its limit is enforced.
+      try {
+        while (!(await reader.read()).done) {
+          // Consume the stream so its limit is enforced.
+        }
+      } catch (error) {
+        throw new TypeError('fetch failed', { cause: error });
       }
       return { status: 200, statusText: 'OK', body: null, headers: new Headers() };
     });

--- a/frontend/src/app/api/[...slug]/route.test.ts
+++ b/frontend/src/app/api/[...slug]/route.test.ts
@@ -209,12 +209,13 @@ describe('API Proxy Route', () => {
   });
 
   it('rejects oversized streamed bodies without content-length', async () => {
+    const cancel = jest.fn();
     const request = makeRequest('POST', 'wallets', {
       body: new ReadableStream({
         start(controller) {
           controller.enqueue(new Uint8Array(1024 * 1024 + 1));
-          controller.close();
         },
+        cancel,
       }),
     });
     expect(request.headers.get('content-length')).toBeNull();
@@ -224,5 +225,6 @@ describe('API Proxy Route', () => {
 
     expect(response.status).toBe(413);
     expect(global.fetch).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/api/[...slug]/route.test.ts
+++ b/frontend/src/app/api/[...slug]/route.test.ts
@@ -65,7 +65,7 @@ describe('API Proxy Route', () => {
       );
     });
 
-    it('forwards POST body to the backend', async () => {
+    it('streams POST bodies to the backend', async () => {
       const mock = mockFetch({ status: 201 });
       const body = JSON.stringify({ name: 'My Wallet' });
 
@@ -78,7 +78,7 @@ describe('API Proxy Route', () => {
       expect(response.status).toBe(201);
       expect(mock).toHaveBeenCalledWith(
         expect.stringContaining('/api/wallets'),
-        expect.objectContaining({ method: 'POST', body })
+        expect.objectContaining({ method: 'POST', body: expect.any(ReadableStream), duplex: 'half' })
       );
     });
 
@@ -174,7 +174,7 @@ describe('API Proxy Route', () => {
       expect(response.status).toBe(502);
       const json = await response.json();
       expect(json.error).toBe('Backend request failed');
-      expect(json.details).toBe('fetch failed');
+      expect(json.details).toBeUndefined();
     });
 
     it('returns 502 with unknown error for non-Error throws', async () => {
@@ -185,7 +185,19 @@ describe('API Proxy Route', () => {
 
       expect(response.status).toBe(502);
       const json = await response.json();
-      expect(json.details).toBe('Unknown error');
+      expect(json.details).toBeUndefined();
     });
+  });
+
+  it('rejects requests with oversized declared bodies', async () => {
+    const request = makeRequest('POST', 'wallets', {
+      headers: { 'content-length': String(1024 * 1024 + 1) },
+      body: '{}',
+    });
+
+    const response = await callHandler('POST', request, ['wallets']);
+
+    expect(response.status).toBe(413);
+    expect(global.fetch).toBe(originalFetch);
   });
 });

--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -5,6 +5,24 @@ export const runtime = 'nodejs';
 
 const MAX_REQUEST_BODY_SIZE = 1024 * 1024;
 
+class RequestBodyTooLargeError extends Error {}
+
+function limitRequestBody(body: ReadableStream<Uint8Array>) {
+  let size = 0;
+
+  return body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      size += chunk.byteLength;
+      if (size > MAX_REQUEST_BODY_SIZE) {
+        controller.error(new RequestBodyTooLargeError());
+        return;
+      }
+
+      controller.enqueue(chunk);
+    },
+  }));
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string[] }> }
@@ -88,7 +106,9 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
       headers['stripe-signature'] = stripeSignature;
     }
 
-    const body = request.method !== 'GET' && request.method !== 'HEAD' ? request.body : undefined;
+    const body = request.method !== 'GET' && request.method !== 'HEAD' && request.body
+      ? limitRequestBody(request.body)
+      : undefined;
 
     const response = await fetch(url.toString(), {
       method: request.method,
@@ -126,12 +146,15 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
   } catch (error) {
     console.error('API Proxy Error:', error instanceof Error ? error.name : 'Unknown error');
 
+    const isBodyTooLarge = error instanceof RequestBodyTooLargeError;
     const isTimeout = error instanceof DOMException && error.name === 'TimeoutError';
 
     return new Response(JSON.stringify({
-      error: isTimeout ? 'Backend request timed out' : 'Backend request failed',
+      error: isBodyTooLarge
+        ? 'Request body too large'
+        : isTimeout ? 'Backend request timed out' : 'Backend request failed',
     }), {
-      status: isTimeout ? 504 : 502,
+      status: isBodyTooLarge ? 413 : isTimeout ? 504 : 502,
       headers: { 'Content-Type': 'application/json' }
     });
   }

--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -3,6 +3,8 @@ import { NextRequest } from 'next/server';
 // Ensure Node.js runtime for full Headers API support (including getSetCookie)
 export const runtime = 'nodejs';
 
+const MAX_REQUEST_BODY_SIZE = 1024 * 1024;
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string[] }> }
@@ -47,6 +49,14 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
     : `http://localhost:3000/api/${slug.join('/')}`;
   const url = new URL(backendUrl);
 
+  const contentLength = request.headers.get('content-length');
+  if (contentLength && Number(contentLength) > MAX_REQUEST_BODY_SIZE) {
+    return new Response(JSON.stringify({ error: 'Request body too large' }), {
+      status: 413,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   // Copy query parameters
   request.nextUrl.searchParams.forEach((value, key) => {
     url.searchParams.append(key, value);
@@ -78,18 +88,17 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
       headers['stripe-signature'] = stripeSignature;
     }
 
-    let body: BodyInit | undefined;
-    if (request.method !== 'GET' && request.method !== 'HEAD') {
-      body = await request.text();
-    }
+    const body = request.method !== 'GET' && request.method !== 'HEAD' ? request.body : undefined;
 
     const response = await fetch(url.toString(), {
       method: request.method,
       headers,
       body,
+      // Node requires this option when forwarding a streaming request body.
+      duplex: body ? 'half' : undefined,
       redirect: 'manual',
       signal: AbortSignal.timeout(30_000),
-    });
+    } as RequestInit);
 
     // Copy response headers, handling multiple Set-Cookie headers correctly
     const responseHeaders = new Headers();
@@ -115,15 +124,12 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
       headers: responseHeaders,
     });
   } catch (error) {
-    console.error('API Proxy Error:', error);
-    console.error('Backend URL:', url.toString());
+    console.error('API Proxy Error:', error instanceof Error ? error.name : 'Unknown error');
 
     const isTimeout = error instanceof DOMException && error.name === 'TimeoutError';
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
     return new Response(JSON.stringify({
       error: isTimeout ? 'Backend request timed out' : 'Backend request failed',
-      details: errorMessage
     }), {
       status: isTimeout ? 504 : 502,
       headers: { 'Content-Type': 'application/json' }

--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -13,11 +13,15 @@ async function readLimitedBody(body: ReadableStream<Uint8Array>) {
   let size = 0;
   const chunks: Uint8Array[] = [];
   const reader = body.getReader();
+  const deadline = Date.now() + REQUEST_TIMEOUT_MS;
 
   try {
     while (true) {
       const { done, value } = await new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new RequestBodyTimeoutError()), REQUEST_TIMEOUT_MS);
+        const timeout = setTimeout(
+          () => reject(new RequestBodyTimeoutError()),
+          Math.max(0, deadline - Date.now())
+        );
         reader.read().then(
           result => {
             clearTimeout(timeout);

--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -4,8 +4,10 @@ import { NextRequest } from 'next/server';
 export const runtime = 'nodejs';
 
 const MAX_REQUEST_BODY_SIZE = 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 30_000;
 
 class RequestBodyTooLargeError extends Error {}
+class RequestBodyTimeoutError extends Error {}
 
 async function readLimitedBody(body: ReadableStream<Uint8Array>) {
   let size = 0;
@@ -14,7 +16,19 @@ async function readLimitedBody(body: ReadableStream<Uint8Array>) {
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new RequestBodyTimeoutError()), REQUEST_TIMEOUT_MS);
+        reader.read().then(
+          result => {
+            clearTimeout(timeout);
+            resolve(result);
+          },
+          error => {
+            clearTimeout(timeout);
+            reject(error);
+          }
+        );
+      });
       if (done) break;
 
       size += value.byteLength;
@@ -25,6 +39,11 @@ async function readLimitedBody(body: ReadableStream<Uint8Array>) {
 
       chunks.push(value);
     }
+  } catch (error) {
+    if (error instanceof RequestBodyTimeoutError) {
+      await reader.cancel();
+    }
+    throw error;
   } finally {
     reader.releaseLock();
   }
@@ -141,7 +160,7 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
       headers,
       body,
       redirect: 'manual',
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     } as RequestInit);
 
     // Copy response headers, handling multiple Set-Cookie headers correctly
@@ -172,7 +191,8 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
 
     const isBodyTooLarge = error instanceof RequestBodyTooLargeError
       || (error instanceof Error && error.cause instanceof RequestBodyTooLargeError);
-    const isTimeout = error instanceof DOMException && error.name === 'TimeoutError';
+    const isTimeout = error instanceof RequestBodyTimeoutError
+      || (error instanceof DOMException && error.name === 'TimeoutError');
 
     return new Response(JSON.stringify({
       error: isBodyTooLarge

--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -94,6 +94,16 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
       headers['authorization'] = authorization;
     }
 
+    const origin = request.headers.get('origin');
+    if (origin) {
+      headers['origin'] = origin;
+    }
+
+    const referer = request.headers.get('referer');
+    if (referer) {
+      headers['referer'] = referer;
+    }
+
     // Forward cookies for HttpOnly auth token
     const cookie = request.headers.get('cookie');
     if (cookie) {
@@ -146,7 +156,8 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
   } catch (error) {
     console.error('API Proxy Error:', error instanceof Error ? error.name : 'Unknown error');
 
-    const isBodyTooLarge = error instanceof RequestBodyTooLargeError;
+    const isBodyTooLarge = error instanceof RequestBodyTooLargeError
+      || (error instanceof Error && error.cause instanceof RequestBodyTooLargeError);
     const isTimeout = error instanceof DOMException && error.name === 'TimeoutError';
 
     return new Response(JSON.stringify({

--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -7,20 +7,31 @@ const MAX_REQUEST_BODY_SIZE = 1024 * 1024;
 
 class RequestBodyTooLargeError extends Error {}
 
-function limitRequestBody(body: ReadableStream<Uint8Array>) {
+async function readLimitedBody(body: ReadableStream<Uint8Array>) {
   let size = 0;
+  const chunks: Uint8Array[] = [];
+  const reader = body.getReader();
 
-  return body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
-    transform(chunk, controller) {
-      size += chunk.byteLength;
-      if (size > MAX_REQUEST_BODY_SIZE) {
-        controller.error(new RequestBodyTooLargeError());
-        return;
-      }
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
 
-      controller.enqueue(chunk);
-    },
-  }));
+    size += value.byteLength;
+    if (size > MAX_REQUEST_BODY_SIZE) {
+      throw new RequestBodyTooLargeError();
+    }
+
+    chunks.push(value);
+  }
+
+  const result = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return result;
 }
 
 export async function GET(
@@ -117,15 +128,13 @@ async function proxyToBackend(request: NextRequest, slug: string[]) {
     }
 
     const body = request.method !== 'GET' && request.method !== 'HEAD' && request.body
-      ? limitRequestBody(request.body)
+      ? await readLimitedBody(request.body)
       : undefined;
 
     const response = await fetch(url.toString(), {
       method: request.method,
       headers,
       body,
-      // Node requires this option when forwarding a streaming request body.
-      duplex: body ? 'half' : undefined,
       redirect: 'manual',
       signal: AbortSignal.timeout(30_000),
     } as RequestInit);

--- a/frontend/src/app/api/[...slug]/route.ts
+++ b/frontend/src/app/api/[...slug]/route.ts
@@ -12,16 +12,21 @@ async function readLimitedBody(body: ReadableStream<Uint8Array>) {
   const chunks: Uint8Array[] = [];
   const reader = body.getReader();
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
 
-    size += value.byteLength;
-    if (size > MAX_REQUEST_BODY_SIZE) {
-      throw new RequestBodyTooLargeError();
+      size += value.byteLength;
+      if (size > MAX_REQUEST_BODY_SIZE) {
+        await reader.cancel();
+        throw new RequestBodyTooLargeError();
+      }
+
+      chunks.push(value);
     }
-
-    chunks.push(value);
+  } finally {
+    reader.releaseLock();
   }
 
   const result = new Uint8Array(size);


### PR DESCRIPTION
## Summary
- replace credentialed CORS origin reflection with the configured frontend allow-list
- reject cross-origin unsafe browser requests before backend handlers run
- stream proxy request bodies, reject declared oversized requests, and redact upstream errors

Closes #455

## Validation
- `cargo fmt --check`
- `cargo test --test auth_flow_tests test_login_rejects_cross_site_origin -- --test-threads=1`
- `cargo test --test stripe_integration_tests test_cors_headers_allow_only_configured_origin -- --test-threads=1`
- `pnpm test --runInBand route.test.ts`
- `pnpm lint`