### PR TITLE
fix: make Stripe webhooks idempotent

### DIFF
--- a/backend/migrations/038_add_stripe_webhook_event_tracking.sql
+++ b/backend/migrations/038_add_stripe_webhook_event_tracking.sql
@@ -1,4 +1,6 @@
 -- Track the latest Stripe event applied to each user's entitlement.
 ALTER TABLE users ADD COLUMN stripe_event_created INTEGER;
+ALTER TABLE users ADD COLUMN stripe_event_id TEXT;
 ALTER TABLE stripe_webhook_events ADD COLUMN delivery_status TEXT NOT NULL DEFAULT 'completed';
 ALTER TABLE stripe_webhook_events ADD COLUMN processing_started_at DATETIME;
+ALTER TABLE stripe_webhook_events ADD COLUMN claim_token TEXT;

--- a/backend/migrations/038_add_stripe_webhook_event_tracking.sql
+++ b/backend/migrations/038_add_stripe_webhook_event_tracking.sql
@@ -1,0 +1,2 @@
+-- Track the latest Stripe event applied to each user's entitlement.
+ALTER TABLE users ADD COLUMN stripe_event_created INTEGER;

--- a/backend/migrations/038_add_stripe_webhook_event_tracking.sql
+++ b/backend/migrations/038_add_stripe_webhook_event_tracking.sql
@@ -1,2 +1,4 @@
 -- Track the latest Stripe event applied to each user's entitlement.
 ALTER TABLE users ADD COLUMN stripe_event_created INTEGER;
+ALTER TABLE stripe_webhook_events ADD COLUMN delivery_status TEXT NOT NULL DEFAULT 'completed';
+ALTER TABLE stripe_webhook_events ADD COLUMN processing_started_at DATETIME;

--- a/backend/migrations/039_add_trial_ending_email_tracking.sql
+++ b/backend/migrations/039_add_trial_ending_email_tracking.sql
@@ -1,0 +1,2 @@
+-- Persist completion of the trial-ending email independently from webhook completion.
+ALTER TABLE stripe_webhook_events ADD COLUMN trial_ending_email_sent_at DATETIME;

--- a/backend/src/email_service.rs
+++ b/backend/src/email_service.rs
@@ -631,6 +631,7 @@ Your verification code is: {otp_code}
         to_name: &str,
         trial_ends_at: &str,
         language: &str,
+        idempotency_key: &str,
     ) -> Result<()> {
         let billing_url = format!("{}/billing", self.config.frontend_url);
 
@@ -789,8 +790,22 @@ Your verification code is: {otp_code}
             footer = footer
         );
 
-        self.send_email(to_email, to_name, &subject, &html_body, &text_body)
+        let from = format!(
+            "{} <{}>",
+            self.config.resend_from_name, self.config.resend_from_email
+        );
+        let to = vec![format!("{} <{}>", to_name, to_email)];
+        let email = CreateEmailBaseOptions::new(from, to, subject)
+            .with_html(&html_body)
+            .with_text(&text_body)
+            .with_idempotency_key(idempotency_key);
+
+        self.resend
+            .emails
+            .send(email)
             .await
+            .map(|_| ())
+            .map_err(|e| anyhow!("Resend API error: {}", e))
     }
 
     /// Send contact form submission to admin

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -439,6 +439,7 @@ pub async fn handle_stripe_webhook(
     };
 
     let (claim_heartbeat, mut claim_heartbeat_stop) = tokio::sync::watch::channel(false);
+    let (heartbeat_failure, mut heartbeat_failure_rx) = tokio::sync::watch::channel(false);
     let heartbeat_db = app_services.metadata_db.clone();
     let heartbeat_event_id = verified_event.event_id.clone();
     let heartbeat_claim_token = claim_token.clone();
@@ -454,7 +455,11 @@ pub async fn handle_stripe_webhook(
                     {
                         Ok(true) => {}
                         Ok(false) => break,
-                        Err(e) => tracing::error!("Failed to refresh Stripe webhook claim: {}", e),
+                        Err(e) => {
+                            tracing::error!("Failed to refresh Stripe webhook claim: {}", e);
+                            let _ = heartbeat_failure.send(true);
+                            break;
+                        }
                     }
                 }
                 result = claim_heartbeat_stop.changed() => {
@@ -468,14 +473,26 @@ pub async fn handle_stripe_webhook(
 
     // Side effects are safe only after this delivery owns the event claim.
     tracing::info!("🎣 Processing Stripe webhook");
-    match stripe_billing
-        .handle_webhook(body.as_bytes(), signature)
-        .await
-    {
+    let webhook_result = tokio::select! {
+        result = stripe_billing.handle_webhook(body.as_bytes(), signature) => result,
+        result = heartbeat_failure_rx.changed() => {
+            let message = if result.is_ok() {
+                "Stripe webhook claim heartbeat failed"
+            } else {
+                "Stripe webhook claim heartbeat stopped"
+            };
+            Err(anyhow::anyhow!(message))
+        }
+    };
+    match webhook_result {
         Ok(webhook_result) => {
             // Process any subscription updates - no mutex blocking!
             let mut persistence_failed = false;
             for update in webhook_result.subscription_updates {
+                if *heartbeat_failure_rx.borrow() {
+                    persistence_failed = true;
+                    break;
+                }
                 tracing::info!(
                     "Processing subscription update for user {}: {} -> {}",
                     update.user_id,
@@ -802,6 +819,10 @@ pub async fn handle_stripe_webhook(
                         }
                     }
                 }
+            }
+
+            if *heartbeat_failure_rx.borrow() {
+                persistence_failed = true;
             }
 
             if persistence_failed {

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -589,6 +589,7 @@ pub async fn handle_stripe_webhook(
                                 &actual_user_id,
                                 webhook_result.event_created,
                                 &webhook_result.event_id,
+                                true,
                             )
                             .await
                     } else {
@@ -600,6 +601,7 @@ pub async fn handle_stripe_webhook(
                                 update.stripe_subscription_id.as_deref(),
                                 webhook_result.event_created,
                                 &webhook_result.event_id,
+                                true,
                             )
                             .await
                     };
@@ -687,6 +689,7 @@ pub async fn handle_stripe_webhook(
                             &sub_params,
                             webhook_result.event_created,
                             &webhook_result.event_id,
+                            true,
                         )
                         .await
                     {

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -385,7 +385,7 @@ pub async fn handle_stripe_webhook(
         .await
     {
         Ok(webhook_result) => {
-            match app_services
+            let claim_token = match app_services
                 .metadata_db
                 .claim_stripe_webhook_event(
                     &webhook_result.event_id,
@@ -394,7 +394,7 @@ pub async fn handle_stripe_webhook(
                 )
                 .await
             {
-                Ok(false) => match app_services
+                Ok(None) => match app_services
                     .metadata_db
                     .is_stripe_webhook_event_complete(&webhook_result.event_id)
                     .await
@@ -420,7 +420,7 @@ pub async fn handle_stripe_webhook(
                             .into_response();
                     }
                 },
-                Ok(true) => {}
+                Ok(Some(claim_token)) => claim_token,
                 Err(e) => {
                     tracing::error!("Failed to check Stripe webhook idempotency: {}", e);
                     return (
@@ -429,7 +429,7 @@ pub async fn handle_stripe_webhook(
                     )
                         .into_response();
                 }
-            }
+            };
 
             // Process any subscription updates - no mutex blocking!
             let mut persistence_failed = false;
@@ -559,6 +559,7 @@ pub async fn handle_stripe_webhook(
                             .expire_user_subscription_for_stripe_event(
                                 &actual_user_id,
                                 webhook_result.event_created,
+                                &webhook_result.event_id,
                             )
                             .await
                     } else {
@@ -569,6 +570,7 @@ pub async fn handle_stripe_webhook(
                                 &update.subscription_status,
                                 update.stripe_subscription_id.as_deref(),
                                 webhook_result.event_created,
+                                &webhook_result.event_id,
                             )
                             .await
                     };
@@ -655,6 +657,7 @@ pub async fn handle_stripe_webhook(
                             &actual_user_id,
                             &sub_params,
                             webhook_result.event_created,
+                            &webhook_result.event_id,
                         )
                         .await
                     {
@@ -745,7 +748,7 @@ pub async fn handle_stripe_webhook(
                 tracing::error!("Webhook state update failed; returning an error for Stripe retry");
                 if let Err(e) = app_services
                     .metadata_db
-                    .fail_stripe_webhook_event(&webhook_result.event_id)
+                    .fail_stripe_webhook_event(&webhook_result.event_id, &claim_token)
                     .await
                 {
                     tracing::error!("Failed to release Stripe webhook claim: {}", e);
@@ -757,24 +760,35 @@ pub async fn handle_stripe_webhook(
                     .into_response();
             }
 
-            if let Err(e) = app_services
+            match app_services
                 .metadata_db
-                .complete_stripe_webhook_event(&webhook_result.event_id)
+                .complete_stripe_webhook_event(&webhook_result.event_id, &claim_token)
                 .await
             {
-                tracing::error!("Failed to record processed Stripe webhook: {}", e);
-                if let Err(e) = app_services
-                    .metadata_db
-                    .fail_stripe_webhook_event(&webhook_result.event_id)
-                    .await
-                {
-                    tracing::error!("Failed to release Stripe webhook claim: {}", e);
+                Ok(true) => {}
+                Ok(false) => {
+                    tracing::error!("Stripe webhook claim was superseded before completion");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::new("Webhook state update failed")),
+                    )
+                        .into_response();
                 }
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new("Webhook state update failed")),
-                )
-                    .into_response();
+                Err(e) => {
+                    tracing::error!("Failed to record processed Stripe webhook: {}", e);
+                    if let Err(e) = app_services
+                        .metadata_db
+                        .fail_stripe_webhook_event(&webhook_result.event_id, &claim_token)
+                        .await
+                    {
+                        tracing::error!("Failed to release Stripe webhook claim: {}", e);
+                    }
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::new("Webhook state update failed")),
+                    )
+                        .into_response();
+                }
             }
 
             tracing::info!("✅ Webhook processed successfully");

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -378,59 +378,73 @@ pub async fn handle_stripe_webhook(
         }
     };
 
-    // Handle the webhook
+    let verified_event = match stripe_billing
+        .verify_webhook_event(body.as_bytes(), signature)
+        .await
+    {
+        Ok(event) => event,
+        Err(e) => {
+            tracing::error!("❌ Webhook verification failed: {}", e);
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new(format!(
+                    "Webhook processing failed: {}",
+                    e
+                ))),
+            )
+                .into_response();
+        }
+    };
+
+    let claim_token = match app_services
+        .metadata_db
+        .claim_stripe_webhook_event(
+            &verified_event.event_id,
+            verified_event.event_created,
+            &verified_event.event_type,
+        )
+        .await
+    {
+        Ok(None) => match app_services
+            .metadata_db
+            .is_stripe_webhook_event_complete(&verified_event.event_id)
+            .await
+        {
+            Ok(true) => return (StatusCode::OK, "OK").into_response(),
+            Ok(false) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("Webhook state update in progress")),
+                )
+                    .into_response()
+            }
+            Err(e) => {
+                tracing::error!("Failed to inspect Stripe webhook claim: {}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("Webhook state update failed")),
+                )
+                    .into_response();
+            }
+        },
+        Ok(Some(claim_token)) => claim_token,
+        Err(e) => {
+            tracing::error!("Failed to claim Stripe webhook: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("Webhook state update failed")),
+            )
+                .into_response();
+        }
+    };
+
+    // Side effects are safe only after this delivery owns the event claim.
     tracing::info!("🎣 Processing Stripe webhook");
     match stripe_billing
         .handle_webhook(body.as_bytes(), signature)
         .await
     {
         Ok(webhook_result) => {
-            let claim_token = match app_services
-                .metadata_db
-                .claim_stripe_webhook_event(
-                    &webhook_result.event_id,
-                    webhook_result.event_created,
-                    &webhook_result.event_type,
-                )
-                .await
-            {
-                Ok(None) => match app_services
-                    .metadata_db
-                    .is_stripe_webhook_event_complete(&webhook_result.event_id)
-                    .await
-                {
-                    Ok(true) => {
-                        tracing::info!(event_id = %webhook_result.event_id, "Ignoring duplicate Stripe webhook");
-                        return (StatusCode::OK, "OK").into_response();
-                    }
-                    Ok(false) => {
-                        tracing::info!(event_id = %webhook_result.event_id, "Stripe webhook is already being processed");
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new("Webhook state update in progress")),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        tracing::error!("Failed to inspect Stripe webhook claim: {}", e);
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse::new("Webhook state update failed")),
-                        )
-                            .into_response();
-                    }
-                },
-                Ok(Some(claim_token)) => claim_token,
-                Err(e) => {
-                    tracing::error!("Failed to check Stripe webhook idempotency: {}", e);
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse::new("Webhook state update failed")),
-                    )
-                        .into_response();
-                }
-            };
-
             // Process any subscription updates - no mutex blocking!
             let mut persistence_failed = false;
             for update in webhook_result.subscription_updates {
@@ -811,6 +825,13 @@ pub async fn handle_stripe_webhook(
         }
         Err(e) => {
             tracing::error!("❌ Webhook processing failed: {}", e);
+            if let Err(release_error) = app_services
+                .metadata_db
+                .fail_stripe_webhook_event(&verified_event.event_id, &claim_token)
+                .await
+            {
+                tracing::error!("Failed to release Stripe webhook claim: {}", release_error);
+            }
             (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(format!(

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -387,14 +387,40 @@ pub async fn handle_stripe_webhook(
         Ok(webhook_result) => {
             match app_services
                 .metadata_db
-                .has_processed_stripe_event(&webhook_result.event_id)
+                .claim_stripe_webhook_event(
+                    &webhook_result.event_id,
+                    webhook_result.event_created,
+                    &webhook_result.event_type,
+                )
                 .await
             {
-                Ok(true) => {
-                    tracing::info!(event_id = %webhook_result.event_id, "Ignoring duplicate Stripe webhook");
-                    return (StatusCode::OK, "OK").into_response();
-                }
-                Ok(false) => {}
+                Ok(false) => match app_services
+                    .metadata_db
+                    .is_stripe_webhook_event_complete(&webhook_result.event_id)
+                    .await
+                {
+                    Ok(true) => {
+                        tracing::info!(event_id = %webhook_result.event_id, "Ignoring duplicate Stripe webhook");
+                        return (StatusCode::OK, "OK").into_response();
+                    }
+                    Ok(false) => {
+                        tracing::info!(event_id = %webhook_result.event_id, "Stripe webhook is already being processed");
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(ErrorResponse::new("Webhook state update in progress")),
+                        )
+                            .into_response();
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to inspect Stripe webhook claim: {}", e);
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(ErrorResponse::new("Webhook state update failed")),
+                        )
+                            .into_response();
+                    }
+                },
+                Ok(true) => {}
                 Err(e) => {
                     tracing::error!("Failed to check Stripe webhook idempotency: {}", e);
                     return (
@@ -523,27 +549,6 @@ pub async fn handle_stripe_webhook(
                     update.user_id.clone()
                 };
 
-                match app_services
-                    .metadata_db
-                    .is_stripe_event_stale(&actual_user_id, webhook_result.event_created)
-                    .await
-                {
-                    Ok(true) => {
-                        tracing::info!(
-                            user_id = %actual_user_id,
-                            event_id = %webhook_result.event_id,
-                            "Ignoring stale Stripe webhook"
-                        );
-                        continue;
-                    }
-                    Ok(false) => {}
-                    Err(e) => {
-                        tracing::error!("Failed to check Stripe webhook ordering: {}", e);
-                        persistence_failed = true;
-                        continue;
-                    }
-                }
-
                 // Handle special "keep_current" tier for cancellations
                 if update.subscription_tier == "keep_current" {
                     let update_result = if update.subscription_status == "expired"
@@ -551,71 +556,86 @@ pub async fn handle_stripe_webhook(
                     {
                         app_services
                             .metadata_db
-                            .expire_user_subscription(&actual_user_id)
+                            .expire_user_subscription_for_stripe_event(
+                                &actual_user_id,
+                                webhook_result.event_created,
+                            )
                             .await
                     } else {
                         app_services
                             .metadata_db
-                            .update_user_subscription_status(
+                            .update_user_subscription_status_for_stripe_event(
                                 &actual_user_id,
                                 &update.subscription_status,
                                 update.stripe_subscription_id.as_deref(),
+                                webhook_result.event_created,
                             )
                             .await
                     };
-                    if let Err(e) = update_result {
-                        tracing::error!(
-                            "Failed to update user {} subscription status: {}",
-                            actual_user_id,
-                            e
-                        );
-                        persistence_failed = true;
-                    } else {
-                        tracing::info!(
+                    match update_result {
+                        Ok(false) => {
+                            tracing::info!(
+                                user_id = %actual_user_id,
+                                event_id = %webhook_result.event_id,
+                                "Ignoring stale Stripe webhook"
+                            );
+                            continue;
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to update user {} subscription status: {}",
+                                actual_user_id,
+                                e
+                            );
+                            persistence_failed = true;
+                        }
+                        Ok(true) => {
+                            tracing::info!(
                             "✅ Updated user {} subscription status to {} (keeping current tier)",
                             actual_user_id,
                             update.subscription_status
                         );
 
-                        match app_services
-                            .metadata_db
-                            .get_user_by_id(&actual_user_id)
-                            .await
-                        {
-                            Ok(Some(user_record)) => {
-                                if let Err(e) = app_services
-                                    .apply_subscription_limits(
-                                        &actual_user_id,
-                                        user_record.subscription_tier.as_str(),
-                                        &update.subscription_status,
-                                        user_record.is_admin,
-                                        user_record.trial_ends_at.clone(),
-                                        user_record.subscription_ends_at.clone(),
-                                    )
-                                    .await
-                                {
+                            match app_services
+                                .metadata_db
+                                .get_user_by_id(&actual_user_id)
+                                .await
+                            {
+                                Ok(Some(user_record)) => {
+                                    if let Err(e) = app_services
+                                        .apply_subscription_limits(
+                                            &actual_user_id,
+                                            user_record.subscription_tier.as_str(),
+                                            &update.subscription_status,
+                                            user_record.is_admin,
+                                            user_record.trial_ends_at.clone(),
+                                            user_record.subscription_ends_at.clone(),
+                                        )
+                                        .await
+                                    {
+                                        tracing::error!(
+                                            "Failed to apply subscription limits for user {}: {}",
+                                            actual_user_id,
+                                            e
+                                        );
+                                        persistence_failed = true;
+                                    }
+                                }
+                                Ok(None) => {
                                     tracing::error!(
-                                        "Failed to apply subscription limits for user {}: {}",
+                                        "User {} not found when applying limits",
+                                        actual_user_id
+                                    );
+                                    persistence_failed = true;
+                                }
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Failed to fetch user {} when applying limits: {}",
                                         actual_user_id,
                                         e
                                     );
                                     persistence_failed = true;
                                 }
-                            }
-                            Ok(None) => {
-                                tracing::error!(
-                                    "User {} not found when applying limits",
-                                    actual_user_id
-                                );
-                                persistence_failed = true;
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to fetch user {} when applying limits: {}",
-                                    actual_user_id,
-                                    e
-                                );
-                                persistence_failed = true;
                             }
                         }
                     }
@@ -629,96 +649,107 @@ pub async fn handle_stripe_webhook(
                         subscription_ends_at: update.subscription_ends_at.as_deref(),
                         trial_ends_at: update.trial_ends_at.as_deref(),
                     };
-                    if let Err(e) = app_services
+                    match app_services
                         .metadata_db
-                        .update_user_subscription(&actual_user_id, &sub_params)
+                        .update_user_subscription_for_stripe_event(
+                            &actual_user_id,
+                            &sub_params,
+                            webhook_result.event_created,
+                        )
                         .await
                     {
-                        tracing::error!(
-                            "Failed to update user {} subscription: {}",
-                            actual_user_id,
-                            e
-                        );
-                        persistence_failed = true;
-                    } else {
-                        tracing::info!(
-                            "✅ Updated user {} subscription to {} ({})",
-                            actual_user_id,
-                            update.subscription_tier,
-                            update.subscription_status
-                        );
+                        Ok(false) => {
+                            tracing::info!(
+                                user_id = %actual_user_id,
+                                event_id = %webhook_result.event_id,
+                                "Ignoring stale Stripe webhook"
+                            );
+                            continue;
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to update user {} subscription: {}",
+                                actual_user_id,
+                                e
+                            );
+                            persistence_failed = true;
+                        }
+                        Ok(true) => {
+                            tracing::info!(
+                                "✅ Updated user {} subscription to {} ({})",
+                                actual_user_id,
+                                update.subscription_tier,
+                                update.subscription_status
+                            );
 
-                        // Apply subscription tier limits to wallets and contacts
-                        // First, get user record to check admin status - no mutex blocking!
-                        match app_services
-                            .metadata_db
-                            .get_user_by_id(&actual_user_id)
-                            .await
-                        {
-                            Ok(Some(user_record)) => {
-                                if let Err(e) = app_services
-                                    .apply_subscription_limits(
-                                        &actual_user_id,
-                                        &update.subscription_tier,
-                                        &update.subscription_status,
-                                        user_record.is_admin,
-                                        user_record.trial_ends_at.clone(),
-                                        user_record.subscription_ends_at.clone(),
-                                    )
-                                    .await
-                                {
+                            // Apply subscription tier limits to wallets and contacts
+                            // First, get user record to check admin status - no mutex blocking!
+                            match app_services
+                                .metadata_db
+                                .get_user_by_id(&actual_user_id)
+                                .await
+                            {
+                                Ok(Some(user_record)) => {
+                                    if let Err(e) = app_services
+                                        .apply_subscription_limits(
+                                            &actual_user_id,
+                                            &update.subscription_tier,
+                                            &update.subscription_status,
+                                            user_record.is_admin,
+                                            user_record.trial_ends_at.clone(),
+                                            user_record.subscription_ends_at.clone(),
+                                        )
+                                        .await
+                                    {
+                                        tracing::error!(
+                                            "Failed to apply subscription limits for user {}: {}",
+                                            actual_user_id,
+                                            e
+                                        );
+                                        persistence_failed = true;
+                                    } else if user_record.is_admin {
+                                        tracing::info!(
+                                            "✅ Applied unlimited limits for admin user {}",
+                                            actual_user_id
+                                        );
+                                    } else {
+                                        tracing::info!(
+                                            "✅ Applied {} tier limits for user {}",
+                                            update.subscription_tier,
+                                            actual_user_id
+                                        );
+                                    }
+                                }
+                                Ok(None) => {
                                     tracing::error!(
-                                        "Failed to apply subscription limits for user {}: {}",
+                                        "User {} not found when applying limits",
+                                        actual_user_id
+                                    );
+                                    persistence_failed = true;
+                                }
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Failed to fetch user {} when applying limits: {}",
                                         actual_user_id,
                                         e
                                     );
                                     persistence_failed = true;
-                                } else if user_record.is_admin {
-                                    tracing::info!(
-                                        "✅ Applied unlimited limits for admin user {}",
-                                        actual_user_id
-                                    );
-                                } else {
-                                    tracing::info!(
-                                        "✅ Applied {} tier limits for user {}",
-                                        update.subscription_tier,
-                                        actual_user_id
-                                    );
                                 }
                             }
-                            Ok(None) => {
-                                tracing::error!(
-                                    "User {} not found when applying limits",
-                                    actual_user_id
-                                );
-                                persistence_failed = true;
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to fetch user {} when applying limits: {}",
-                                    actual_user_id,
-                                    e
-                                );
-                                persistence_failed = true;
-                            }
                         }
-                    }
-                }
-
-                if !persistence_failed {
-                    if let Err(e) = app_services
-                        .metadata_db
-                        .mark_stripe_event_applied(&actual_user_id, webhook_result.event_created)
-                        .await
-                    {
-                        tracing::error!("Failed to record Stripe webhook ordering state: {}", e);
-                        persistence_failed = true;
                     }
                 }
             }
 
             if persistence_failed {
                 tracing::error!("Webhook state update failed; returning an error for Stripe retry");
+                if let Err(e) = app_services
+                    .metadata_db
+                    .fail_stripe_webhook_event(&webhook_result.event_id)
+                    .await
+                {
+                    tracing::error!("Failed to release Stripe webhook claim: {}", e);
+                }
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ErrorResponse::new("Webhook state update failed")),
@@ -728,14 +759,17 @@ pub async fn handle_stripe_webhook(
 
             if let Err(e) = app_services
                 .metadata_db
-                .record_processed_stripe_event(
-                    &webhook_result.event_id,
-                    webhook_result.event_created,
-                    &webhook_result.event_type,
-                )
+                .complete_stripe_webhook_event(&webhook_result.event_id)
                 .await
             {
                 tracing::error!("Failed to record processed Stripe webhook: {}", e);
+                if let Err(e) = app_services
+                    .metadata_db
+                    .fail_stripe_webhook_event(&webhook_result.event_id)
+                    .await
+                {
+                    tracing::error!("Failed to release Stripe webhook claim: {}", e);
+                }
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ErrorResponse::new("Webhook state update failed")),

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -438,6 +438,34 @@ pub async fn handle_stripe_webhook(
         }
     };
 
+    let (claim_heartbeat, mut claim_heartbeat_stop) = tokio::sync::watch::channel(false);
+    let heartbeat_db = app_services.metadata_db.clone();
+    let heartbeat_event_id = verified_event.event_id.clone();
+    let heartbeat_claim_token = claim_token.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    match heartbeat_db
+                        .refresh_stripe_webhook_claim(&heartbeat_event_id, &heartbeat_claim_token)
+                        .await
+                    {
+                        Ok(true) => {}
+                        Ok(false) => break,
+                        Err(e) => tracing::error!("Failed to refresh Stripe webhook claim: {}", e),
+                    }
+                }
+                result = claim_heartbeat_stop.changed() => {
+                    if result.is_err() || *claim_heartbeat_stop.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
     // Side effects are safe only after this delivery owns the event claim.
     tracing::info!("🎣 Processing Stripe webhook");
     match stripe_billing
@@ -824,6 +852,7 @@ pub async fn handle_stripe_webhook(
             }
 
             tracing::info!("✅ Webhook processed successfully");
+            let _ = claim_heartbeat.send(true);
             (StatusCode::OK, "OK").into_response()
         }
         Err(e) => {

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -385,6 +385,26 @@ pub async fn handle_stripe_webhook(
         .await
     {
         Ok(webhook_result) => {
+            match app_services
+                .metadata_db
+                .has_processed_stripe_event(&webhook_result.event_id)
+                .await
+            {
+                Ok(true) => {
+                    tracing::info!(event_id = %webhook_result.event_id, "Ignoring duplicate Stripe webhook");
+                    return (StatusCode::OK, "OK").into_response();
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::error!("Failed to check Stripe webhook idempotency: {}", e);
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::new("Webhook state update failed")),
+                    )
+                        .into_response();
+                }
+            }
+
             // Process any subscription updates - no mutex blocking!
             let mut persistence_failed = false;
             for update in webhook_result.subscription_updates {
@@ -502,6 +522,27 @@ pub async fn handle_stripe_webhook(
                 } else {
                     update.user_id.clone()
                 };
+
+                match app_services
+                    .metadata_db
+                    .is_stripe_event_stale(&actual_user_id, webhook_result.event_created)
+                    .await
+                {
+                    Ok(true) => {
+                        tracing::info!(
+                            user_id = %actual_user_id,
+                            event_id = %webhook_result.event_id,
+                            "Ignoring stale Stripe webhook"
+                        );
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        tracing::error!("Failed to check Stripe webhook ordering: {}", e);
+                        persistence_failed = true;
+                        continue;
+                    }
+                }
 
                 // Handle special "keep_current" tier for cancellations
                 if update.subscription_tier == "keep_current" {
@@ -663,10 +704,38 @@ pub async fn handle_stripe_webhook(
                         }
                     }
                 }
+
+                if !persistence_failed {
+                    if let Err(e) = app_services
+                        .metadata_db
+                        .mark_stripe_event_applied(&actual_user_id, webhook_result.event_created)
+                        .await
+                    {
+                        tracing::error!("Failed to record Stripe webhook ordering state: {}", e);
+                        persistence_failed = true;
+                    }
+                }
             }
 
             if persistence_failed {
                 tracing::error!("Webhook state update failed; returning an error for Stripe retry");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("Webhook state update failed")),
+                )
+                    .into_response();
+            }
+
+            if let Err(e) = app_services
+                .metadata_db
+                .record_processed_stripe_event(
+                    &webhook_result.event_id,
+                    webhook_result.event_created,
+                    &webhook_result.event_type,
+                )
+                .await
+            {
+                tracing::error!("Failed to record processed Stripe webhook: {}", e);
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ErrorResponse::new("Webhook state update failed")),

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -454,7 +454,10 @@ pub async fn handle_stripe_webhook(
                         .await
                     {
                         Ok(true) => {}
-                        Ok(false) => break,
+                        Ok(false) => {
+                            let _ = heartbeat_failure.send(true);
+                            break;
+                        }
                         Err(e) => {
                             tracing::error!("Failed to refresh Stripe webhook claim: {}", e);
                             let _ = heartbeat_failure.send(true);

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -549,6 +549,21 @@ pub async fn handle_stripe_webhook(
                     update.user_id.clone()
                 };
 
+                // Stripe's event timestamps have second precision. Fetch the current
+                // subscription before applying events that can otherwise tie.
+                let update = if update.stripe_subscription_id.is_some() {
+                    match stripe_billing.reconcile_subscription_update(&update).await {
+                        Ok(update) => update,
+                        Err(e) => {
+                            tracing::error!("Failed to reconcile Stripe subscription state: {}", e);
+                            persistence_failed = true;
+                            continue;
+                        }
+                    }
+                } else {
+                    update
+                };
+
                 // Handle special "keep_current" tier for cancellations
                 if update.subscription_tier == "keep_current" {
                     let update_result = if update.subscription_status == "expired"

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -574,6 +574,36 @@ impl MetadataDb {
         .await?
     }
 
+    pub async fn trial_ending_email_was_sent(&self, event_id: &str) -> Result<bool> {
+        let pool = self.pool.clone();
+        let event_id = event_id.to_string();
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            Ok(conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM stripe_webhook_events WHERE id = ?1 AND trial_ending_email_sent_at IS NOT NULL)",
+                params![event_id],
+                |row| row.get(0),
+            )?)
+        })
+        .await?
+    }
+
+    pub async fn mark_trial_ending_email_sent(&self, event_id: &str) -> Result<bool> {
+        let pool = self.pool.clone();
+        let event_id = event_id.to_string();
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            Ok(conn.execute(
+                "UPDATE stripe_webhook_events SET trial_ending_email_sent_at = CURRENT_TIMESTAMP
+                 WHERE id = ?1 AND trial_ending_email_sent_at IS NULL",
+                params![event_id],
+            )? > 0)
+        })
+        .await?
+    }
+
     pub async fn update_user_subscription_status_for_stripe_event(
         &self,
         user_id: &str,
@@ -594,7 +624,7 @@ impl MetadataDb {
                 "UPDATE users SET subscription_status = ?1,
                     stripe_subscription_id = COALESCE(?2, stripe_subscription_id),
                     stripe_event_created = ?3, stripe_event_id = ?4
-                 WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created <= ?3)",
+                  WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created < ?3)",
                 params![
                     subscription_status,
                     stripe_subscription_id,
@@ -621,9 +651,8 @@ impl MetadataDb {
             let conn = pool.get()?;
             Ok(conn.execute(
                 "UPDATE users SET subscription_status = 'expired', stripe_subscription_id = NULL,
-                    stripe_event_created = ?1
-                    , stripe_event_id = ?2
-                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created <= ?1)",
+                    stripe_event_created = ?1, stripe_event_id = ?2
+                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created < ?1)",
                 params![event_created, event_id, user_id],
             )? > 0)
         })
@@ -654,7 +683,7 @@ impl MetadataDb {
                     stripe_subscription_id = ?3, subscription_started_at = ?4,
                     subscription_ends_at = ?5, trial_ends_at = COALESCE(?6, trial_ends_at),
                     stripe_event_created = ?7, stripe_event_id = ?8
-                 WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created <= ?7)",
+                  WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created < ?7)",
                 params![
                     subscription_tier,
                     subscription_status,

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -498,37 +498,44 @@ impl MetadataDb {
         event_id: &str,
         event_created: i64,
         event_type: &str,
-    ) -> Result<bool> {
+    ) -> Result<Option<String>> {
         let pool = self.pool.clone();
         let event_id = event_id.to_string();
         let event_type = event_type.to_string();
+        let claim_token = uuid::Uuid::new_v4().to_string();
 
-        spawn_blocking(move || -> Result<bool> {
+        spawn_blocking(move || -> Result<Option<String>> {
             let conn = pool.get()?;
-            Ok(conn.execute(
-                "INSERT INTO stripe_webhook_events (id, event_type, metadata, delivery_status, processing_started_at)
-                 VALUES (?1, ?2, ?3, 'processing', CURRENT_TIMESTAMP)
-                 ON CONFLICT(id) DO UPDATE SET delivery_status = 'processing', processing_started_at = CURRENT_TIMESTAMP
+            let claimed = conn.execute(
+                "INSERT INTO stripe_webhook_events (id, event_type, metadata, delivery_status, processing_started_at, claim_token)
+                 VALUES (?1, ?2, ?3, 'processing', CURRENT_TIMESTAMP, ?4)
+                 ON CONFLICT(id) DO UPDATE SET delivery_status = 'processing', processing_started_at = CURRENT_TIMESTAMP, claim_token = ?4
                  WHERE stripe_webhook_events.delivery_status = 'failed'
                     OR (stripe_webhook_events.delivery_status = 'processing'
                         AND stripe_webhook_events.processing_started_at < datetime('now', '-5 minutes'))",
-                params![event_id, event_type, format!("{{\"created\":{event_created}}}")],
-            )? > 0)
+                params![event_id, event_type, format!("{{\"created\":{event_created}}}"), claim_token],
+            )? > 0;
+            Ok(claimed.then_some(claim_token))
         })
         .await?
     }
 
-    pub async fn complete_stripe_webhook_event(&self, event_id: &str) -> Result<()> {
+    pub async fn complete_stripe_webhook_event(
+        &self,
+        event_id: &str,
+        claim_token: &str,
+    ) -> Result<bool> {
         let pool = self.pool.clone();
         let event_id = event_id.to_string();
+        let claim_token = claim_token.to_string();
 
-        spawn_blocking(move || -> Result<()> {
+        spawn_blocking(move || -> Result<bool> {
             let conn = pool.get()?;
-            conn.execute(
-                "UPDATE stripe_webhook_events SET delivery_status = 'completed', processed_at = CURRENT_TIMESTAMP WHERE id = ?1",
-                params![event_id],
-            )?;
-            Ok(())
+            Ok(conn.execute(
+                "UPDATE stripe_webhook_events SET delivery_status = 'completed', processed_at = CURRENT_TIMESTAMP
+                 WHERE id = ?1 AND claim_token = ?2",
+                params![event_id, claim_token],
+            )? > 0)
         })
         .await?
     }
@@ -548,17 +555,21 @@ impl MetadataDb {
         .await?
     }
 
-    pub async fn fail_stripe_webhook_event(&self, event_id: &str) -> Result<()> {
+    pub async fn fail_stripe_webhook_event(
+        &self,
+        event_id: &str,
+        claim_token: &str,
+    ) -> Result<bool> {
         let pool = self.pool.clone();
         let event_id = event_id.to_string();
+        let claim_token = claim_token.to_string();
 
-        spawn_blocking(move || -> Result<()> {
+        spawn_blocking(move || -> Result<bool> {
             let conn = pool.get()?;
-            conn.execute(
-                "UPDATE stripe_webhook_events SET delivery_status = 'failed' WHERE id = ?1",
-                params![event_id],
-            )?;
-            Ok(())
+            Ok(conn.execute(
+                "UPDATE stripe_webhook_events SET delivery_status = 'failed' WHERE id = ?1 AND claim_token = ?2",
+                params![event_id, claim_token],
+            )? > 0)
         })
         .await?
     }
@@ -569,23 +580,27 @@ impl MetadataDb {
         subscription_status: &str,
         stripe_subscription_id: Option<&str>,
         event_created: i64,
+        event_id: &str,
     ) -> Result<bool> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
         let subscription_status = subscription_status.to_string();
         let stripe_subscription_id = stripe_subscription_id.map(str::to_string);
+        let event_id = event_id.to_string();
 
         spawn_blocking(move || -> Result<bool> {
             let conn = pool.get()?;
             Ok(conn.execute(
                 "UPDATE users SET subscription_status = ?1,
                     stripe_subscription_id = COALESCE(?2, stripe_subscription_id),
-                    stripe_event_created = ?3
-                 WHERE id = ?4 AND (stripe_event_created IS NULL OR stripe_event_created <= ?3)",
+                    stripe_event_created = ?3, stripe_event_id = ?4
+                 WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created < ?3
+                    OR (stripe_event_created = ?3 AND stripe_event_id = ?4))",
                 params![
                     subscription_status,
                     stripe_subscription_id,
                     event_created,
+                    event_id,
                     user_id
                 ],
             )? > 0)
@@ -597,17 +612,21 @@ impl MetadataDb {
         &self,
         user_id: &str,
         event_created: i64,
+        event_id: &str,
     ) -> Result<bool> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
+        let event_id = event_id.to_string();
 
         spawn_blocking(move || -> Result<bool> {
             let conn = pool.get()?;
             Ok(conn.execute(
                 "UPDATE users SET subscription_status = 'expired', stripe_subscription_id = NULL,
                     stripe_event_created = ?1
-                 WHERE id = ?2 AND (stripe_event_created IS NULL OR stripe_event_created <= ?1)",
-                params![event_created, user_id],
+                    , stripe_event_id = ?2
+                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created < ?1
+                    OR (stripe_event_created = ?1 AND stripe_event_id = ?2))",
+                params![event_created, event_id, user_id],
             )? > 0)
         })
         .await?
@@ -618,6 +637,7 @@ impl MetadataDb {
         user_id: &str,
         params: &SubscriptionUpdateParams<'_>,
         event_created: i64,
+        event_id: &str,
     ) -> Result<bool> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
@@ -627,6 +647,7 @@ impl MetadataDb {
         let subscription_started_at = params.subscription_started_at.map(str::to_string);
         let subscription_ends_at = params.subscription_ends_at.map(str::to_string);
         let trial_ends_at = params.trial_ends_at.map(str::to_string);
+        let event_id = event_id.to_string();
 
         spawn_blocking(move || -> Result<bool> {
             let conn = pool.get()?;
@@ -634,8 +655,9 @@ impl MetadataDb {
                 "UPDATE users SET subscription_tier = ?1, subscription_status = ?2,
                     stripe_subscription_id = ?3, subscription_started_at = ?4,
                     subscription_ends_at = ?5, trial_ends_at = COALESCE(?6, trial_ends_at),
-                    stripe_event_created = ?7
-                 WHERE id = ?8 AND (stripe_event_created IS NULL OR stripe_event_created <= ?7)",
+                    stripe_event_created = ?7, stripe_event_id = ?8
+                 WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created < ?7
+                    OR (stripe_event_created = ?7 AND stripe_event_id = ?8))",
                 params![
                     subscription_tier,
                     subscription_status,
@@ -644,6 +666,7 @@ impl MetadataDb {
                     subscription_ends_at,
                     trial_ends_at,
                     event_created,
+                    event_id,
                     user_id
                 ],
             )? > 0)

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -493,6 +493,72 @@ impl MetadataDb {
         .await?
     }
 
+    pub async fn is_stripe_event_stale(&self, user_id: &str, event_created: i64) -> Result<bool> {
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            Ok(conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM users WHERE id = ?1 AND stripe_event_created > ?2)",
+                params![user_id, event_created],
+                |row| row.get(0),
+            )?)
+        })
+        .await?
+    }
+
+    pub async fn mark_stripe_event_applied(&self, user_id: &str, event_created: i64) -> Result<()> {
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+
+        spawn_blocking(move || -> Result<()> {
+            let conn = pool.get()?;
+            conn.execute(
+                "UPDATE users SET stripe_event_created = MAX(COALESCE(stripe_event_created, ?2), ?2) WHERE id = ?1",
+                params![user_id, event_created],
+            )?;
+            Ok(())
+        })
+        .await?
+    }
+
+    pub async fn has_processed_stripe_event(&self, event_id: &str) -> Result<bool> {
+        let pool = self.pool.clone();
+        let event_id = event_id.to_string();
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            Ok(conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM stripe_webhook_events WHERE id = ?1)",
+                params![event_id],
+                |row| row.get(0),
+            )?)
+        })
+        .await?
+    }
+
+    pub async fn record_processed_stripe_event(
+        &self,
+        event_id: &str,
+        event_created: i64,
+        event_type: &str,
+    ) -> Result<()> {
+        let pool = self.pool.clone();
+        let event_id = event_id.to_string();
+        let event_type = event_type.to_string();
+
+        spawn_blocking(move || -> Result<()> {
+            let conn = pool.get()?;
+            conn.execute(
+                "INSERT OR IGNORE INTO stripe_webhook_events (id, event_type, metadata) VALUES (?1, ?2, ?3)",
+                params![event_id, event_type, format!("{{\"created\":{event_created}}}")],
+            )?;
+            Ok(())
+        })
+        .await?
+    }
+
     pub async fn update_user_subscription(
         &self,
         user_id: &str,

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -624,7 +624,7 @@ impl MetadataDb {
                 "UPDATE users SET subscription_status = ?1,
                     stripe_subscription_id = COALESCE(?2, stripe_subscription_id),
                     stripe_event_created = ?3, stripe_event_id = ?4
-                  WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created < ?3)",
+                  WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created <= ?3)",
                 params![
                     subscription_status,
                     stripe_subscription_id,
@@ -652,7 +652,7 @@ impl MetadataDb {
             Ok(conn.execute(
                 "UPDATE users SET subscription_status = 'expired', stripe_subscription_id = NULL,
                     stripe_event_created = ?1, stripe_event_id = ?2
-                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created < ?1)",
+                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created <= ?1)",
                 params![event_created, event_id, user_id],
             )? > 0)
         })
@@ -683,7 +683,7 @@ impl MetadataDb {
                     stripe_subscription_id = ?3, subscription_started_at = ?4,
                     subscription_ends_at = ?5, trial_ends_at = COALESCE(?6, trial_ends_at),
                     stripe_event_created = ?7, stripe_event_id = ?8
-                  WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created < ?7)",
+                  WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created <= ?7)",
                 params![
                     subscription_tier,
                     subscription_status,

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -540,6 +540,26 @@ impl MetadataDb {
         .await?
     }
 
+    pub async fn refresh_stripe_webhook_claim(
+        &self,
+        event_id: &str,
+        claim_token: &str,
+    ) -> Result<bool> {
+        let pool = self.pool.clone();
+        let event_id = event_id.to_string();
+        let claim_token = claim_token.to_string();
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            Ok(conn.execute(
+                "UPDATE stripe_webhook_events SET processing_started_at = CURRENT_TIMESTAMP
+                 WHERE id = ?1 AND claim_token = ?2 AND delivery_status = 'processing'",
+                params![event_id, claim_token],
+            )? > 0)
+        })
+        .await?
+    }
+
     pub async fn is_stripe_webhook_event_complete(&self, event_id: &str) -> Result<bool> {
         let pool = self.pool.clone();
         let event_id = event_id.to_string();

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -594,8 +594,7 @@ impl MetadataDb {
                 "UPDATE users SET subscription_status = ?1,
                     stripe_subscription_id = COALESCE(?2, stripe_subscription_id),
                     stripe_event_created = ?3, stripe_event_id = ?4
-                 WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created < ?3
-                    OR (stripe_event_created = ?3 AND stripe_event_id = ?4))",
+                 WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created <= ?3)",
                 params![
                     subscription_status,
                     stripe_subscription_id,
@@ -624,8 +623,7 @@ impl MetadataDb {
                 "UPDATE users SET subscription_status = 'expired', stripe_subscription_id = NULL,
                     stripe_event_created = ?1
                     , stripe_event_id = ?2
-                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created < ?1
-                    OR (stripe_event_created = ?1 AND stripe_event_id = ?2))",
+                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created <= ?1)",
                 params![event_created, event_id, user_id],
             )? > 0)
         })
@@ -656,8 +654,7 @@ impl MetadataDb {
                     stripe_subscription_id = ?3, subscription_started_at = ?4,
                     subscription_ends_at = ?5, trial_ends_at = COALESCE(?6, trial_ends_at),
                     stripe_event_created = ?7, stripe_event_id = ?8
-                 WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created < ?7
-                    OR (stripe_event_created = ?7 AND stripe_event_id = ?8))",
+                 WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created <= ?7)",
                 params![
                     subscription_tier,
                     subscription_status,

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -611,6 +611,7 @@ impl MetadataDb {
         stripe_subscription_id: Option<&str>,
         event_created: i64,
         event_id: &str,
+        authoritative_same_timestamp: bool,
     ) -> Result<bool> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
@@ -624,13 +625,15 @@ impl MetadataDb {
                 "UPDATE users SET subscription_status = ?1,
                     stripe_subscription_id = COALESCE(?2, stripe_subscription_id),
                     stripe_event_created = ?3, stripe_event_id = ?4
-                  WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created <= ?3)",
+                  WHERE id = ?5 AND (stripe_event_created IS NULL OR stripe_event_created < ?3
+                    OR (stripe_event_created = ?3 AND (stripe_event_id = ?4 OR ?6)))",
                 params![
                     subscription_status,
                     stripe_subscription_id,
                     event_created,
                     event_id,
-                    user_id
+                    user_id,
+                    authoritative_same_timestamp
                 ],
             )? > 0)
         })
@@ -642,6 +645,7 @@ impl MetadataDb {
         user_id: &str,
         event_created: i64,
         event_id: &str,
+        authoritative_same_timestamp: bool,
     ) -> Result<bool> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
@@ -652,8 +656,14 @@ impl MetadataDb {
             Ok(conn.execute(
                 "UPDATE users SET subscription_status = 'expired', stripe_subscription_id = NULL,
                     stripe_event_created = ?1, stripe_event_id = ?2
-                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created <= ?1)",
-                params![event_created, event_id, user_id],
+                 WHERE id = ?3 AND (stripe_event_created IS NULL OR stripe_event_created < ?1
+                    OR (stripe_event_created = ?1 AND (stripe_event_id = ?2 OR ?4)))",
+                params![
+                    event_created,
+                    event_id,
+                    user_id,
+                    authoritative_same_timestamp
+                ],
             )? > 0)
         })
         .await?
@@ -665,6 +675,7 @@ impl MetadataDb {
         params: &SubscriptionUpdateParams<'_>,
         event_created: i64,
         event_id: &str,
+        authoritative_same_timestamp: bool,
     ) -> Result<bool> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
@@ -683,7 +694,8 @@ impl MetadataDb {
                     stripe_subscription_id = ?3, subscription_started_at = ?4,
                     subscription_ends_at = ?5, trial_ends_at = COALESCE(?6, trial_ends_at),
                     stripe_event_created = ?7, stripe_event_id = ?8
-                  WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created <= ?7)",
+                  WHERE id = ?9 AND (stripe_event_created IS NULL OR stripe_event_created < ?7
+                    OR (stripe_event_created = ?7 AND (stripe_event_id = ?8 OR ?10)))",
                 params![
                     subscription_tier,
                     subscription_status,
@@ -693,7 +705,8 @@ impl MetadataDb {
                     trial_ends_at,
                     event_created,
                     event_id,
-                    user_id
+                    user_id,
+                    authoritative_same_timestamp
                 ],
             )? > 0)
         })

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -493,44 +493,54 @@ impl MetadataDb {
         .await?
     }
 
-    pub async fn is_stripe_event_stale(&self, user_id: &str, event_created: i64) -> Result<bool> {
+    pub async fn claim_stripe_webhook_event(
+        &self,
+        event_id: &str,
+        event_created: i64,
+        event_type: &str,
+    ) -> Result<bool> {
         let pool = self.pool.clone();
-        let user_id = user_id.to_string();
+        let event_id = event_id.to_string();
+        let event_type = event_type.to_string();
 
         spawn_blocking(move || -> Result<bool> {
             let conn = pool.get()?;
-            Ok(conn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM users WHERE id = ?1 AND stripe_event_created > ?2)",
-                params![user_id, event_created],
-                |row| row.get(0),
-            )?)
+            Ok(conn.execute(
+                "INSERT INTO stripe_webhook_events (id, event_type, metadata, delivery_status, processing_started_at)
+                 VALUES (?1, ?2, ?3, 'processing', CURRENT_TIMESTAMP)
+                 ON CONFLICT(id) DO UPDATE SET delivery_status = 'processing', processing_started_at = CURRENT_TIMESTAMP
+                 WHERE stripe_webhook_events.delivery_status = 'failed'
+                    OR (stripe_webhook_events.delivery_status = 'processing'
+                        AND stripe_webhook_events.processing_started_at < datetime('now', '-5 minutes'))",
+                params![event_id, event_type, format!("{{\"created\":{event_created}}}")],
+            )? > 0)
         })
         .await?
     }
 
-    pub async fn mark_stripe_event_applied(&self, user_id: &str, event_created: i64) -> Result<()> {
+    pub async fn complete_stripe_webhook_event(&self, event_id: &str) -> Result<()> {
         let pool = self.pool.clone();
-        let user_id = user_id.to_string();
+        let event_id = event_id.to_string();
 
         spawn_blocking(move || -> Result<()> {
             let conn = pool.get()?;
             conn.execute(
-                "UPDATE users SET stripe_event_created = MAX(COALESCE(stripe_event_created, ?2), ?2) WHERE id = ?1",
-                params![user_id, event_created],
+                "UPDATE stripe_webhook_events SET delivery_status = 'completed', processed_at = CURRENT_TIMESTAMP WHERE id = ?1",
+                params![event_id],
             )?;
             Ok(())
         })
         .await?
     }
 
-    pub async fn has_processed_stripe_event(&self, event_id: &str) -> Result<bool> {
+    pub async fn is_stripe_webhook_event_complete(&self, event_id: &str) -> Result<bool> {
         let pool = self.pool.clone();
         let event_id = event_id.to_string();
 
         spawn_blocking(move || -> Result<bool> {
             let conn = pool.get()?;
             Ok(conn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM stripe_webhook_events WHERE id = ?1)",
+                "SELECT EXISTS(SELECT 1 FROM stripe_webhook_events WHERE id = ?1 AND delivery_status = 'completed')",
                 params![event_id],
                 |row| row.get(0),
             )?)
@@ -538,23 +548,105 @@ impl MetadataDb {
         .await?
     }
 
-    pub async fn record_processed_stripe_event(
-        &self,
-        event_id: &str,
-        event_created: i64,
-        event_type: &str,
-    ) -> Result<()> {
+    pub async fn fail_stripe_webhook_event(&self, event_id: &str) -> Result<()> {
         let pool = self.pool.clone();
         let event_id = event_id.to_string();
-        let event_type = event_type.to_string();
 
         spawn_blocking(move || -> Result<()> {
             let conn = pool.get()?;
             conn.execute(
-                "INSERT OR IGNORE INTO stripe_webhook_events (id, event_type, metadata) VALUES (?1, ?2, ?3)",
-                params![event_id, event_type, format!("{{\"created\":{event_created}}}")],
+                "UPDATE stripe_webhook_events SET delivery_status = 'failed' WHERE id = ?1",
+                params![event_id],
             )?;
             Ok(())
+        })
+        .await?
+    }
+
+    pub async fn update_user_subscription_status_for_stripe_event(
+        &self,
+        user_id: &str,
+        subscription_status: &str,
+        stripe_subscription_id: Option<&str>,
+        event_created: i64,
+    ) -> Result<bool> {
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        let subscription_status = subscription_status.to_string();
+        let stripe_subscription_id = stripe_subscription_id.map(str::to_string);
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            Ok(conn.execute(
+                "UPDATE users SET subscription_status = ?1,
+                    stripe_subscription_id = COALESCE(?2, stripe_subscription_id),
+                    stripe_event_created = ?3
+                 WHERE id = ?4 AND (stripe_event_created IS NULL OR stripe_event_created <= ?3)",
+                params![
+                    subscription_status,
+                    stripe_subscription_id,
+                    event_created,
+                    user_id
+                ],
+            )? > 0)
+        })
+        .await?
+    }
+
+    pub async fn expire_user_subscription_for_stripe_event(
+        &self,
+        user_id: &str,
+        event_created: i64,
+    ) -> Result<bool> {
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            Ok(conn.execute(
+                "UPDATE users SET subscription_status = 'expired', stripe_subscription_id = NULL,
+                    stripe_event_created = ?1
+                 WHERE id = ?2 AND (stripe_event_created IS NULL OR stripe_event_created <= ?1)",
+                params![event_created, user_id],
+            )? > 0)
+        })
+        .await?
+    }
+
+    pub async fn update_user_subscription_for_stripe_event(
+        &self,
+        user_id: &str,
+        params: &SubscriptionUpdateParams<'_>,
+        event_created: i64,
+    ) -> Result<bool> {
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        let subscription_tier = params.subscription_tier.to_string();
+        let subscription_status = params.subscription_status.to_string();
+        let stripe_subscription_id = params.stripe_subscription_id.map(str::to_string);
+        let subscription_started_at = params.subscription_started_at.map(str::to_string);
+        let subscription_ends_at = params.subscription_ends_at.map(str::to_string);
+        let trial_ends_at = params.trial_ends_at.map(str::to_string);
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            Ok(conn.execute(
+                "UPDATE users SET subscription_tier = ?1, subscription_status = ?2,
+                    stripe_subscription_id = ?3, subscription_started_at = ?4,
+                    subscription_ends_at = ?5, trial_ends_at = COALESCE(?6, trial_ends_at),
+                    stripe_event_created = ?7
+                 WHERE id = ?8 AND (stripe_event_created IS NULL OR stripe_event_created <= ?7)",
+                params![
+                    subscription_tier,
+                    subscription_status,
+                    stripe_subscription_id,
+                    subscription_started_at,
+                    subscription_ends_at,
+                    trial_ends_at,
+                    event_created,
+                    user_id
+                ],
+            )? > 0)
         })
         .await?
     }

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -16,6 +16,13 @@ pub struct WebhookResult {
 }
 
 #[derive(Debug, Clone)]
+pub struct VerifiedWebhookEvent {
+    pub event_id: String,
+    pub event_created: i64,
+    pub event_type: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct SubscriptionUpdate {
     pub user_id: String,
     pub subscription_tier: String,
@@ -84,6 +91,35 @@ pub struct FrontendPriceInfo {
 }
 
 impl StripeBilling {
+    pub async fn verify_webhook_event(
+        &self,
+        payload: &[u8],
+        signature: &str,
+    ) -> Result<VerifiedWebhookEvent> {
+        let payload_str = std::str::from_utf8(payload)?;
+        self.client
+            .parse_webhook_event(payload_str, signature, &self.webhook_secret)
+            .await?;
+        let event_metadata: serde_json::Value = serde_json::from_str(payload_str)?;
+        Ok(VerifiedWebhookEvent {
+            event_id: event_metadata
+                .get("id")
+                .and_then(|id| id.as_str())
+                .ok_or_else(|| anyhow::anyhow!("Stripe webhook event is missing an ID"))?
+                .to_string(),
+            event_created: event_metadata
+                .get("created")
+                .and_then(|created| created.as_i64())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Stripe webhook event is missing a creation time")
+                })?,
+            event_type: event_metadata
+                .get("type")
+                .and_then(|event_type| event_type.as_str())
+                .ok_or_else(|| anyhow::anyhow!("Stripe webhook event is missing a type"))?
+                .to_string(),
+        })
+    }
     pub async fn reconcile_subscription_update(
         &self,
         update: &SubscriptionUpdate,

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -9,6 +9,9 @@ use crate::subscription::SubscriptionTier;
 
 #[derive(Debug, Clone)]
 pub struct WebhookResult {
+    pub event_id: String,
+    pub event_created: i64,
+    pub event_type: String,
     pub subscription_updates: Vec<SubscriptionUpdate>,
 }
 
@@ -624,6 +627,21 @@ impl StripeBilling {
             .client
             .parse_webhook_event(payload_str, signature, &self.webhook_secret)
             .await?;
+        let event_metadata: serde_json::Value = serde_json::from_str(payload_str)?;
+        let event_id = event_metadata
+            .get("id")
+            .and_then(|id| id.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Stripe webhook event is missing an ID"))?
+            .to_string();
+        let event_created = event_metadata
+            .get("created")
+            .and_then(|created| created.as_i64())
+            .ok_or_else(|| anyhow::anyhow!("Stripe webhook event is missing a creation time"))?;
+        let event_type = event_metadata
+            .get("type")
+            .and_then(|event_type| event_type.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Stripe webhook event is missing a type"))?
+            .to_string();
 
         let mut updates = Vec::new();
 
@@ -1159,6 +1177,9 @@ impl StripeBilling {
         }
 
         Ok(WebhookResult {
+            event_id,
+            event_created,
+            event_type,
             subscription_updates: updates,
         })
     }

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -807,10 +807,10 @@ impl StripeBilling {
                                                         );
                                                     }
                                                     Err(e) => {
-                                                        tracing::warn!(
-                                                            "⚠️  Email service not configured, skipping trial ending notification: {}",
+                                                        return Err(anyhow::anyhow!(
+                                                            "Email service not configured: {}",
                                                             e
-                                                        );
+                                                        ));
                                                     }
                                                 }
                                             }

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -1117,8 +1117,8 @@ impl StripeBilling {
                                 if let (Some(customer_id), Some(deleted_subscription_id)) =
                                     (customer_id, deleted_subscription_id)
                                 {
-                                    // Reconcile the deleted subscription against Stripe before
-                                    // updating entitlements, including same-second event ties.
+                                    // The API layer conditionally expires only the subscription
+                                    // currently attached to this customer.
                                     let update = SubscriptionUpdate {
                                         user_id: format!(
                                             "stripe_customer:{}:{}",
@@ -1126,9 +1126,7 @@ impl StripeBilling {
                                         ),
                                         subscription_tier: "keep_current".to_string(),
                                         subscription_status: "expired".to_string(),
-                                        stripe_subscription_id: Some(
-                                            deleted_subscription_id.to_string(),
-                                        ),
+                                        stripe_subscription_id: None,
                                         subscription_started_at: None,
                                         subscription_ends_at: Some(chrono::Utc::now().to_rfc3339()),
                                         trial_ends_at: None,

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -84,6 +84,30 @@ pub struct FrontendPriceInfo {
 }
 
 impl StripeBilling {
+    pub async fn reconcile_subscription_update(
+        &self,
+        update: &SubscriptionUpdate,
+    ) -> Result<SubscriptionUpdate> {
+        let subscription_id = update
+            .stripe_subscription_id
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("Cannot reconcile a deleted subscription"))?;
+        let subscription = self.client.get_subscription_json(subscription_id).await?;
+        let status = subscription
+            .get("status")
+            .and_then(|status| status.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Stripe subscription is missing a status"))?;
+
+        Ok(SubscriptionUpdate {
+            user_id: update.user_id.clone(),
+            subscription_tier: self.determine_tier_from_subscription_items(&subscription),
+            subscription_status: status.to_string(),
+            stripe_subscription_id: Some(subscription_id.to_string()),
+            subscription_started_at: update.subscription_started_at.clone(),
+            subscription_ends_at: update.subscription_ends_at.clone(),
+            trial_ends_at: update.trial_ends_at.clone(),
+        })
+    }
     pub async fn new(metadata_db: Arc<MetadataDb>) -> Result<Self> {
         let secret_key = std::env::var("STRIPE_SECRET_KEY")
             .map_err(|_| anyhow::anyhow!("STRIPE_SECRET_KEY environment variable not set"))?;

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -147,6 +147,11 @@ impl StripeBilling {
             .and_then(|items| items.first())
             .and_then(|item| item.get("current_period_end"))
             .and_then(|value| value.as_i64())
+            .or_else(|| {
+                subscription
+                    .get("current_period_end")
+                    .and_then(|value| value.as_i64())
+            })
             .and_then(|value| chrono::DateTime::from_timestamp(value, 0))
             .map(|value| value.to_rfc3339());
 

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -133,15 +133,31 @@ impl StripeBilling {
             .get("status")
             .and_then(|status| status.as_str())
             .ok_or_else(|| anyhow::anyhow!("Stripe subscription is missing a status"))?;
+        let timestamp = |field: &str| {
+            subscription
+                .get(field)
+                .and_then(|value| value.as_i64())
+                .and_then(|value| chrono::DateTime::from_timestamp(value, 0))
+                .map(|value| value.to_rfc3339())
+        };
+        let period_end = subscription
+            .get("items")
+            .and_then(|items| items.get("data"))
+            .and_then(|data| data.as_array())
+            .and_then(|items| items.first())
+            .and_then(|item| item.get("current_period_end"))
+            .and_then(|value| value.as_i64())
+            .and_then(|value| chrono::DateTime::from_timestamp(value, 0))
+            .map(|value| value.to_rfc3339());
 
         Ok(SubscriptionUpdate {
             user_id: update.user_id.clone(),
             subscription_tier: self.determine_tier_from_subscription_items(&subscription),
             subscription_status: status.to_string(),
             stripe_subscription_id: Some(subscription_id.to_string()),
-            subscription_started_at: update.subscription_started_at.clone(),
-            subscription_ends_at: update.subscription_ends_at.clone(),
-            trial_ends_at: update.trial_ends_at.clone(),
+            subscription_started_at: timestamp("created"),
+            subscription_ends_at: timestamp("cancel_at").or(period_end),
+            trial_ends_at: timestamp("trial_end"),
         })
     }
     pub async fn new(metadata_db: Arc<MetadataDb>) -> Result<Self> {

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -746,43 +746,51 @@ impl StripeBilling {
                                             let user_name =
                                                 user.name.as_deref().unwrap_or(&user.email);
 
-                                            // Attempt to send email notification
-                                            use crate::email_service::EmailService;
-                                            let user_language = user
-                                                .preferred_language
-                                                .as_deref()
-                                                .unwrap_or("en-US");
-                                            match EmailService::from_env() {
-                                                Ok(email_service) => {
-                                                    match email_service
-                                                        .send_trial_ending_notification(
-                                                            &user.email,
-                                                            user_name,
-                                                            &trial_ends_at,
-                                                            user_language,
-                                                        )
-                                                        .await
-                                                    {
-                                                        Ok(_) => {
-                                                            tracing::info!(
-                                                                "✅ Trial ending notification sent to {}",
-                                                                user.email
-                                                            );
-                                                        }
-                                                        Err(e) => {
-                                                            tracing::error!(
-                                                                "❌ Failed to send trial ending notification to {}: {}",
-                                                                user.email,
-                                                                e
-                                                            );
-                                                        }
+                                            if self
+                                                .metadata_db
+                                                .trial_ending_email_was_sent(&event_id)
+                                                .await?
+                                            {
+                                                tracing::info!(
+                                                    "Trial ending notification already sent for event {}",
+                                                    event_id
+                                                );
+                                            } else {
+                                                // Resend deduplicates this key if a previous attempt sent
+                                                // the email before its database completion marker was written.
+                                                use crate::email_service::EmailService;
+                                                let user_language = user
+                                                    .preferred_language
+                                                    .as_deref()
+                                                    .unwrap_or("en-US");
+                                                match EmailService::from_env() {
+                                                    Ok(email_service) => {
+                                                        email_service
+                                                            .send_trial_ending_notification(
+                                                                &user.email,
+                                                                user_name,
+                                                                &trial_ends_at,
+                                                                user_language,
+                                                                &format!(
+                                                                    "stripe-trial-will-end-{}",
+                                                                    event_id
+                                                                ),
+                                                            )
+                                                            .await?;
+                                                        self.metadata_db
+                                                            .mark_trial_ending_email_sent(&event_id)
+                                                            .await?;
+                                                        tracing::info!(
+                                                            "✅ Trial ending notification sent to {}",
+                                                            user.email
+                                                        );
                                                     }
-                                                }
-                                                Err(e) => {
-                                                    tracing::warn!(
-                                                        "⚠️  Email service not configured, skipping trial ending notification: {}",
-                                                        e
-                                                    );
+                                                    Err(e) => {
+                                                        tracing::warn!(
+                                                            "⚠️  Email service not configured, skipping trial ending notification: {}",
+                                                            e
+                                                        );
+                                                    }
                                                 }
                                             }
                                         }
@@ -1109,7 +1117,8 @@ impl StripeBilling {
                                 if let (Some(customer_id), Some(deleted_subscription_id)) =
                                     (customer_id, deleted_subscription_id)
                                 {
-                                    // Create a conditional update that the API layer will verify
+                                    // Reconcile the deleted subscription against Stripe before
+                                    // updating entitlements, including same-second event ties.
                                     let update = SubscriptionUpdate {
                                         user_id: format!(
                                             "stripe_customer:{}:{}",
@@ -1117,7 +1126,9 @@ impl StripeBilling {
                                         ),
                                         subscription_tier: "keep_current".to_string(),
                                         subscription_status: "expired".to_string(),
-                                        stripe_subscription_id: None, // Clear subscription ID
+                                        stripe_subscription_id: Some(
+                                            deleted_subscription_id.to_string(),
+                                        ),
                                         subscription_started_at: None,
                                         subscription_ends_at: Some(chrono::Utc::now().to_rfc3339()),
                                         trial_ends_at: None,

--- a/backend/src/stripe_billing.rs
+++ b/backend/src/stripe_billing.rs
@@ -15,6 +15,24 @@ pub struct WebhookResult {
     pub subscription_updates: Vec<SubscriptionUpdate>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::subscription_status_from_snapshot;
+
+    #[test]
+    fn scheduled_cancellation_overrides_active_snapshot_status() {
+        let subscription = serde_json::json!({
+            "status": "active",
+            "cancel_at_period_end": true
+        });
+
+        assert_eq!(
+            subscription_status_from_snapshot(&subscription).unwrap(),
+            "canceled"
+        );
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct VerifiedWebhookEvent {
     pub event_id: String,
@@ -31,6 +49,22 @@ pub struct SubscriptionUpdate {
     pub subscription_started_at: Option<String>,
     pub subscription_ends_at: Option<String>,
     pub trial_ends_at: Option<String>,
+}
+
+fn subscription_status_from_snapshot(subscription: &serde_json::Value) -> Result<String> {
+    if subscription
+        .get("cancel_at_period_end")
+        .and_then(|value| value.as_bool())
+        == Some(true)
+    {
+        return Ok("canceled".to_string());
+    }
+
+    subscription
+        .get("status")
+        .and_then(|status| status.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("Stripe subscription is missing a status"))
 }
 
 /// New Stripe billing service using our custom client with 2025 API
@@ -129,10 +163,7 @@ impl StripeBilling {
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("Cannot reconcile a deleted subscription"))?;
         let subscription = self.client.get_subscription_json(subscription_id).await?;
-        let status = subscription
-            .get("status")
-            .and_then(|status| status.as_str())
-            .ok_or_else(|| anyhow::anyhow!("Stripe subscription is missing a status"))?;
+        let status = subscription_status_from_snapshot(&subscription)?;
         let timestamp = |field: &str| {
             subscription
                 .get(field)
@@ -158,7 +189,7 @@ impl StripeBilling {
         Ok(SubscriptionUpdate {
             user_id: update.user_id.clone(),
             subscription_tier: self.determine_tier_from_subscription_items(&subscription),
-            subscription_status: status.to_string(),
+            subscription_status: status,
             stripe_subscription_id: Some(subscription_id.to_string()),
             subscription_started_at: timestamp("created"),
             subscription_ends_at: timestamp("cancel_at").or(period_end),

--- a/backend/src/stripe_client_service.rs
+++ b/backend/src/stripe_client_service.rs
@@ -419,6 +419,24 @@ impl StripeClientService {
         Ok(subscription)
     }
 
+    pub async fn get_subscription_json(&self, subscription_id: &str) -> Result<serde_json::Value> {
+        let url = format!(
+            "https://api.stripe.com/v1/subscriptions/{}",
+            subscription_id
+        );
+        let response = self
+            .add_stripe_headers(self.client.get(&url))
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Stripe get subscription failed: {}",
+                response.text().await?
+            ));
+        }
+        Ok(response.json().await?)
+    }
+
     pub async fn create_subscription(
         &self,
         customer_id: String,

--- a/backend/src/subscription.rs
+++ b/backend/src/subscription.rs
@@ -178,10 +178,15 @@ impl std::fmt::Display for LimitError {
 impl std::error::Error for LimitError {}
 
 /// Parse a datetime string and check if it's in the future
-fn is_future_datetime(date_str: &str) -> Option<bool> {
-    chrono::NaiveDateTime::parse_from_str(date_str, "%Y-%m-%d %H:%M:%S")
+fn parse_datetime(date_str: &str) -> Option<chrono::NaiveDateTime> {
+    chrono::DateTime::parse_from_rfc3339(date_str)
         .ok()
-        .map(|dt| dt > chrono::Utc::now().naive_utc())
+        .map(|dt| dt.naive_utc())
+        .or_else(|| chrono::NaiveDateTime::parse_from_str(date_str, "%Y-%m-%d %H:%M:%S").ok())
+}
+
+fn is_future_datetime(date_str: &str) -> Option<bool> {
+    parse_datetime(date_str).map(|dt| dt > chrono::Utc::now().naive_utc())
 }
 
 /// Check if a subscription is currently active
@@ -225,9 +230,7 @@ pub fn get_effective_subscription_status(
 ) -> String {
     if subscription_status == "trialing" {
         if let Some(trial_ends_at_str) = trial_ends_at {
-            if let Ok(trial_ends_at) =
-                chrono::NaiveDateTime::parse_from_str(trial_ends_at_str, "%Y-%m-%d %H:%M:%S")
-            {
+            if let Some(trial_ends_at) = parse_datetime(trial_ends_at_str) {
                 let now = chrono::Utc::now().naive_utc();
                 if trial_ends_at < now {
                     return "expired".to_string();
@@ -309,6 +312,18 @@ mod tests {
         let past_date = chrono::Utc::now().naive_utc() - chrono::Duration::days(30);
         let past_str = past_date.format("%Y-%m-%d %H:%M:%S").to_string();
         assert!(!is_subscription_active("trialing", Some(&past_str), None));
+    }
+
+    #[test]
+    fn test_subscription_dates_accept_rfc3339() {
+        let future = (chrono::Utc::now() + chrono::Duration::days(1)).to_rfc3339();
+        let past = (chrono::Utc::now() - chrono::Duration::days(1)).to_rfc3339();
+
+        assert!(is_subscription_active("trialing", Some(&future), None));
+        assert_eq!(
+            get_effective_subscription_status("trialing", Some(&past)),
+            "expired"
+        );
     }
 
     #[test]

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2270,7 +2270,10 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
         db.claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated"),
         db.claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated"),
     );
-    let claim_token = first_claim.unwrap().or(duplicate_claim.unwrap()).unwrap();
+    let first_claim = first_claim.unwrap();
+    let duplicate_claim = duplicate_claim.unwrap();
+    assert_ne!(first_claim.is_some(), duplicate_claim.is_some());
+    let claim_token = first_claim.or(duplicate_claim).unwrap();
     assert!(db
         .complete_stripe_webhook_event("evt_1", &claim_token)
         .await

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2250,3 +2250,30 @@ async fn expiring_subscription_clears_stripe_id_without_changing_tier() {
     assert_eq!(user.subscription_status, "expired");
     assert_eq!(user.stripe_subscription_id, None);
 }
+
+#[tokio::test]
+async fn stripe_webhook_events_are_idempotent_and_ordered() {
+    let (db, _temp_dir) = create_test_db().await;
+    let user_id = db
+        .create_user(
+            "subscriber@example.com",
+            "hashedpassword",
+            None,
+            true,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(!db.has_processed_stripe_event("evt_1").await.unwrap());
+    db.record_processed_stripe_event("evt_1", 200, "customer.subscription.updated")
+        .await
+        .unwrap();
+    assert!(db.has_processed_stripe_event("evt_1").await.unwrap());
+
+    assert!(!db.is_stripe_event_stale(&user_id, 200).await.unwrap());
+    db.mark_stripe_event_applied(&user_id, 200).await.unwrap();
+    assert!(db.is_stripe_event_stale(&user_id, 199).await.unwrap());
+    assert!(!db.is_stripe_event_stale(&user_id, 200).await.unwrap());
+}

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2329,11 +2329,11 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
     let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
     assert_eq!(user.subscription_tier.as_str(), "personal");
     assert_eq!(user.subscription_status, "active");
-    assert!(!db
+    assert!(db
         .update_user_subscription_for_stripe_event(&user_id, &older, 200, "evt_same_second")
         .await
         .unwrap());
-    assert!(!db
+    assert!(db
         .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_newer")
         .await
         .unwrap());

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2319,22 +2319,22 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
         trial_ends_at: None,
     };
     assert!(db
-        .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_newer")
+        .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_newer", false)
         .await
         .unwrap());
     assert!(!db
-        .update_user_subscription_for_stripe_event(&user_id, &older, 199, "evt_older")
+        .update_user_subscription_for_stripe_event(&user_id, &older, 199, "evt_older", false)
         .await
         .unwrap());
     let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
     assert_eq!(user.subscription_tier.as_str(), "personal");
     assert_eq!(user.subscription_status, "active");
     assert!(db
-        .update_user_subscription_for_stripe_event(&user_id, &older, 200, "evt_same_second")
+        .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_reconciled", true,)
         .await
         .unwrap());
     assert!(db
-        .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_newer")
+        .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_reconciled", false)
         .await
         .unwrap());
 

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2275,6 +2275,14 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
     assert_ne!(first_claim.is_some(), duplicate_claim.is_some());
     let claim_token = first_claim.or(duplicate_claim).unwrap();
     assert!(db
+        .refresh_stripe_webhook_claim("evt_1", &claim_token)
+        .await
+        .unwrap());
+    assert!(!db
+        .refresh_stripe_webhook_claim("evt_1", "wrong-token")
+        .await
+        .unwrap());
+    assert!(db
         .complete_stripe_webhook_event("evt_1", &claim_token)
         .await
         .unwrap());

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2297,6 +2297,11 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
         .unwrap()
         .is_some());
 
+    assert!(!db.trial_ending_email_was_sent("evt_failed").await.unwrap());
+    assert!(db.mark_trial_ending_email_sent("evt_failed").await.unwrap());
+    assert!(db.trial_ending_email_was_sent("evt_failed").await.unwrap());
+    assert!(!db.mark_trial_ending_email_sent("evt_failed").await.unwrap());
+
     let newer = SubscriptionUpdateParams {
         subscription_tier: "personal",
         subscription_status: "active",
@@ -2324,12 +2329,16 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
     let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
     assert_eq!(user.subscription_tier.as_str(), "personal");
     assert_eq!(user.subscription_status, "active");
-    assert!(db
+    assert!(!db
         .update_user_subscription_for_stripe_event(&user_id, &older, 200, "evt_same_second")
         .await
         .unwrap());
-    assert!(db
+    assert!(!db
         .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_newer")
         .await
         .unwrap());
+
+    let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
+    assert_eq!(user.subscription_tier.as_str(), "personal");
+    assert_eq!(user.subscription_status, "active");
 }

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2266,14 +2266,43 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
         .await
         .unwrap();
 
-    assert!(!db.has_processed_stripe_event("evt_1").await.unwrap());
-    db.record_processed_stripe_event("evt_1", 200, "customer.subscription.updated")
+    let (first_claim, duplicate_claim) = tokio::join!(
+        db.claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated"),
+        db.claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated"),
+    );
+    assert_ne!(first_claim.unwrap(), duplicate_claim.unwrap());
+    db.complete_stripe_webhook_event("evt_1").await.unwrap();
+    assert!(db.is_stripe_webhook_event_complete("evt_1").await.unwrap());
+    assert!(!db
+        .claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated")
         .await
-        .unwrap();
-    assert!(db.has_processed_stripe_event("evt_1").await.unwrap());
+        .unwrap());
 
-    assert!(!db.is_stripe_event_stale(&user_id, 200).await.unwrap());
-    db.mark_stripe_event_applied(&user_id, 200).await.unwrap();
-    assert!(db.is_stripe_event_stale(&user_id, 199).await.unwrap());
-    assert!(!db.is_stripe_event_stale(&user_id, 200).await.unwrap());
+    let newer = SubscriptionUpdateParams {
+        subscription_tier: "personal",
+        subscription_status: "active",
+        stripe_subscription_id: Some("sub_new"),
+        subscription_started_at: None,
+        subscription_ends_at: None,
+        trial_ends_at: None,
+    };
+    let older = SubscriptionUpdateParams {
+        subscription_tier: "team",
+        subscription_status: "expired",
+        stripe_subscription_id: None,
+        subscription_started_at: None,
+        subscription_ends_at: None,
+        trial_ends_at: None,
+    };
+    assert!(db
+        .update_user_subscription_for_stripe_event(&user_id, &newer, 200)
+        .await
+        .unwrap());
+    assert!(!db
+        .update_user_subscription_for_stripe_event(&user_id, &older, 199)
+        .await
+        .unwrap());
+    let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
+    assert_eq!(user.subscription_tier.as_str(), "personal");
+    assert_eq!(user.subscription_status, "active");
 }

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2270,13 +2270,32 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
         db.claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated"),
         db.claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated"),
     );
-    assert_ne!(first_claim.unwrap(), duplicate_claim.unwrap());
-    db.complete_stripe_webhook_event("evt_1").await.unwrap();
-    assert!(db.is_stripe_webhook_event_complete("evt_1").await.unwrap());
-    assert!(!db
-        .claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated")
+    let claim_token = first_claim.unwrap().or(duplicate_claim.unwrap()).unwrap();
+    assert!(db
+        .complete_stripe_webhook_event("evt_1", &claim_token)
         .await
         .unwrap());
+    assert!(db.is_stripe_webhook_event_complete("evt_1").await.unwrap());
+    assert!(db
+        .claim_stripe_webhook_event("evt_1", 200, "customer.subscription.updated")
+        .await
+        .unwrap()
+        .is_none());
+
+    let failed_claim = db
+        .claim_stripe_webhook_event("evt_failed", 200, "customer.subscription.updated")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(db
+        .fail_stripe_webhook_event("evt_failed", &failed_claim)
+        .await
+        .unwrap());
+    assert!(db
+        .claim_stripe_webhook_event("evt_failed", 200, "customer.subscription.updated")
+        .await
+        .unwrap()
+        .is_some());
 
     let newer = SubscriptionUpdateParams {
         subscription_tier: "personal",
@@ -2295,14 +2314,22 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
         trial_ends_at: None,
     };
     assert!(db
-        .update_user_subscription_for_stripe_event(&user_id, &newer, 200)
+        .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_newer")
         .await
         .unwrap());
     assert!(!db
-        .update_user_subscription_for_stripe_event(&user_id, &older, 199)
+        .update_user_subscription_for_stripe_event(&user_id, &older, 199, "evt_older")
         .await
         .unwrap());
     let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
     assert_eq!(user.subscription_tier.as_str(), "personal");
     assert_eq!(user.subscription_status, "active");
+    assert!(!db
+        .update_user_subscription_for_stripe_event(&user_id, &older, 200, "evt_same_second")
+        .await
+        .unwrap());
+    assert!(db
+        .update_user_subscription_for_stripe_event(&user_id, &newer, 200, "evt_newer")
+        .await
+        .unwrap());
 }

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2324,7 +2324,7 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
     let user = db.get_user_by_id(&user_id).await.unwrap().unwrap();
     assert_eq!(user.subscription_tier.as_str(), "personal");
     assert_eq!(user.subscription_status, "active");
-    assert!(!db
+    assert!(db
         .update_user_subscription_for_stripe_event(&user_id, &older, 200, "evt_same_second")
         .await
         .unwrap());


### PR DESCRIPTION
## Summary\n\n- persist completed Stripe event IDs and acknowledge duplicate deliveries without replaying state\n- track the latest Stripe event timestamp per user to ignore stale entitlement updates\n- add coverage for duplicate and out-of-order event tracking\n\nCloses #452.\n\n## Validation\n\n- 