### PR TITLE
fix: harden authentication abuse controls

### DIFF
--- a/backend/.env.example.cloud
+++ b/backend/.env.example.cloud
@@ -16,6 +16,9 @@ CANARY_MODE=cloud
 CANARY_NETWORK=mainnet
 CANARY_ELECTRUM_URL=ssl://electrum.blockstream.info:50002
 CANARY_BIND_ADDRESS=0.0.0.0:3000
+# Comma-separated reverse-proxy addresses allowed to supply X-Forwarded-For.
+# Leave unset when Canary is exposed directly.
+CANARY_TRUSTED_PROXY_IPS=
 
 # Storage Configuration
 CANARY_DATA_DIR=./database/cloud

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -9,6 +9,7 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 use reqwest::Client;
 use serde::{Deserialize, Deserializer, Serialize};
 use sha2::{Digest, Sha256};
+use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
@@ -193,6 +194,14 @@ pub const DEMO_USER_EMAIL: &str = "demo@canarybitcoin.com";
 // Dev mode password for all test accounts
 pub const DEV_TEST_PASSWORD: &str = "password123";
 
+static DUMMY_PASSWORD_HASH: LazyLock<String> = LazyLock::new(|| {
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(b"canary-dummy-password", &salt)
+        .expect("dummy password hash generation must succeed")
+        .to_string()
+});
+
 pub struct AuthService {
     jwt_secret: String,
     client: Client,
@@ -226,6 +235,14 @@ impl AuthService {
             Ok(()) => Ok(true),
             Err(_) => Ok(false),
         }
+    }
+
+    pub fn verify_dummy_password(password: &str) -> Result<bool> {
+        let parsed_hash = PasswordHash::new(&DUMMY_PASSWORD_HASH)
+            .map_err(|e| anyhow!("Invalid dummy password hash: {}", e))?;
+        Ok(Argon2::default()
+            .verify_password(password.as_bytes(), &parsed_hash)
+            .is_ok())
     }
 
     pub fn generate_verification_token(&self) -> String {

--- a/backend/src/email_service.rs
+++ b/backend/src/email_service.rs
@@ -506,6 +506,7 @@ Your verification code is: {otp_code}
     }
 
     /// Send account locked notification email
+    #[allow(dead_code)] // Account lockouts are replaced by per-IP throttling.
     pub async fn send_account_locked(
         &self,
         to_email: &str,

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -39,6 +39,8 @@ const FORGOT_PASSWORD_SUCCESS_MESSAGE: &str =
 const MIN_PASSWORD_LENGTH: usize = 12;
 const MAX_AUTH_REQUESTS_PER_IP: i64 = 10;
 const AUTH_IP_RATE_LIMIT_WINDOW_MINUTES: i64 = 15;
+const MAX_FAILED_LOGIN_ATTEMPTS_PER_EMAIL: i64 = 50;
+const FAILED_LOGIN_EMAIL_RATE_LIMIT_WINDOW_MINUTES: i64 = 60;
 const MAX_CONTACT_REQUESTS_PER_IP: i64 = 3;
 const CONTACT_RATE_LIMIT_WINDOW_MINUTES: i64 = 60;
 
@@ -125,6 +127,44 @@ async fn enforce_ip_rate_limit(
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("Failed to validate request rate limit")),
+            )
+                .into_response())
+        }
+    }
+}
+
+async fn enforce_failed_login_email_rate_limit(
+    app_services: &AppServicesState,
+    email: &str,
+) -> Result<(), Response> {
+    match app_services
+        .metadata_db
+        .check_auth_rate_limit(
+            "login_email",
+            email,
+            MAX_FAILED_LOGIN_ATTEMPTS_PER_EMAIL,
+            FAILED_LOGIN_EMAIL_RATE_LIMIT_WINDOW_MINUTES,
+        )
+        .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            [(
+                header::RETRY_AFTER,
+                (FAILED_LOGIN_EMAIL_RATE_LIMIT_WINDOW_MINUTES * 60).to_string(),
+            )],
+            Json(ErrorResponse::coded(
+                "invalid_credentials",
+                "Invalid credentials",
+            )),
+        )
+            .into_response()),
+        Err(e) => {
+            tracing::error!("Failed to check login email rate limit: {}", e);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("Failed to validate login rate limit")),
             )
                 .into_response())
         }
@@ -644,6 +684,11 @@ pub async fn login(
             {
                 return response;
             }
+            if let Err(response) =
+                enforce_failed_login_email_rate_limit(&app_services, &request.email).await
+            {
+                return response;
+            }
 
             return (
                 StatusCode::BAD_REQUEST,
@@ -722,6 +767,11 @@ pub async fn login(
             true,
         )
         .await
+        {
+            return response;
+        }
+        if let Err(response) =
+            enforce_failed_login_email_rate_limit(&app_services, &request.email).await
         {
             return response;
         }

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -12,11 +12,12 @@ use crate::metadata::MetadataDb;
 use crate::models::{ContactFormRequest, ContactFormResponse, DemoLoginRequest, ErrorResponse};
 use anyhow::Result;
 use axum::{
-    extract::{Path, State},
+    extract::{ConnectInfo, Extension, Path, State},
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Json, Response},
 };
-use std::sync::Arc;
+use sha2::{Digest, Sha256};
+use std::{net::SocketAddr, sync::Arc};
 use tracing::info;
 
 // Request types imported for handler use only
@@ -30,6 +31,11 @@ const AUTH_COOKIE_NAME: &str = "auth_token";
 const ENUMERATION_RESPONSE_FLOOR: std::time::Duration = std::time::Duration::from_millis(1500);
 const FORGOT_PASSWORD_SUCCESS_MESSAGE: &str =
     "If an account with that email exists, a password reset link has been sent.";
+const MIN_PASSWORD_LENGTH: usize = 12;
+const MAX_AUTH_REQUESTS_PER_IP: i64 = 10;
+const AUTH_IP_RATE_LIMIT_WINDOW_MINUTES: i64 = 15;
+const MAX_CONTACT_REQUESTS_PER_IP: i64 = 3;
+const CONTACT_RATE_LIMIT_WINDOW_MINUTES: i64 = 60;
 
 async fn pad_enumeration_response(start_time: std::time::Instant) {
     pad_response_to_duration(start_time, ENUMERATION_RESPONSE_FLOOR).await;
@@ -50,6 +56,52 @@ async fn pad_response_to_duration(
     let elapsed = start_time.elapsed();
     if elapsed < target_duration {
         tokio::time::sleep(target_duration - elapsed).await;
+    }
+}
+
+async fn enforce_ip_rate_limit(
+    app_services: &AppServicesState,
+    endpoint: &str,
+    address: Option<SocketAddr>,
+    max_attempts: i64,
+    window_minutes: i64,
+) -> Result<(), Response> {
+    let Some(address) = address else {
+        return Ok(());
+    };
+
+    // Only this digest is stored. Raw client addresses never enter persistent storage.
+    let identifier = hex::encode(Sha256::digest(address.ip().to_string().as_bytes()));
+    let scope = format!("{}_ip", endpoint);
+    match app_services
+        .metadata_db
+        .check_endpoint_rate_limit(&scope, &identifier, max_attempts, window_minutes)
+        .await
+    {
+        Ok(decision) if decision.allowed => Ok(()),
+        Ok(decision) => Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            [(
+                header::RETRY_AFTER,
+                decision
+                    .retry_after_seconds
+                    .unwrap_or(window_minutes * 60)
+                    .to_string(),
+            )],
+            Json(ErrorResponse::coded(
+                "endpoint_rate_limit",
+                "Too many requests. Please try again later.",
+            )),
+        )
+            .into_response()),
+        Err(e) => {
+            tracing::error!("Failed to check {} IP rate limit: {}", endpoint, e);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("Failed to validate request rate limit")),
+            )
+                .into_response())
+        }
     }
 }
 
@@ -114,6 +166,7 @@ pub async fn register(
     State(app_services): State<AppServicesState>,
     State(stripe_billing): State<StripeBillingState>,
     State(config): State<Arc<AppConfig>>,
+    address: Option<Extension<ConnectInfo<SocketAddr>>>,
     Json(request): Json<RegisterRequest>,
 ) -> Response {
     if config.is_self_hosted_mode() {
@@ -127,6 +180,17 @@ pub async fn register(
     }
 
     let start_time = std::time::Instant::now();
+    if let Err(response) = enforce_ip_rate_limit(
+        &app_services,
+        "register",
+        address.map(|Extension(ConnectInfo(address))| address),
+        MAX_AUTH_REQUESTS_PER_IP,
+        AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+    )
+    .await
+    {
+        return response;
+    }
 
     // Validate email format
     if !request.email.contains('@') || request.email.len() < 5 {
@@ -141,12 +205,12 @@ pub async fn register(
     }
 
     // Validate password strength
-    if request.password.len() < 6 {
+    if request.password.len() < MIN_PASSWORD_LENGTH {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::coded(
                 "password_too_short",
-                "Password must be at least 6 characters long",
+                "Password must be at least 12 characters long",
             )),
         )
             .into_response();
@@ -451,8 +515,6 @@ const MAX_REGISTRATION_ATTEMPTS_PER_EMAIL: i64 = 3;
 const REGISTRATION_RATE_LIMIT_WINDOW_MINUTES: i64 = 60;
 const MAX_FORGOT_PASSWORD_ATTEMPTS_PER_EMAIL: i64 = 3;
 const FORGOT_PASSWORD_RATE_LIMIT_WINDOW_MINUTES: i64 = 60;
-const MAX_FAILED_ATTEMPTS_PER_EMAIL: i64 = 5; // Lock account after 5 failed attempts
-const ACCOUNT_LOCKOUT_MINUTES: i64 = 15; // How long to lock an account
 const REGISTRATION_RATE_LIMIT_SCOPE: &str = "register";
 const FORGOT_PASSWORD_RATE_LIMIT_SCOPE: &str = "forgot_password";
 
@@ -460,40 +522,19 @@ const FORGOT_PASSWORD_RATE_LIMIT_SCOPE: &str = "forgot_password";
 pub async fn login(
     State(app_services): State<AppServicesState>,
     State(config): State<Arc<AppConfig>>,
+    address: Option<Extension<ConnectInfo<SocketAddr>>>,
     Json(request): Json<LoginRequest>,
 ) -> Response {
-    // Check if account is locked
-    match app_services
-        .metadata_db
-        .check_account_lockout(&request.email)
-        .await
+    if let Err(response) = enforce_ip_rate_limit(
+        &app_services,
+        "login",
+        address.map(|Extension(ConnectInfo(address))| address),
+        MAX_AUTH_REQUESTS_PER_IP,
+        AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+    )
+    .await
     {
-        Ok(Some(locked_until)) => {
-            tracing::warn!("Login attempt for locked account: {}", request.email);
-            return (
-                StatusCode::TOO_MANY_REQUESTS,
-                Json(ErrorResponse::coded("account_locked", format!(
-                        "Account temporarily locked due to too many failed login attempts. Try again after {}.",
-                        locked_until
-                    ))),
-            )
-                .into_response();
-        }
-        Ok(None) => {
-            // Account is not actively locked - check if lockout just expired
-            // If so, reset the counter to give user a fresh start
-            if let Ok(true) = app_services
-                .metadata_db
-                .clear_expired_lockout(&request.email)
-                .await
-            {
-                tracing::info!("Cleared expired lockout for {}", request.email);
-            }
-        }
-        Err(e) => {
-            tracing::error!("Failed to check account lockout: {}", e);
-            // Continue with login attempt if lockout check fails
-        }
+        return response;
     }
 
     // Check if user exists - no mutex blocking!
@@ -504,11 +545,14 @@ pub async fn login(
     {
         Ok(Some(user)) => user,
         Ok(None) => {
-            // Record failed attempt even for non-existent users (prevents user enumeration timing attacks)
-            let _ = app_services
-                .metadata_db
-                .record_login_attempt(&request.email, false)
-                .await;
+            if let Err(e) = AuthService::verify_dummy_password(&request.password) {
+                tracing::error!("Failed to perform dummy password verification: {}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("Failed to verify credentials")),
+                )
+                    .into_response();
+            }
 
             return (
                 StatusCode::BAD_REQUEST,
@@ -583,70 +627,6 @@ pub async fn login(
             .record_login_attempt(&request.email, false)
             .await;
 
-        // Increment failed login counter and check if we need to lock the account
-        match app_services
-            .metadata_db
-            .increment_failed_login_count(&request.email)
-            .await
-        {
-            Ok(failed_count) if failed_count >= MAX_FAILED_ATTEMPTS_PER_EMAIL => {
-                // Lock the account
-                if let Err(e) = app_services
-                    .metadata_db
-                    .lock_account(&request.email, ACCOUNT_LOCKOUT_MINUTES)
-                    .await
-                {
-                    tracing::error!("Failed to lock account {}: {}", request.email, e);
-                } else {
-                    tracing::warn!(
-                        "Account {} locked after {} failed attempts",
-                        request.email,
-                        failed_count
-                    );
-
-                    // Send account locked notification email (fire-and-forget)
-                    if let Ok(email_service) = EmailService::from_env() {
-                        let email = user_record.email.clone();
-                        let name = user_record
-                            .name
-                            .clone()
-                            .unwrap_or_else(|| "User".to_string());
-                        let language = user_record
-                            .preferred_language
-                            .clone()
-                            .unwrap_or_else(|| "en-US".to_string());
-                        let lockout_minutes = ACCOUNT_LOCKOUT_MINUTES;
-
-                        tokio::spawn(async move {
-                            if let Err(e) = email_service
-                                .send_account_locked(&email, &name, lockout_minutes, &language)
-                                .await
-                            {
-                                tracing::error!(
-                                    "Failed to send account locked email to {}: {}",
-                                    email,
-                                    e
-                                );
-                            }
-                        });
-                    }
-                }
-
-                return (
-                    StatusCode::TOO_MANY_REQUESTS,
-                    Json(ErrorResponse::coded("account_locked", format!(
-                            "Account temporarily locked due to too many failed login attempts. Try again in {} minutes.",
-                            ACCOUNT_LOCKOUT_MINUTES
-                        ))),
-                )
-                    .into_response();
-            }
-            Err(e) => {
-                tracing::error!("Failed to increment failed login count: {}", e);
-            }
-            _ => {}
-        }
-
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::coded(
@@ -673,11 +653,6 @@ pub async fn login(
     let _ = app_services
         .metadata_db
         .record_login_attempt(&request.email, true)
-        .await;
-
-    let _ = app_services
-        .metadata_db
-        .reset_failed_login_count(&request.email)
         .await;
 
     // Update last login
@@ -997,6 +972,7 @@ pub async fn verify_email(
 pub async fn forgot_password(
     State(app_services): State<AppServicesState>,
     State(config): State<Arc<AppConfig>>,
+    address: Option<Extension<ConnectInfo<SocketAddr>>>,
     Json(request): Json<ForgotPasswordRequest>,
 ) -> Response {
     if config.is_self_hosted_mode() {
@@ -1010,6 +986,17 @@ pub async fn forgot_password(
     }
 
     let start_time = std::time::Instant::now();
+    if let Err(response) = enforce_ip_rate_limit(
+        &app_services,
+        "forgot_password",
+        address.map(|Extension(ConnectInfo(address))| address),
+        MAX_AUTH_REQUESTS_PER_IP,
+        AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+    )
+    .await
+    {
+        return response;
+    }
 
     match app_services
         .metadata_db
@@ -1143,7 +1130,22 @@ pub async fn forgot_password(
 }
 
 /// Contact form submission endpoint
-pub async fn submit_contact_form(Json(payload): Json<ContactFormRequest>) -> Response {
+pub async fn submit_contact_form(
+    State(app_services): State<AppServicesState>,
+    address: Option<Extension<ConnectInfo<SocketAddr>>>,
+    Json(payload): Json<ContactFormRequest>,
+) -> Response {
+    if let Err(response) = enforce_ip_rate_limit(
+        &app_services,
+        "contact",
+        address.map(|Extension(ConnectInfo(address))| address),
+        MAX_CONTACT_REQUESTS_PER_IP,
+        CONTACT_RATE_LIMIT_WINDOW_MINUTES,
+    )
+    .await
+    {
+        return response;
+    }
     let email = payload.email.trim();
     let message = payload.message.trim();
 
@@ -1245,12 +1247,12 @@ pub async fn reset_password(
     let start_time = std::time::Instant::now();
 
     // Validate password strength
-    if request.password.len() < 6 {
+    if request.password.len() < MIN_PASSWORD_LENGTH {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::coded(
                 "password_too_short",
-                "Password must be at least 6 characters long",
+                "Password must be at least 12 characters long",
             )),
         )
             .into_response();

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -144,7 +144,9 @@ fn client_ip(headers: &HeaderMap, peer: Option<SocketAddr>) -> Option<SocketAddr
     headers
         .get("x-forwarded-for")
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.split(',').next())
+        // A trusted proxy appends the client address, so the rightmost entry
+        // cannot be supplied by the client before the proxy receives it.
+        .and_then(|value| value.rsplit(',').next())
         .and_then(|value| value.trim().parse::<IpAddr>().ok())
         .map(|ip| SocketAddr::new(ip, peer.port()))
         .or(Some(peer))
@@ -576,21 +578,10 @@ pub async fn login(
     headers: HeaderMap,
     Json(request): Json<LoginRequest>,
 ) -> Response {
-    if let Err(response) = enforce_ip_rate_limit(
-        &app_services,
-        &config,
-        "login",
-        client_ip(
-            &headers,
-            address.map(|Extension(ConnectInfo(address))| address),
-        ),
-        MAX_AUTH_REQUESTS_PER_IP,
-        AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
-    )
-    .await
-    {
-        return response;
-    }
+    let client_address = client_ip(
+        &headers,
+        address.map(|Extension(ConnectInfo(address))| address),
+    );
 
     // Check if user exists - no mutex blocking!
     let user_record = match app_services
@@ -607,6 +598,19 @@ pub async fn login(
                     Json(ErrorResponse::new("Failed to verify credentials")),
                 )
                     .into_response();
+            }
+
+            if let Err(response) = enforce_ip_rate_limit(
+                &app_services,
+                &config,
+                "login",
+                client_address,
+                MAX_AUTH_REQUESTS_PER_IP,
+                AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+            )
+            .await
+            {
+                return response;
             }
 
             return (
@@ -676,6 +680,19 @@ pub async fn login(
     };
 
     if !password_valid {
+        if let Err(response) = enforce_ip_rate_limit(
+            &app_services,
+            &config,
+            "login",
+            client_address,
+            MAX_AUTH_REQUESTS_PER_IP,
+            AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+        )
+        .await
+        {
+            return response;
+        }
+
         // Record failed login attempt
         let _ = app_services
             .metadata_db

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -96,18 +96,24 @@ async fn enforce_ip_rate_limit(
             .metadata_db
             .check_endpoint_rate_limit(&scope, &identifier, max_attempts, window_minutes)
             .await
-            .map(|decision| !decision.allowed)
+            .map(|decision| (!decision.allowed, decision.retry_after_seconds))
     } else {
         app_services
             .metadata_db
             .is_endpoint_rate_limited(&scope, &identifier)
             .await
+            .map(|limited| (limited, None))
     };
     match decision {
-        Ok(false) => Ok(()),
-        Ok(true) => Err((
+        Ok((false, _)) => Ok(()),
+        Ok((true, retry_after_seconds)) => Err((
             StatusCode::TOO_MANY_REQUESTS,
-            [(header::RETRY_AFTER, (window_minutes * 60).to_string())],
+            [(
+                header::RETRY_AFTER,
+                retry_after_seconds
+                    .unwrap_or(window_minutes * 60)
+                    .to_string(),
+            )],
             Json(ErrorResponse::coded(
                 "endpoint_rate_limit",
                 "Too many requests. Please try again later.",
@@ -127,7 +133,7 @@ async fn enforce_ip_rate_limit(
 
 fn client_ip(headers: &HeaderMap, peer: Option<SocketAddr>) -> Option<SocketAddr> {
     let peer = peer?;
-    let trusted_proxies: HashSet<IpAddr> = std::env::var("CANARY_TRUSTED_PROXY_IPS")
+    let trusted_proxies = std::env::var("CANARY_TRUSTED_PROXY_IPS")
         .ok()
         .into_iter()
         .flat_map(|value| {
@@ -140,6 +146,14 @@ fn client_ip(headers: &HeaderMap, peer: Option<SocketAddr>) -> Option<SocketAddr
         .filter_map(|value| value.parse().ok())
         .collect();
 
+    client_ip_from_forwarded_for(headers, peer, &trusted_proxies)
+}
+
+fn client_ip_from_forwarded_for(
+    headers: &HeaderMap,
+    peer: SocketAddr,
+    trusted_proxies: &HashSet<IpAddr>,
+) -> Option<SocketAddr> {
     if !trusted_proxies.contains(&peer.ip()) {
         return Some(peer);
     }
@@ -147,10 +161,10 @@ fn client_ip(headers: &HeaderMap, peer: Option<SocketAddr>) -> Option<SocketAddr
     headers
         .get("x-forwarded-for")
         .and_then(|value| value.to_str().ok())
-        // A trusted proxy appends the client address, so the rightmost entry
-        // cannot be supplied by the client before the proxy receives it.
-        .and_then(|value| value.rsplit(',').next())
-        .and_then(|value| value.trim().parse::<IpAddr>().ok())
+        .into_iter()
+        .flat_map(|value| value.rsplit(','))
+        .filter_map(|value| value.trim().parse::<IpAddr>().ok())
+        .find(|ip| !trusted_proxies.contains(ip))
         .map(|ip| SocketAddr::new(ip, peer.port()))
         .or(Some(peer))
 }
@@ -1609,9 +1623,12 @@ pub async fn update_user(
 
 #[cfg(test)]
 mod tests {
-    use super::{client_ip, pad_response_to_duration};
+    use super::{client_ip_from_forwarded_for, pad_response_to_duration};
     use axum::http::HeaderMap;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::{
+        collections::HashSet,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
 
     #[tokio::test]
     async fn pad_response_to_duration_waits_until_floor() {
@@ -1629,6 +1646,29 @@ mod tests {
         headers.insert("x-forwarded-for", "203.0.113.10".parse().unwrap());
         let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000);
 
-        assert_eq!(client_ip(&headers, Some(peer)), Some(peer));
+        assert_eq!(
+            client_ip_from_forwarded_for(&headers, peer, &HashSet::new()),
+            Some(peer)
+        );
+    }
+
+    #[test]
+    fn client_ip_skips_trusted_proxies_from_right_to_left() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            "198.51.100.10, 192.0.2.10, 192.0.2.11".parse().unwrap(),
+        );
+        let peer = SocketAddr::new("192.0.2.12".parse().unwrap(), 3000);
+        let trusted_proxies = HashSet::from([
+            "192.0.2.10".parse().unwrap(),
+            "192.0.2.11".parse().unwrap(),
+            peer.ip(),
+        ]);
+
+        assert_eq!(
+            client_ip_from_forwarded_for(&headers, peer, &trusted_proxies),
+            Some(SocketAddr::new("198.51.100.10".parse().unwrap(), 3000))
+        );
     }
 }

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -71,6 +71,7 @@ async fn enforce_ip_rate_limit(
     address: Option<SocketAddr>,
     max_attempts: i64,
     window_minutes: i64,
+    record_attempt: bool,
 ) -> Result<(), Response> {
     let Some(address) = address else {
         return Ok(());
@@ -90,21 +91,23 @@ async fn enforce_ip_rate_limit(
     mac.update(address.ip().to_string().as_bytes());
     let identifier = hex::encode(mac.finalize().into_bytes());
     let scope = format!("{}_ip", endpoint);
-    match app_services
-        .metadata_db
-        .check_endpoint_rate_limit(&scope, &identifier, max_attempts, window_minutes)
-        .await
-    {
-        Ok(decision) if decision.allowed => Ok(()),
-        Ok(decision) => Err((
+    let decision = if record_attempt {
+        app_services
+            .metadata_db
+            .check_endpoint_rate_limit(&scope, &identifier, max_attempts, window_minutes)
+            .await
+            .map(|decision| !decision.allowed)
+    } else {
+        app_services
+            .metadata_db
+            .is_endpoint_rate_limited(&scope, &identifier)
+            .await
+    };
+    match decision {
+        Ok(false) => Ok(()),
+        Ok(true) => Err((
             StatusCode::TOO_MANY_REQUESTS,
-            [(
-                header::RETRY_AFTER,
-                decision
-                    .retry_after_seconds
-                    .unwrap_or(window_minutes * 60)
-                    .to_string(),
-            )],
+            [(header::RETRY_AFTER, (window_minutes * 60).to_string())],
             Json(ErrorResponse::coded(
                 "endpoint_rate_limit",
                 "Too many requests. Please try again later.",
@@ -238,6 +241,7 @@ pub async fn register(
         ),
         MAX_AUTH_REQUESTS_PER_IP,
         AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+        true,
     )
     .await
     {
@@ -582,6 +586,19 @@ pub async fn login(
         &headers,
         address.map(|Extension(ConnectInfo(address))| address),
     );
+    if let Err(response) = enforce_ip_rate_limit(
+        &app_services,
+        &config,
+        "login",
+        client_address,
+        MAX_AUTH_REQUESTS_PER_IP,
+        AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+        false,
+    )
+    .await
+    {
+        return response;
+    }
 
     // Check if user exists - no mutex blocking!
     let user_record = match app_services
@@ -607,6 +624,7 @@ pub async fn login(
                 client_address,
                 MAX_AUTH_REQUESTS_PER_IP,
                 AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+                true,
             )
             .await
             {
@@ -687,6 +705,7 @@ pub async fn login(
             client_address,
             MAX_AUTH_REQUESTS_PER_IP,
             AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+            true,
         )
         .await
         {
@@ -1069,6 +1088,7 @@ pub async fn forgot_password(
         ),
         MAX_AUTH_REQUESTS_PER_IP,
         AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
+        true,
     )
     .await
     {
@@ -1224,6 +1244,7 @@ pub async fn submit_contact_form(
         ),
         MAX_CONTACT_REQUESTS_PER_IP,
         CONTACT_RATE_LIMIT_WINDOW_MINUTES,
+        true,
     )
     .await
     {

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -16,8 +16,13 @@ use axum::{
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Json, Response},
 };
-use sha2::{Digest, Sha256};
-use std::{net::SocketAddr, sync::Arc};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::{
+    collections::HashSet,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 use tracing::info;
 
 // Request types imported for handler use only
@@ -61,6 +66,7 @@ async fn pad_response_to_duration(
 
 async fn enforce_ip_rate_limit(
     app_services: &AppServicesState,
+    config: &AppConfig,
     endpoint: &str,
     address: Option<SocketAddr>,
     max_attempts: i64,
@@ -70,8 +76,19 @@ async fn enforce_ip_rate_limit(
         return Ok(());
     };
 
-    // Only this digest is stored. Raw client addresses never enter persistent storage.
-    let identifier = hex::encode(Sha256::digest(address.ip().to_string().as_bytes()));
+    // Only an HMAC is stored. Raw client addresses cannot be recovered without the server secret.
+    let secret = match config.get_jwt_secret() {
+        Ok(secret) => secret,
+        Err(e) => {
+            return Err(
+                (StatusCode::SERVICE_UNAVAILABLE, Json(ErrorResponse::new(e))).into_response(),
+            )
+        }
+    };
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(address.ip().to_string().as_bytes());
+    let identifier = hex::encode(mac.finalize().into_bytes());
     let scope = format!("{}_ip", endpoint);
     match app_services
         .metadata_db
@@ -103,6 +120,34 @@ async fn enforce_ip_rate_limit(
                 .into_response())
         }
     }
+}
+
+fn client_ip(headers: &HeaderMap, peer: Option<SocketAddr>) -> Option<SocketAddr> {
+    let peer = peer?;
+    let trusted_proxies: HashSet<IpAddr> = std::env::var("CANARY_TRUSTED_PROXY_IPS")
+        .ok()
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .filter_map(|value| value.parse().ok())
+        .collect();
+
+    if !trusted_proxies.contains(&peer.ip()) {
+        return Some(peer);
+    }
+
+    headers
+        .get("x-forwarded-for")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(',').next())
+        .and_then(|value| value.trim().parse::<IpAddr>().ok())
+        .map(|ip| SocketAddr::new(ip, peer.port()))
+        .or(Some(peer))
 }
 
 /// Build an HttpOnly, Secure, SameSite=Lax cookie for authentication
@@ -167,6 +212,7 @@ pub async fn register(
     State(stripe_billing): State<StripeBillingState>,
     State(config): State<Arc<AppConfig>>,
     address: Option<Extension<ConnectInfo<SocketAddr>>>,
+    headers: HeaderMap,
     Json(request): Json<RegisterRequest>,
 ) -> Response {
     if config.is_self_hosted_mode() {
@@ -182,8 +228,12 @@ pub async fn register(
     let start_time = std::time::Instant::now();
     if let Err(response) = enforce_ip_rate_limit(
         &app_services,
+        &config,
         "register",
-        address.map(|Extension(ConnectInfo(address))| address),
+        client_ip(
+            &headers,
+            address.map(|Extension(ConnectInfo(address))| address),
+        ),
         MAX_AUTH_REQUESTS_PER_IP,
         AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
     )
@@ -205,7 +255,7 @@ pub async fn register(
     }
 
     // Validate password strength
-    if request.password.len() < MIN_PASSWORD_LENGTH {
+    if request.password.chars().count() < MIN_PASSWORD_LENGTH {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::coded(
@@ -523,12 +573,17 @@ pub async fn login(
     State(app_services): State<AppServicesState>,
     State(config): State<Arc<AppConfig>>,
     address: Option<Extension<ConnectInfo<SocketAddr>>>,
+    headers: HeaderMap,
     Json(request): Json<LoginRequest>,
 ) -> Response {
     if let Err(response) = enforce_ip_rate_limit(
         &app_services,
+        &config,
         "login",
-        address.map(|Extension(ConnectInfo(address))| address),
+        client_ip(
+            &headers,
+            address.map(|Extension(ConnectInfo(address))| address),
+        ),
         MAX_AUTH_REQUESTS_PER_IP,
         AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
     )
@@ -973,6 +1028,7 @@ pub async fn forgot_password(
     State(app_services): State<AppServicesState>,
     State(config): State<Arc<AppConfig>>,
     address: Option<Extension<ConnectInfo<SocketAddr>>>,
+    headers: HeaderMap,
     Json(request): Json<ForgotPasswordRequest>,
 ) -> Response {
     if config.is_self_hosted_mode() {
@@ -988,8 +1044,12 @@ pub async fn forgot_password(
     let start_time = std::time::Instant::now();
     if let Err(response) = enforce_ip_rate_limit(
         &app_services,
+        &config,
         "forgot_password",
-        address.map(|Extension(ConnectInfo(address))| address),
+        client_ip(
+            &headers,
+            address.map(|Extension(ConnectInfo(address))| address),
+        ),
         MAX_AUTH_REQUESTS_PER_IP,
         AUTH_IP_RATE_LIMIT_WINDOW_MINUTES,
     )
@@ -1132,13 +1192,19 @@ pub async fn forgot_password(
 /// Contact form submission endpoint
 pub async fn submit_contact_form(
     State(app_services): State<AppServicesState>,
+    State(config): State<Arc<AppConfig>>,
     address: Option<Extension<ConnectInfo<SocketAddr>>>,
+    headers: HeaderMap,
     Json(payload): Json<ContactFormRequest>,
 ) -> Response {
     if let Err(response) = enforce_ip_rate_limit(
         &app_services,
+        &config,
         "contact",
-        address.map(|Extension(ConnectInfo(address))| address),
+        client_ip(
+            &headers,
+            address.map(|Extension(ConnectInfo(address))| address),
+        ),
         MAX_CONTACT_REQUESTS_PER_IP,
         CONTACT_RATE_LIMIT_WINDOW_MINUTES,
     )
@@ -1247,7 +1313,7 @@ pub async fn reset_password(
     let start_time = std::time::Instant::now();
 
     // Validate password strength
-    if request.password.len() < MIN_PASSWORD_LENGTH {
+    if request.password.chars().count() < MIN_PASSWORD_LENGTH {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::coded(
@@ -1505,7 +1571,9 @@ pub async fn update_user(
 
 #[cfg(test)]
 mod tests {
-    use super::pad_response_to_duration;
+    use super::{client_ip, pad_response_to_duration};
+    use axum::http::HeaderMap;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     #[tokio::test]
     async fn pad_response_to_duration_waits_until_floor() {
@@ -1515,5 +1583,14 @@ mod tests {
         pad_response_to_duration(start_time, target_duration).await;
 
         assert!(start_time.elapsed() >= target_duration);
+    }
+
+    #[test]
+    fn client_ip_ignores_forwarded_headers_from_untrusted_peers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.10".parse().unwrap());
+        let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000);
+
+        assert_eq!(client_ip(&headers, Some(peer)), Some(peer));
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1311,7 +1311,11 @@ async fn main() -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&config.bind_address).await?;
     println!("Server running on http://{}", config.bind_address);
 
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
 }

--- a/backend/src/metadata/user.rs
+++ b/backend/src/metadata/user.rs
@@ -1228,6 +1228,27 @@ impl MetadataDb {
     // ENDPOINT RATE LIMITING
     // ============================
 
+    /// Check whether an endpoint identifier is currently blocked without recording an attempt.
+    pub async fn is_endpoint_rate_limited(&self, scope: &str, identifier: &str) -> Result<bool> {
+        let pool = self.pool.clone();
+        let scope = scope.to_string();
+        let identifier = identifier.trim().to_lowercase();
+        let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+
+        spawn_blocking(move || -> Result<bool> {
+            let conn = pool.get()?;
+            let blocked: Option<String> = conn
+                .query_row(
+                    "SELECT blocked_until FROM auth_rate_limits WHERE scope = ?1 AND identifier = ?2",
+                    params![scope, identifier],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            Ok(blocked.is_some_and(|until| until > now))
+        })
+        .await?
+    }
+
     /// Check and record a rate-limited endpoint attempt.
     /// Returns the allow/deny decision plus retry guidance when blocked.
     pub async fn check_endpoint_rate_limit(

--- a/backend/src/tests/auth.rs
+++ b/backend/src/tests/auth.rs
@@ -257,3 +257,8 @@ async fn cloud_registration_never_grants_admin_by_order() {
     let user = db.get_user_by_id(&first_user_id).await.unwrap().unwrap();
     assert!(!user.is_admin);
 }
+
+#[test]
+fn dummy_password_verification_runs_and_rejects_credentials() {
+    assert!(!AuthService::verify_dummy_password("not-the-dummy-password").unwrap());
+}

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2378,7 +2378,7 @@ async fn test_ip_rate_limits_are_endpoint_scoped() {
     assert!(
         db.check_endpoint_rate_limit("forgot_password_ip", ip_digest, 10, 15)
             .await
-        .unwrap()
-        .allowed
+            .unwrap()
+            .allowed
     );
 }

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -2353,3 +2353,32 @@ async fn stripe_webhook_events_are_idempotent_and_ordered() {
     assert_eq!(user.subscription_tier.as_str(), "personal");
     assert_eq!(user.subscription_status, "active");
 }
+
+#[tokio::test]
+async fn test_ip_rate_limits_are_endpoint_scoped() {
+    let (db, _temp_dir) = create_test_db().await;
+    let ip_digest = "b13df9d8a4c2e5721d6e1b3d1dbdf4a3c1a7751d35d05c927e7b160dba39c3c9";
+
+    for _ in 0..10 {
+        assert!(
+            db.check_endpoint_rate_limit("login_ip", ip_digest, 10, 15)
+                .await
+                .unwrap()
+                .allowed
+        );
+    }
+
+    assert!(
+        !db.check_endpoint_rate_limit("login_ip", ip_digest, 10, 15)
+            .await
+            .unwrap()
+            .allowed
+    );
+
+    assert!(
+        db.check_endpoint_rate_limit("forgot_password_ip", ip_digest, 10, 15)
+            .await
+        .unwrap()
+        .allowed
+    );
+}


### PR DESCRIPTION
## Summary\n\n- throttle login, registration, password reset, and contact requests by endpoint and client IP using persisted IP digests only\n- replace target-email account lockouts with per-IP login throttling and perform a dummy Argon2 verification for unknown emails\n- require passwords to be at least 12 characters and add rate-limit/timing regression coverage\n\nCloses #456\n\n## Validation\n\n- 
running 314 tests
test admin_notifications::tests::is_enabled_for_env_requires_cloud_mode_and_topic ... ok
test admin_notifications::tests::spawn_if_enabled_does_not_run_when_disabled ... ok
test admin_notifications::tests::spawn_if_enabled_runs_when_enabled ... ok
test config::tests::test_bdk_network_conversion ... ok
test config::tests::test_cloud_mode_ignores_detected_ntfy_default ... ok
test config::tests::test_cloud_mode_sync_interval_fallback ... ok
test config::tests::test_custom_electrum_url_override ... ok
test config::tests::test_default_electrum_urls ... ok
test config::tests::test_detected_ntfy_server_becomes_self_hosted_default ... ok
test config::tests::test_detected_ntfy_server_takes_precedence_over_fallback_url ... ok
test config::tests::test_detected_umbrel_ntfy_url_takes_precedence_over_fallback_env ... ok
test config::tests::test_effective_paths ... ok
test config::tests::test_get_jwt_secret_cloud_mode_with_secret ... ok
test config::tests::test_get_jwt_secret_cloud_mode_without_secret ... ok
test config::tests::test_get_jwt_secret_rejects_blank_self_hosted_secret ... ok
test config::tests::test_get_jwt_secret_self_hosted_mode ... ok
test config::tests::test_get_self_hosted_admin_password_cloud_mode ... ok
test config::tests::test_get_self_hosted_admin_password_rejects_blank_password ... ok
test config::tests::test_get_self_hosted_admin_password_self_hosted_mode ... ok
test config::tests::test_is_cloud_mode ... ok
test config::tests::test_load_detects_startos_managed_ntfy_defaults_in_self_hosted_mode ... ok
test config::tests::test_load_detects_tx_explorer_url_lists_in_self_hosted_mode ... ok
test config::tests::test_load_detects_umbrel_ntfy_url_in_self_hosted_mode ... ok
test config::tests::test_load_does_not_guess_default_when_multiple_local_ntfy_servers_exist ... ok
test config::tests::test_load_ignores_invalid_startos_ntfy_topic ... ok
test config::tests::test_load_ignores_startos_ntfy_defaults_in_cloud_mode ... ok
test config::tests::test_load_ignores_startos_ntfy_token_without_server_url ... ok
test config::tests::test_load_registers_startos_ntfy_url_without_managed_auth ... ok
test config::tests::test_network_config_parsing ... ok
test config::tests::test_network_database_isolation ... ok
test config::tests::test_network_electrum_url_defaults ... ok
test config::tests::test_network_specific_paths ... ok
test config::tests::test_ntfy_auth_allowed_for_matching_configured_url_in_cloud_mode ... ok
test config::tests::test_ntfy_auth_only_allowed_for_matching_saved_or_detected_url ... ok
test config::tests::test_ntfy_fallback_url_env_validates_configured_url ... ok
test config::tests::test_ntfy_server_config_rejects_blank_url ... ok
test config::tests::test_ntfy_server_url_falls_back_to_env_without_detected_local ... ok
test config::tests::test_operating_mode_parsing ... ok
test config::tests::test_self_hosted_mode_sync_interval_legacy_fallback ... ok
test config::tests::test_self_hosted_mode_sync_interval_network_defaults ... ok
test config::tests::test_tx_explorer_config_ignores_blank_platform ... ok
test config::tests::test_tx_explorer_config_rejects_blank_base_url ... ok
test config::tests::test_tx_explorer_url_list_env_validates_and_deduplicates_urls ... ok
test config::tests::test_with_managed_ntfy_auth_only_fills_empty_auth_for_managed_server ... ok
test electrum::tests::operation_gate_is_scoped_to_subscription_enabled_self_hosted_clients ... ok
test electrum::tests::test_is_transport_error ... ok
test electrum::tests::timeout_cancels_worker_and_allows_work_gate_release ... ok
test electrum_history::tests::cancelled_work_stops_before_the_next_electrum_rpc ... ok
test electrum_history::tests::changed_and_multiple_queued_notifications_refresh_once ... ok
test electrum_history::tests::consumed_notification_remains_dirty_after_failed_history_refresh ... ok
test electrum_history::tests::electrs_warning_condition_is_avoided_and_warm_history_is_cached ... ok
test electrum_history::tests::large_cold_cache_subscribes_once_per_bdk_batch ... ok
test electrum_history::tests::malformed_history_batch_lengths_return_errors ... ok
test electrum_history::tests::not_subscribed_after_hidden_reconnect_resubscribes_and_compares_status ... ok
test electrum_history::tests::notification_drain_has_a_safety_bound ... ok
test electrum_history::tests::null_status_after_hidden_reconnect_clears_non_empty_history ... ok
test electrum_history::tests::partial_batch_subscription_is_reconciled_without_an_already_subscribed_loop ... ok
test electrum_history::tests::polling_and_recurring_clients_share_timeout_state ... ok
test electrum_history::tests::reconnect_resubscribes_without_refetching_unchanged_history ... ok
test electrum_history::tests::safety_revalidation_clears_non_empty_history_after_ambiguous_null ... ok
test electrum_history::tests::six_hour_revalidation_and_polling_fallback_preserve_order ... ok
test electrum_history::tests::sparse_batch_refresh_keeps_status_with_its_original_script ... ok
test electrum_history::tests::wallet_cleanup_error_requires_connection_replacement ... ok
test electrum_history::tests::wallet_cleanup_handles_large_subscription_sets ... ok
test electrum_history::tests::wallet_cleanup_stops_between_rpcs_after_cancellation ... ok
test electrum_history::tests::wallet_cleanup_unsubscribes_and_evicts_only_removed_scripts ... ok
test exchange_rates::tests::fetch_rates_retries_connect_failures_with_backoff ... ok
test exchange_rates::tests::retryable_status_includes_429_and_5xx_only ... ok
test exchange_rates::tests::test_locale_to_currency_case_insensitive ... ok
test exchange_rates::tests::test_locale_to_currency_simple_language ... ok
test exchange_rates::tests::test_locale_to_currency_unknown_falls_back_to_usd ... ok
test exchange_rates::tests::test_locale_to_currency_with_encoding ... ok
test exchange_rates::tests::test_locale_to_currency_with_quality ... ok
test exchange_rates::tests::test_locale_to_currency_with_region ... ok
test exchange_rates::tests::test_locale_to_currency_with_script ... ok
test exchange_rates::tests::test_locale_to_currency_with_underscore ... ok
test handlers::auth::tests::pad_response_to_duration_waits_until_floor ... ok
test handlers::config::tests::cloud_config_does_not_expose_self_hosted_ntfy_servers ... ok
test handlers::helpers::tests::fixed_database_error_message_does_not_leak_internal_details ... ok
test metadata::integrity::tests::cleanup_rolls_back_when_audit_insert_fails ... ok
test metadata::integrity::tests::cleanup_writes_admin_audit_log_for_noop ... ok
test metadata::integrity::tests::cleanup_writes_admin_audit_log_with_counts ... ok
test metadata::wallet::tests::map_wallet_metadata_row_can_decode_is_active_strictly_or_with_fallback ... ok
test metadata::wallet::tests::map_wallet_metadata_row_defaults_optional_values_to_zero_when_requested ... ok
test metadata::wallet::tests::map_wallet_metadata_row_preserves_none_for_balance_total_without_zero_default ... ok
test models::responses::tests::coded_error_response_serializes_error_code ... ok
test models::responses::tests::new_error_response_omits_error_code ... ok
test nostr_provider::tests::builds_legacy_nip04_dm_events ... ok
test nostr_provider::tests::canonicalizes_npub_and_hex_public_keys ... ok
test nostr_provider::tests::formats_display_target_from_stored_hex_public_key ... ok
test nostr_provider::tests::formats_test_message_with_delivery_mode ... ok
test nostr_provider::tests::limits_recipient_inbox_relay_attempts ... ok
test nostr_provider::tests::maps_known_test_send_errors_to_codes ... ok
test nostr_provider::tests::parses_nostr_dm_modes ... ok
test nostr_provider::tests::rejects_empty_invalid_and_private_keys ... ok
test notification_failure_tracker::tests::test_display_formatting ... ok
test notification_failure_tracker::tests::test_error_categorization ... ok
test notification_failure_tracker::tests::test_failure_tracking ... ok
test notification_failure_tracker::tests::test_recovery_notification ... ok
test notification_failure_tracker::tests::test_suggested_actions ... ok
test subscription::tests::test_defaults_when_no_env_vars ... ok
test subscription::tests::test_get_effective_subscription_status_active ... ok
test subscription::tests::test_get_effective_subscription_status_expired_trial ... ok
test subscription::tests::test_get_effective_subscription_status_other_statuses ... ok
test subscription::tests::test_get_effective_subscription_status_valid_trial ... ok
test subscription::tests::test_is_subscription_active_with_active_status ... ok
test subscription::tests::test_is_subscription_active_with_canceled_future_end ... ok
test subscription::tests::test_is_subscription_active_with_canceled_invalid_date ... ok
test subscription::tests::test_is_subscription_active_with_canceled_past_end ... ok
test subscription::tests::test_is_subscription_active_with_expired_trial ... ok
test subscription::tests::test_is_subscription_active_with_other_statuses ... ok
test subscription::tests::test_is_subscription_active_with_valid_trial ... ok
test subscription::tests::test_tier_specific_intervals ... ok
test sync::tests::sync_pending_and_confirmation_events_flow_to_webhook_delivery ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_adds_coinbase_when_history_present ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_avoids_double_counting ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_does_not_adjust_without_history_entry ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_requires_exact_script ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_requires_mainnet ... ok
test sync::tests::test_confirmed_block_height_accepts_genesis_height ... ok
test sync::tests::test_detect_address_watch_cpfp_relationships ... ok
test sync::tests::test_detect_address_watch_rbf_replacements ... ok
test sync::tests::test_detect_address_watch_rbf_replacements_accepts_confirmed_candidate ... ok
test sync::tests::test_genesis_block_timestamp_is_mainnet_only ... ok
test sync::tests::test_is_tx_confirmed_genesis_coinbase ... ok
test sync::tests::test_is_tx_confirmed_genesis_coinbase_requires_mainnet ... ok
test sync::tests::test_is_tx_confirmed_mempool ... ok
test sync::tests::test_is_tx_confirmed_positive_height ... ok
test sync::tests::test_is_tx_confirmed_unconfirmed_parents ... ok
test sync::tests::test_mainnet_genesis_coinbase_tx_state ... ok
test sync::tests::test_mainnet_genesis_coinbase_tx_state_requires_exact_match ... ok
test sync::tests::test_mainnet_genesis_p2pk_script_includes_checksig ... ok
test tests::address::tests::test_address_to_descriptor_deterministic ... ok
test tests::address::tests::test_address_to_descriptor_format ... ok
test tests::address::tests::test_is_bitcoin_address_regtest_p2pkh ... ok
test tests::address::tests::test_is_bitcoin_address_regtest_p2sh ... ok
test tests::address::tests::test_is_bitcoin_address_regtest_p2tr ... ok
test tests::address::tests::test_is_bitcoin_address_regtest_p2wpkh ... ok
test tests::address::tests::test_is_bitcoin_address_rejects_non_addresses ... ok
test tests::address::tests::test_validate_address_network_accepts_regtest ... ok
test tests::address::tests::test_validate_address_network_rejects_invalid_string ... ok
test tests::address::tests::test_validate_address_network_rejects_mainnet_on_regtest ... ok
test tests::auth::authenticate_user_accepts_self_hosted_token_with_active_session ... ok
test tests::auth::authenticate_user_rejects_self_hosted_token_without_active_session ... ok
test tests::auth::authenticate_user_rejects_token_after_logout ... ok
test tests::auth::authenticate_user_rejects_token_with_expired_session ... ok
test tests::auth::authenticate_user_rejects_token_without_active_session ... ok
test tests::auth::dummy_password_verification_runs_and_rejects_credentials ... ok
test tests::auth::password_reset_helper_revokes_all_existing_tokens ... ok
test tests::donations::test_btcpay_client_creation_with_full_config ... ok
test tests::donations::test_btcpay_client_creation_without_recurring ... ok
test tests::donations::test_btcpay_enabled_with_required_fields ... ok
test tests::donations::test_btcpay_not_enabled_by_default ... ok
test tests::donations::test_btcpay_not_enabled_with_partial_config ... ok
test tests::donations::test_btcpay_recurring_enabled_with_full_config ... ok
test tests::donations::test_btcpay_recurring_requires_non_empty_fields ... ok
test tests::donations::test_redirect_response_invalid_url ... ok
test tests::donations::test_redirect_response_valid_url ... ok
test tests::donations::test_thank_you_url_fallback_without_frontend_url ... ok
test tests::donations::test_thank_you_url_strips_trailing_slash ... ok
test tests::donations::test_thank_you_url_with_frontend_url ... ok
test tests::message_formatter::test_create_english_message_includes_wallet_balance ... ok
test tests::message_formatter::test_create_english_message_receive_confirmed ... ok
test tests::message_formatter::test_create_english_message_receive_unconfirmed ... ok
test tests::message_formatter::test_create_english_message_send_confirmed ... ok
test tests::message_formatter::test_create_english_message_send_cpfp ... ok
test tests::message_formatter::test_create_english_message_send_unconfirmed ... ok
test tests::message_formatter::test_create_english_subject_send_cpfp ... ok
test tests::message_formatter::test_create_norwegian_message_receive_confirmed ... ok
test tests::message_formatter::test_create_norwegian_message_receive_unconfirmed ... ok
test tests::message_formatter::test_create_norwegian_message_send_confirmed ... ok
test tests::message_formatter::test_create_norwegian_message_send_unconfirmed ... ok
test tests::message_formatter::test_format_btc_amount_all_decimals_significant ... ok
test tests::message_formatter::test_format_btc_amount_large_english ... ok
test tests::message_formatter::test_format_btc_amount_large_norwegian ... ok
test tests::message_formatter::test_format_btc_amount_max_supply ... ok
test tests::message_formatter::test_format_btc_amount_mixed_trailing_zeros ... ok
test tests::message_formatter::test_format_btc_amount_one_satoshi ... ok
test tests::message_formatter::test_format_btc_amount_small_english ... ok
test tests::message_formatter::test_format_btc_amount_small_norwegian ... ok
test tests::message_formatter::test_format_btc_amount_trailing_zeros_trimmed ... ok
test tests::message_formatter::test_format_btc_amount_zero ... ok
test tests::metadata::test_auth_rate_limit_blocks_after_threshold_within_window ... ok
test tests::metadata::test_auth_rate_limit_is_scoped_by_endpoint_and_identifier ... ok
test tests::metadata::test_auth_rate_limit_normalizes_identifier ... ok
test tests::metadata::test_auth_rate_limit_resets_after_block_expires ... ok
test tests::metadata::test_auth_rate_limit_resets_after_window_expires ... ok
test tests::metadata::test_auth_rate_limit_stays_blocked_until_expiry ... ok
test tests::metadata::test_cross_wallet_verification_different_users ... ok
test tests::metadata::test_cross_wallet_verification_email_case_insensitive ... ok
test tests::metadata::test_cross_wallet_verification_same_user_email ... ok
test tests::metadata::test_cross_wallet_verification_same_user_sms ... ok
test tests::metadata::test_cross_wallet_verification_sms_exact_match ... ok
test tests::metadata::test_delete_wallet_contact_authorization ... ok
test tests::metadata::test_delete_wallet_contact_nonexistent ... ok
test tests::metadata::test_delete_wallet_contact_wrong_wallet ... ok
test tests::metadata::test_deleted_wallets_do_not_consume_limit_slots ... ok
test tests::metadata::test_deleted_wallets_excluded_from_subscription_limits ... ok
test tests::metadata::test_failed_wallets_do_not_consume_active_limit_slots ... ok
test tests::metadata::test_failed_wallets_do_not_count_toward_wallet_limit ... ok
test tests::metadata::test_get_user_preferred_language_default ... ok
test tests::metadata::test_get_user_preferred_language_japanese ... ok
test tests::metadata::test_get_user_preferred_language_nonexistent_user ... ok
test tests::metadata::test_get_user_preferred_language_norwegian ... ok
test tests::metadata::test_get_wallets_for_tier_sync_excludes_pending_descriptor_wallets ... ok
test tests::metadata::test_get_wallets_for_tier_sync_uses_transaction_last_activity ... ok
test tests::metadata::test_inactive_contacts_do_not_consume_limit_slots ... ok
test tests::metadata::test_include_notifications_batches_correctly ... ok
test tests::metadata::test_ip_rate_limits_are_endpoint_scoped ... ok
test tests::metadata::test_legacy_wallet_level_balance_alerts_remain_active_and_manageable ... ok
test tests::metadata::test_rate_limit_reports_remaining_retry_after_seconds ... ok
test tests::metadata::test_transaction_ordering_expression_index_is_applied ... ok
test tests::metadata::test_transaction_ordering_prefers_confirmed_at ... ok
test tests::metadata::test_transaction_pagination_since_timestamp_returns_changed_rows ... ok
test tests::metadata::test_transaction_pagination_uses_cursor ... ok
test tests::metadata::test_twilio_locale_all_languages_are_valid ... ok
test tests::metadata::test_twilio_locale_danish ... ok
test tests::metadata::test_twilio_locale_english ... ok
test tests::metadata::test_twilio_locale_french ... ok
test tests::metadata::test_twilio_locale_german ... ok
test tests::metadata::test_twilio_locale_japanese ... ok
test tests::metadata::test_twilio_locale_norwegian ... ok
test tests::metadata::test_twilio_locale_portuguese ... ok
test tests::metadata::test_twilio_locale_spanish ... ok
test tests::metadata::test_twilio_locale_swedish ... ok
test tests::metadata::test_update_contact_preserves_matching_notification_method_ids ... ok
test tests::metadata::test_update_user_preferred_tx_explorer_id ... ok
test tests::metadata::test_wallet_last_activity_falls_back_to_first_seen_at_for_pending_transactions ... ok
test tests::metadata::test_wallet_last_activity_uses_confirmed_at_for_confirmed_transactions ... ok
test tests::metadata::test_wallet_status_accepts_failed_and_rejects_invalid_statuses ... ok
test tests::metadata::test_wallet_status_if_not_deleted_does_not_overwrite_deleted_wallets ... ok
test tests::notifications::test_contact_allows_notification_rejects_contact_specific_balance_alert_without_contact_id ... ok
test tests::notifications::test_contact_allows_notification_rejects_inactive_contacts ... ok
test tests::notifications::test_contact_allows_notification_respects_replacement_and_fee_bump_checkboxes ... ok
test tests::notifications::test_contact_allows_notification_respects_transaction_type_checkboxes ... ok
test tests::notifications::test_contact_allows_notification_routes_legacy_wallet_level_balance_alerts_to_active_contacts ... ok
test tests::notifications::test_contact_allows_notification_treats_replaced_cpfp_as_rbf ... ok
test tests::notifications::test_create_contact_request_defaults_wallet_balance_notifications_off ... ok
test tests::notifications::test_email_provider_unconfigured_filters_only_email_methods ... ok
test tests::notifications::test_notification_manager ... ok
test tests::notifications::test_notification_manager_unknown_provider ... ok
test tests::notifications::test_notification_methods_for_provider_excludes_disabled_methods ... ok
test tests::notifications::test_notification_methods_for_provider_filters_and_preserves_contacts ... ok
test tests::notifications::test_ntfy_filters_only_ntfy_methods ... ok
test tests::notifications::test_ntfy_provider_custom_server ... ok
test tests::notifications::test_ntfy_provider_info ... ok
test tests::notifications::test_ntfy_send_notification ... ok
test tests::notifications::test_twilio_filters_only_sms_methods ... ok
test tests::notifications::test_twilio_provider_creation ... ok
test tests::notifications::test_twilio_provider_missing_env ... ok
test tests::notifications::test_twilio_send_notification ... ok
test tests::notifications::test_update_contact_request_preserves_omitted_notification_settings ... ok
test tests::wallet::tests::test_custom_stop_gap_requires_script_type ... ok
test tests::wallet::tests::test_descriptor_network_validation ... ok
test tests::wallet::tests::test_fresh_wallet_xpub_requires_script_type ... ok
test tests::wallet::tests::test_key_network_validation ... ok
test tests::wallet::tests::test_network_detection ... ok
test tests::wallet::tests::test_stop_gap_valid_values ... ok
test tests::wallet::tests::test_strip_key_origin_logic ... ok
test tests::wallet::tests::test_xpub_address_derivation_mock ... ok
test tests::wallet::tests::test_xpub_conversion_integration ... ignored, functionality moved to create_from_xpub_with_probing in wallet creation
test tests::wallet::tests::test_xpub_detection ... ok
test tests::wallet::tests::test_xpub_normalization ... ok
test tests::wallet::tests::test_xpub_script_type_detection ... ok
test tests::webhook_provider::bounds_concurrent_deliveries ... ok
test tests::webhook_provider::builds_balance_alert_and_test_payloads ... ok
test tests::webhook_provider::builds_every_transaction_payload_variant ... ok
test tests::webhook_provider::delivers_every_event_variant_to_a_disposable_receiver ... ok
test tests::webhook_provider::does_not_follow_redirects ... ok
test tests::webhook_provider::does_not_retry_failed_deliveries ... ok
test tests::webhook_provider::posts_json_and_accepts_any_2xx_status ... ok
test tests::webhook_provider::redacts_webhook_secrets_to_the_origin ... ok
test tests::webhook_provider::reports_timeouts_without_exposing_url_secrets ... ok
test tests::webhook_provider::validates_and_canonicalizes_absolute_http_urls ... ok
test tls::tests::rustls_crypto_provider_install_is_idempotent ... ok
test utils::descriptor::tests::test_extract_address_from_descriptor_rejects_pk ... ok
test utils::descriptor::tests::test_extract_address_from_descriptor_valid ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_rejects_addr ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_rejects_invalid ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_with_checksum ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_without_checksum ... ok
test utils::descriptor::tests::test_parse_descriptor_rejects_single_path_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_accepts_account_level_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_accepts_key_origin_hardened_path ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_derivation_in_sh_wpkh ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_wildcard_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_non_multipath ... ok
test utils::descriptor::tests::test_strip_key_origin_accepts_uppercase_h_hardened_path ... ok
test utils::descriptor::tests::test_strip_key_origin_rejects_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_strip_key_origin_with_origin ... ok
test utils::descriptor::tests::test_strip_key_origin_without_origin ... ok
test utils::time::tests::current_unix_timestamp_returns_current_time ... ok
test utils::time::tests::unix_timestamp_rejects_pre_epoch_times ... ok
test utils::time::tests::unix_timestamp_returns_seconds_since_epoch ... ok
test wallet::tests::bdk_two_path_creation_matches_canarys_former_split ... ok
test wallet::tests::bdk_two_path_creation_rejects_wrong_path_shapes ... ok
test wallet::tests::bdk_v2_sqlite_wallet_migrates_and_reloads ... ok
test wallet::tests::deferred_failure_does_not_starve_healthy_wallets ... ok
test wallet::tests::mixed_address_watch_group_suppresses_only_pending_watcher ... ok
test wallet::tests::pending_address_watches_keep_shared_subscriptions_active ... ok
test wallet::tests::persisted_wallet_load_checks_descriptor_and_network ... ok
test wallet::tests::recovery_scan_gap_uses_bdk_full_scan_depths ... ok
test wallet::tests::self_hosted_due_time_is_measured_from_completion ... ok
test wallet::tests::self_hosted_queue_orders_never_synced_then_oldest_with_stable_tie_breaker ... ok
test wallet::tests::self_hosted_queue_scales_oldest_first_for_reported_wallet_counts ... ok
test wallet::tests::self_hosted_work_gate_keeps_peak_concurrency_at_one ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_compressed ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_rejects_invalid ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_trims_whitespace ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_uncompressed ... ok
test xpub_converter::tests::test_pubkey_to_descriptor ... ok
test xpub_converter::tests::test_pubkey_to_descriptor_invalid ... ok
test xpub_converter::tests::test_validate_descriptor_network_bypasses_pubkey ... ok

test result: ok. 313 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 20.92s


running 172 tests
test admin_notifications::tests::is_enabled_for_env_requires_cloud_mode_and_topic ... ok
test admin_notifications::tests::spawn_if_enabled_does_not_run_when_disabled ... ok
test admin_notifications::tests::spawn_if_enabled_runs_when_enabled ... ok
test config::tests::test_bdk_network_conversion ... ok
test config::tests::test_cloud_mode_ignores_detected_ntfy_default ... ok
test config::tests::test_cloud_mode_sync_interval_fallback ... ok
test config::tests::test_custom_electrum_url_override ... ok
test config::tests::test_default_electrum_urls ... ok
test config::tests::test_detected_ntfy_server_becomes_self_hosted_default ... ok
test config::tests::test_detected_ntfy_server_takes_precedence_over_fallback_url ... ok
test config::tests::test_detected_umbrel_ntfy_url_takes_precedence_over_fallback_env ... ok
test config::tests::test_effective_paths ... ok
test config::tests::test_get_jwt_secret_cloud_mode_with_secret ... ok
test config::tests::test_get_jwt_secret_cloud_mode_without_secret ... ok
test config::tests::test_get_jwt_secret_rejects_blank_self_hosted_secret ... ok
test config::tests::test_get_jwt_secret_self_hosted_mode ... ok
test config::tests::test_get_self_hosted_admin_password_cloud_mode ... ok
test config::tests::test_get_self_hosted_admin_password_rejects_blank_password ... ok
test config::tests::test_get_self_hosted_admin_password_self_hosted_mode ... ok
test config::tests::test_is_cloud_mode ... ok
test config::tests::test_load_detects_startos_managed_ntfy_defaults_in_self_hosted_mode ... ok
test config::tests::test_load_detects_tx_explorer_url_lists_in_self_hosted_mode ... ok
test config::tests::test_load_detects_umbrel_ntfy_url_in_self_hosted_mode ... ok
test config::tests::test_load_does_not_guess_default_when_multiple_local_ntfy_servers_exist ... ok
test config::tests::test_load_ignores_invalid_startos_ntfy_topic ... ok
test config::tests::test_load_ignores_startos_ntfy_defaults_in_cloud_mode ... ok
test config::tests::test_load_ignores_startos_ntfy_token_without_server_url ... ok
test config::tests::test_load_registers_startos_ntfy_url_without_managed_auth ... ok
test config::tests::test_network_config_parsing ... ok
test config::tests::test_network_database_isolation ... ok
test config::tests::test_network_electrum_url_defaults ... ok
test config::tests::test_network_specific_paths ... ok
test config::tests::test_ntfy_auth_allowed_for_matching_configured_url_in_cloud_mode ... ok
test config::tests::test_ntfy_auth_only_allowed_for_matching_saved_or_detected_url ... ok
test config::tests::test_ntfy_fallback_url_env_validates_configured_url ... ok
test config::tests::test_ntfy_server_config_rejects_blank_url ... ok
test config::tests::test_ntfy_server_url_falls_back_to_env_without_detected_local ... ok
test config::tests::test_operating_mode_parsing ... ok
test config::tests::test_self_hosted_mode_sync_interval_legacy_fallback ... ok
test config::tests::test_self_hosted_mode_sync_interval_network_defaults ... ok
test config::tests::test_tx_explorer_config_ignores_blank_platform ... ok
test config::tests::test_tx_explorer_config_rejects_blank_base_url ... ok
test config::tests::test_tx_explorer_url_list_env_validates_and_deduplicates_urls ... ok
test config::tests::test_with_managed_ntfy_auth_only_fills_empty_auth_for_managed_server ... ok
test electrum::tests::operation_gate_is_scoped_to_subscription_enabled_self_hosted_clients ... ok
test electrum::tests::test_is_transport_error ... ok
test electrum::tests::timeout_cancels_worker_and_allows_work_gate_release ... ok
test electrum_history::tests::cancelled_work_stops_before_the_next_electrum_rpc ... ok
test electrum_history::tests::changed_and_multiple_queued_notifications_refresh_once ... ok
test electrum_history::tests::consumed_notification_remains_dirty_after_failed_history_refresh ... ok
test electrum_history::tests::electrs_warning_condition_is_avoided_and_warm_history_is_cached ... ok
test electrum_history::tests::large_cold_cache_subscribes_once_per_bdk_batch ... ok
test electrum_history::tests::malformed_history_batch_lengths_return_errors ... ok
test electrum_history::tests::not_subscribed_after_hidden_reconnect_resubscribes_and_compares_status ... ok
test electrum_history::tests::notification_drain_has_a_safety_bound ... ok
test electrum_history::tests::null_status_after_hidden_reconnect_clears_non_empty_history ... ok
test electrum_history::tests::partial_batch_subscription_is_reconciled_without_an_already_subscribed_loop ... ok
test electrum_history::tests::polling_and_recurring_clients_share_timeout_state ... ok
test electrum_history::tests::reconnect_resubscribes_without_refetching_unchanged_history ... ok
test electrum_history::tests::safety_revalidation_clears_non_empty_history_after_ambiguous_null ... ok
test electrum_history::tests::six_hour_revalidation_and_polling_fallback_preserve_order ... ok
test electrum_history::tests::sparse_batch_refresh_keeps_status_with_its_original_script ... ok
test electrum_history::tests::wallet_cleanup_error_requires_connection_replacement ... ok
test electrum_history::tests::wallet_cleanup_handles_large_subscription_sets ... ok
test electrum_history::tests::wallet_cleanup_stops_between_rpcs_after_cancellation ... ok
test electrum_history::tests::wallet_cleanup_unsubscribes_and_evicts_only_removed_scripts ... ok
test exchange_rates::tests::fetch_rates_retries_connect_failures_with_backoff ... ok
test exchange_rates::tests::retryable_status_includes_429_and_5xx_only ... ok
test exchange_rates::tests::test_locale_to_currency_case_insensitive ... ok
test exchange_rates::tests::test_locale_to_currency_simple_language ... ok
test exchange_rates::tests::test_locale_to_currency_unknown_falls_back_to_usd ... ok
test exchange_rates::tests::test_locale_to_currency_with_encoding ... ok
test exchange_rates::tests::test_locale_to_currency_with_quality ... ok
test exchange_rates::tests::test_locale_to_currency_with_region ... ok
test exchange_rates::tests::test_locale_to_currency_with_script ... ok
test exchange_rates::tests::test_locale_to_currency_with_underscore ... ok
test handlers::auth::tests::pad_response_to_duration_waits_until_floor ... ok
test handlers::config::tests::cloud_config_does_not_expose_self_hosted_ntfy_servers ... ok
test handlers::helpers::tests::fixed_database_error_message_does_not_leak_internal_details ... ok
test metadata::integrity::tests::cleanup_rolls_back_when_audit_insert_fails ... ok
test metadata::integrity::tests::cleanup_writes_admin_audit_log_for_noop ... ok
test metadata::integrity::tests::cleanup_writes_admin_audit_log_with_counts ... ok
test metadata::wallet::tests::map_wallet_metadata_row_can_decode_is_active_strictly_or_with_fallback ... ok
test metadata::wallet::tests::map_wallet_metadata_row_defaults_optional_values_to_zero_when_requested ... ok
test metadata::wallet::tests::map_wallet_metadata_row_preserves_none_for_balance_total_without_zero_default ... ok
test models::responses::tests::coded_error_response_serializes_error_code ... ok
test models::responses::tests::new_error_response_omits_error_code ... ok
test nostr_provider::tests::builds_legacy_nip04_dm_events ... ok
test nostr_provider::tests::canonicalizes_npub_and_hex_public_keys ... ok
test nostr_provider::tests::formats_display_target_from_stored_hex_public_key ... ok
test nostr_provider::tests::formats_test_message_with_delivery_mode ... ok
test nostr_provider::tests::limits_recipient_inbox_relay_attempts ... ok
test nostr_provider::tests::maps_known_test_send_errors_to_codes ... ok
test nostr_provider::tests::parses_nostr_dm_modes ... ok
test nostr_provider::tests::rejects_empty_invalid_and_private_keys ... ok
test notification_failure_tracker::tests::test_display_formatting ... ok
test notification_failure_tracker::tests::test_error_categorization ... ok
test notification_failure_tracker::tests::test_failure_tracking ... ok
test notification_failure_tracker::tests::test_recovery_notification ... ok
test notification_failure_tracker::tests::test_suggested_actions ... ok
test subscription::tests::test_defaults_when_no_env_vars ... ok
test subscription::tests::test_get_effective_subscription_status_active ... ok
test subscription::tests::test_get_effective_subscription_status_expired_trial ... ok
test subscription::tests::test_get_effective_subscription_status_other_statuses ... ok
test subscription::tests::test_get_effective_subscription_status_valid_trial ... ok
test subscription::tests::test_is_subscription_active_with_active_status ... ok
test subscription::tests::test_is_subscription_active_with_canceled_future_end ... ok
test subscription::tests::test_is_subscription_active_with_canceled_invalid_date ... ok
test subscription::tests::test_is_subscription_active_with_canceled_past_end ... ok
test subscription::tests::test_is_subscription_active_with_expired_trial ... ok
test subscription::tests::test_is_subscription_active_with_other_statuses ... ok
test subscription::tests::test_is_subscription_active_with_valid_trial ... ok
test subscription::tests::test_tier_specific_intervals ... ok
test sync::tests::sync_pending_and_confirmation_events_flow_to_webhook_delivery ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_adds_coinbase_when_history_present ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_avoids_double_counting ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_does_not_adjust_without_history_entry ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_requires_exact_script ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_requires_mainnet ... ok
test sync::tests::test_confirmed_block_height_accepts_genesis_height ... ok
test sync::tests::test_detect_address_watch_cpfp_relationships ... ok
test sync::tests::test_detect_address_watch_rbf_replacements ... ok
test sync::tests::test_detect_address_watch_rbf_replacements_accepts_confirmed_candidate ... ok
test sync::tests::test_genesis_block_timestamp_is_mainnet_only ... ok
test sync::tests::test_is_tx_confirmed_genesis_coinbase ... ok
test sync::tests::test_is_tx_confirmed_genesis_coinbase_requires_mainnet ... ok
test sync::tests::test_is_tx_confirmed_mempool ... ok
test sync::tests::test_is_tx_confirmed_positive_height ... ok
test sync::tests::test_is_tx_confirmed_unconfirmed_parents ... ok
test sync::tests::test_mainnet_genesis_coinbase_tx_state ... ok
test sync::tests::test_mainnet_genesis_coinbase_tx_state_requires_exact_match ... ok
test sync::tests::test_mainnet_genesis_p2pk_script_includes_checksig ... ok
test tls::tests::rustls_crypto_provider_install_is_idempotent ... ok
test utils::descriptor::tests::test_extract_address_from_descriptor_rejects_pk ... ok
test utils::descriptor::tests::test_extract_address_from_descriptor_valid ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_rejects_addr ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_rejects_invalid ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_with_checksum ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_without_checksum ... ok
test utils::descriptor::tests::test_parse_descriptor_rejects_single_path_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_accepts_account_level_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_accepts_key_origin_hardened_path ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_derivation_in_sh_wpkh ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_wildcard_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_non_multipath ... ok
test utils::descriptor::tests::test_strip_key_origin_accepts_uppercase_h_hardened_path ... ok
test utils::descriptor::tests::test_strip_key_origin_rejects_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_strip_key_origin_with_origin ... ok
test utils::descriptor::tests::test_strip_key_origin_without_origin ... ok
test utils::time::tests::current_unix_timestamp_returns_current_time ... ok
test utils::time::tests::unix_timestamp_rejects_pre_epoch_times ... ok
test utils::time::tests::unix_timestamp_returns_seconds_since_epoch ... ok
test wallet::tests::bdk_two_path_creation_matches_canarys_former_split ... ok
test wallet::tests::bdk_two_path_creation_rejects_wrong_path_shapes ... ok
test wallet::tests::bdk_v2_sqlite_wallet_migrates_and_reloads ... ok
test wallet::tests::deferred_failure_does_not_starve_healthy_wallets ... ok
test wallet::tests::mixed_address_watch_group_suppresses_only_pending_watcher ... ok
test wallet::tests::pending_address_watches_keep_shared_subscriptions_active ... ok
test wallet::tests::persisted_wallet_load_checks_descriptor_and_network ... ok
test wallet::tests::recovery_scan_gap_uses_bdk_full_scan_depths ... ok
test wallet::tests::self_hosted_due_time_is_measured_from_completion ... ok
test wallet::tests::self_hosted_queue_orders_never_synced_then_oldest_with_stable_tie_breaker ... ok
test wallet::tests::self_hosted_queue_scales_oldest_first_for_reported_wallet_counts ... ok
test wallet::tests::self_hosted_work_gate_keeps_peak_concurrency_at_one ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_compressed ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_rejects_invalid ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_trims_whitespace ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_uncompressed ... ok
test xpub_converter::tests::test_pubkey_to_descriptor ... ok
test xpub_converter::tests::test_pubkey_to_descriptor_invalid ... ok
test xpub_converter::tests::test_validate_descriptor_network_bypasses_pubkey ... ok

test result: ok. 172 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.67s


running 1 test
test test_unused_bech32_address_watch_becomes_ready_after_empty_sync ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test test_cpfp_detection_and_tracking ... ignored
test test_multiple_rbf_sender_and_receiver_perspective ... ignored
test test_single_rbf_sender_and_receiver_perspective ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 9 tests
test test_cloud_mode_accepts_valid_bearer_token_with_session ... ok
test test_cloud_mode_rejects_invalid_jwt ... ok
test test_cookie_auth_ignores_malformed_authorization_header ... ok
test test_login_me_logout_invalidates_session ... ok
test test_login_rejects_invalid_password_and_unverified_email ... ok
test test_reset_password_endpoint_updates_password_and_clears_token ... ok
test test_self_hosted_login_me_logout_invalidates_session ... ok
test test_self_hosted_rejects_jwt_without_session ... ok
test test_verify_email_endpoint_marks_user_verified ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.74s


running 5 tests
test test_balance_alert_above_threshold ... ignored
test test_balance_alert_below_threshold ... ignored
test test_balance_alert_deactivation ... ignored
test test_balance_drain_alert_equals_zero ... ignored
test test_multiple_balance_alerts ... ignored

test result: ok. 0 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 11 tests
test test_balance_alert_database_operations ... ok
test test_balance_alert_edge_cases ... ok
test test_balance_alert_performance ... ok
test test_balance_alert_threshold_crossing_detection ... ok
test test_balance_alert_types ... ok
test test_balance_alert_wallet_isolation ... ok
test test_below_zero_alert_validation ... ok
test test_duplicate_alert_all_types ... ok
test test_duplicate_balance_alert_checking ... ok
test test_fiat_alert_fires_on_exchange_rate_change ... ignored
test test_wallet_drain_alert_special_case ... ok

test result: ok. 10 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 3.66s


running 1 test
test test_batch_send_to_bob_and_charlie ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 13 tests
test test_config_endpoint_cloud_mode_ignores_self_hosted_tx_explorers ... ok
test test_config_endpoint_self_hosted_no_mempool_config ... ok
test test_config_endpoint_self_hosted_serializes_tx_explorer_base_urls ... ok
test test_config_endpoint_self_hosted_with_multiple_tx_explorers ... ok
test test_config_endpoint_self_hosted_with_single_tx_explorer ... ok
test test_user_preferences_accepts_custom_tx_explorer_template ... ok
test test_user_preferences_accepts_custom_tx_explorer_template_in_cloud_mode ... ok
test test_user_preferences_accepts_supported_tx_explorer_ids ... ok
test test_user_preferences_clears_tx_explorer_preference ... ok
test test_user_preferences_clears_tx_explorer_preference_with_null ... ok
test test_user_preferences_cloud_mode_rejects_local_tx_explorer_ids ... ok
test test_user_preferences_rejects_invalid_custom_tx_explorer_template ... ok
test test_user_preferences_rejects_unsupported_tx_explorer_id ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.46s


running 6 tests
test test_duplicate_email_prevention ... ok
test test_duplicate_nostr_recipient_prevention ... ok
test test_duplicate_phone_prevention ... ok
test test_mixed_provider_types_allowed ... ok
test test_ntfy_topics_excluded_from_duplicate_check ... ok
test test_verification_endpoint_rejects_duplicates ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.11s


running 10 tests
test database_health_and_integrity_require_admin_access ... ok
test database_health_reports_degraded_for_orphans_without_fk_violations ... ok
test database_health_reports_no_orphans_for_clean_database ... ok
test database_health_reports_orphans_without_cleanup ... ok
test integrity_check_handles_logs_for_soft_deleted_wallet_transactions ... ok
test integrity_check_rejects_malformed_payload ... ok
test integrity_check_with_auto_fix_deletes_orphans_and_preserves_valid_rows ... ok
test integrity_check_with_auto_fix_on_clean_database_reports_zero_deletions ... ok
test integrity_check_without_auto_fix_reports_orphans_and_leaves_rows ... ok
test integrity_check_without_body_defaults_to_no_cleanup ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.79s


running 1 test
test debug_wallet_drain_detection ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test database_health_endpoint_is_rate_limited ... ok
test database_integrity_endpoint_has_separate_rate_limit_scope ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.76s


running 1 test
test test_high_index_fund_detection ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test test_chain_of_unconfirmed_transactions ... ignored
test test_unconfirmed_chain_with_separate_confirmations ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test migration_031_handles_clean_first_run_and_wallets_without_contacts ... ok
test migration_031_recovers_from_partially_applied_schema ... ok
test migration_033_cleans_active_wallet_level_alerts_with_contacts ... ok
test migration_035_preserves_notification_log_method_references ... ok
test migration_037_preserves_methods_indexes_and_foreign_keys_and_allows_reused_urls ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.70s


running 3 tests
test test_alice_full_send_bob_mined_directly ... ignored
test test_alice_partial_send_bob_mined_directly ... ignored
test test_multiple_partial_sends_mined_directly ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 9 tests
test test_admin_user_bypasses_contact_limits ... ok
test test_admin_user_bypasses_wallet_limits ... ok
test test_cloud_mode_rejects_nostr_contact_method ... ok
test test_cloud_mode_rejects_webhook_create_update_and_test ... ok
test test_personal_user_contact_limit_is_enforced ... ok
test test_personal_user_wallet_limit_is_enforced ... ok
test test_self_hosted_mode_bypasses_contact_limits ... ok
test test_self_hosted_mode_bypasses_wallet_limits ... ok
test test_self_hosted_webhook_provider_validation_reuse_and_redacted_display ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 12.36s


running 2 tests
test test_self_send_full_amount ... ignored
test test_self_send_partial ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test test_checkout_endpoint_without_stripe ... ok
test test_checkout_invalid_json ... ok
test test_checkout_invalid_tier ... ok
test test_checkout_missing_fields ... ok
test test_cors_headers ... ok
test test_pricing_endpoint_without_stripe ... ok
test test_session_details_without_stripe ... ok
test test_webhook_endpoint_without_stripe ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.85s


running 2 tests
test test_direct_mining_transaction_timestamp ... ignored
test test_mempool_first_transaction_timestamp ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test test_alice_full_send_bob_two_stage ... ignored
test test_alice_partial_send_bob_two_stage ... ignored
test test_multiple_partial_sends_bob_two_stage ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test test_utxo_consolidation_send_all_to_bob ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 43 tests
test test_create_address_wallet_duplicate_address ... ok
test test_create_address_wallet_network_mismatch ... ok
test test_create_address_wallet_p2pkh ... ok
test test_create_address_wallet_p2sh ... ok
test test_create_address_wallet_p2tr ... ok
test test_create_address_wallet_p2wpkh ... ok
test test_create_balance_alert_rejects_missing_contact_id ... ok
test test_create_wallet_custom_stop_gap_without_script_type ... ok
test test_create_wallet_duplicate_descriptor ... ok
test test_create_wallet_invalid_descriptor ... ok
test test_create_wallet_invalid_descriptor_returns_coded_generic_error ... ok
test test_create_wallet_network_mismatch ... ok
test test_create_wallet_non_multipath_descriptor_returns_specific_error ... ok
test test_create_wallet_rejects_hardened_derivation_after_xpub_before_insert ... ok
test test_create_wallet_success ... ok
test test_create_wallet_xpub_fresh_no_script_type ... ok
test test_delete_wallet_not_found ... ok
test test_delete_wallet_success ... ok
test test_get_transaction_notifications_forbidden_for_non_owner ... ok
test test_get_transaction_notifications_success_for_non_admin_owner ... ok
test test_get_transaction_notifications_transaction_not_found ... ok
test test_get_transaction_notifications_wallet_not_found ... ok
test test_get_wallet_detail_not_found ... ok
test test_get_wallet_detail_omits_notification_status_and_endpoint_loads_it ... ok
test test_get_wallet_detail_rejects_combined_cursor_and_since_timestamp ... ok
test test_get_wallet_detail_rejects_invalid_cursor ... ok
test test_get_wallet_detail_rejects_out_of_range_cursor_timestamp ... ok
test test_get_wallet_detail_rejects_out_of_range_since_timestamp ... ok
test test_get_wallet_detail_returns_pagination_metadata ... ok
test test_get_wallet_detail_success ... ok
test test_get_wallet_not_found ... ok
test test_get_wallet_success ... ok
test test_get_wallets_list_empty ... ok
test test_get_wallets_list_with_wallets ... ok
test test_self_hosted_forgot_password_is_forbidden ... ok
test test_self_hosted_register_is_forbidden ... ok
test test_self_hosted_reset_password_is_forbidden ... ok
test test_self_hosted_verify_email_is_forbidden ... ok
test test_update_wallet_empty_name ... ok
test test_update_wallet_not_found ... ok
test test_update_wallet_success ... ok
test test_validate_balance_alert_rejects_immediate_trigger ... ok
test test_validate_balance_alert_success_does_not_create_alert ... ok

test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 26.38s


running 7 tests
test test_descriptors_from_vpub_tpub_have_same_checksum ... ok
test test_descriptors_from_zpub_xpub_have_same_checksum ... ok
test test_duplicate_wallet_detection_vpub_tpub ... ok
test test_duplicate_wallet_detection_zpub_xpub ... ok
test test_vpub_tpub_normalize_to_same_value ... ok
test test_vpub_tpub_normalize_to_same_value_regtest ... ok
test test_zpub_xpub_normalize_to_same_value ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.72s


running 2 tests
test test_no_duplicate_events_after_restart ... ignored
test test_recovery_detects_transactions_during_downtime ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test webhook_notification_log_snapshots_store_only_the_origin ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s


running 2 tests
test src/extractors/auth.rs - extractors::auth::AuthenticatedUser (line 20) ... ignored
test src/extractors/auth.rs - extractors::auth::require_non_demo (line 86) ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s