### PR TITLE
fix: prevent SSRF through notification targets

### DIFF
--- a/backend/src/handlers/contact.rs
+++ b/backend/src/handlers/contact.rs
@@ -262,7 +262,7 @@ pub async fn create_wallet_contact(
                     return response;
                 }
 
-                match validate_webhook_url(&method.notification_target) {
+                match validate_webhook_url(&method.notification_target).await {
                     Ok(url) => {
                         processed_methods.push((ProviderType::Webhook, url, method.is_enabled))
                     }
@@ -496,9 +496,7 @@ pub async fn update_wallet_contact(
                             Ok(public_key_hex) => public_key_hex,
                             Err(e) => return Err(e),
                         },
-                        ProviderType::Webhook => {
-                            validate_webhook_url(&new_method.notification_target)?
-                        }
+                        ProviderType::Webhook => new_method.notification_target.clone(),
                         _ => new_method.notification_target.clone(),
                     };
                     Ok(existing.notification_target != new_normalized)
@@ -699,7 +697,7 @@ pub async fn update_wallet_contact(
                     return response;
                 }
 
-                match validate_webhook_url(&method.notification_target) {
+                match validate_webhook_url(&method.notification_target).await {
                     Ok(url) => {
                         processed_methods.push((ProviderType::Webhook, url, method.is_enabled))
                     }

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -12,7 +12,8 @@ use crate::nostr_provider::{
     ensure_nostr_sender_keys, get_nostr_dm_mode, nostr_test_error_code,
     parse_nostr_recipient_or_error, set_nostr_dm_mode, NostrProvider,
 };
-use crate::ntfy_provider::{NtfyAuth, NtfyProvider};
+use crate::ntfy_provider::NtfyAuth;
+use crate::outbound_target::{client_for_public_url, validate_public_url};
 use crate::webhook_provider::{validate_webhook_url, WebhookPayload, WebhookProvider};
 use axum::{
     extract::State,
@@ -123,7 +124,31 @@ pub async fn send_test_ntfy_notification(
     let ntfy_url = format!("{}/{}", ntfy_server.trim_end_matches('/'), topic);
 
     // Build and send the HTTP request
-    let client = NtfyProvider::default_client();
+    let client = match validate_public_url(&ntfy_url).await {
+        Ok(url) => match client_for_public_url(&url).await {
+            Ok(client) => client,
+            Err(_) => {
+                return (
+                    StatusCode::OK,
+                    Json(TestNtfyResponse {
+                        success: false,
+                        error: Some("ntfy server is not publicly reachable".to_string()),
+                    }),
+                )
+                    .into_response()
+            }
+        },
+        Err(_) => {
+            return (
+                StatusCode::OK,
+                Json(TestNtfyResponse {
+                    success: false,
+                    error: Some("ntfy server is not publicly reachable".to_string()),
+                }),
+            )
+                .into_response()
+        }
+    };
     let mut request = client
         .post(&ntfy_url)
         .header("Content-Type", "text/plain; charset=utf-8")
@@ -157,16 +182,7 @@ pub async fn send_test_ntfy_notification(
                     .into_response()
             } else {
                 let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                // Try to extract "error" field from ntfy JSON responses
-                let detail = if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
-                    json["error"].as_str().unwrap_or(&body).to_string()
-                } else if body.is_empty() {
-                    status.canonical_reason().unwrap_or("Unknown").to_string()
-                } else {
-                    body
-                };
-                let error = format!("HTTP {}: {}", status.as_u16(), detail);
+                let error = format!("HTTP {}", status.as_u16());
                 (
                     StatusCode::OK,
                     Json(TestNtfyResponse {
@@ -177,11 +193,11 @@ pub async fn send_test_ntfy_notification(
                     .into_response()
             }
         }
-        Err(e) => (
+        Err(_) => (
             StatusCode::OK,
             Json(TestNtfyResponse {
                 success: false,
-                error: Some(format!("Request failed: {}", e)),
+                error: Some("Request to ntfy server failed".to_string()),
             }),
         )
             .into_response(),
@@ -199,7 +215,7 @@ pub async fn send_test_webhook_notification(
         return response;
     }
 
-    let url = match validate_webhook_url(&payload.url) {
+    let url = match validate_webhook_url(&payload.url).await {
         Ok(url) => url,
         Err(error) => {
             return (

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -126,6 +126,7 @@ pub async fn send_test_ntfy_notification(
     // Build and send the HTTP request
     let client = if user_ntfy_server_url.is_none() {
         reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("failed to build ntfy HTTP client")

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -124,9 +124,26 @@ pub async fn send_test_ntfy_notification(
     let ntfy_url = format!("{}/{}", ntfy_server.trim_end_matches('/'), topic);
 
     // Build and send the HTTP request
-    let client = match validate_public_url(&ntfy_url).await {
-        Ok(url) => match client_for_public_url(&url).await {
-            Ok(client) => client,
+    let client = if user_ntfy_server_url.is_none() {
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("failed to build ntfy HTTP client")
+    } else {
+        match validate_public_url(&ntfy_url).await {
+            Ok(url) => match client_for_public_url(&url).await {
+                Ok(client) => client,
+                Err(_) => {
+                    return (
+                        StatusCode::OK,
+                        Json(TestNtfyResponse {
+                            success: false,
+                            error: Some("ntfy server is not publicly reachable".to_string()),
+                        }),
+                    )
+                        .into_response()
+                }
+            },
             Err(_) => {
                 return (
                     StatusCode::OK,
@@ -137,16 +154,6 @@ pub async fn send_test_ntfy_notification(
                 )
                     .into_response()
             }
-        },
-        Err(_) => {
-            return (
-                StatusCode::OK,
-                Json(TestNtfyResponse {
-                    success: false,
-                    error: Some("ntfy server is not publicly reachable".to_string()),
-                }),
-            )
-                .into_response()
         }
     };
     let mut request = client

--- a/backend/src/handlers/user_preferences.rs
+++ b/backend/src/handlers/user_preferences.rs
@@ -283,7 +283,11 @@ pub async fn update_user_preferences(
                     .into_response();
             }
             if let Err(error) = validate_public_url(ntfy_url).await {
-                return (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(error))).into_response();
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse::coded("invalid_ntfy_url", error)),
+                )
+                    .into_response();
             }
             Some(ntfy_url.as_str())
         };

--- a/backend/src/handlers/user_preferences.rs
+++ b/backend/src/handlers/user_preferences.rs
@@ -5,6 +5,7 @@ use crate::auth::{UpdateUserPreferencesRequest, UserPreferencesResponse};
 use crate::exchange_rates;
 use crate::extractors::{require_non_demo, AuthenticatedUser};
 use crate::models::ErrorResponse;
+use crate::outbound_target::validate_public_url;
 use axum::{
     extract::State,
     http::StatusCode,
@@ -280,6 +281,9 @@ pub async fn update_user_preferences(
                     )),
                 )
                     .into_response();
+            }
+            if let Err(error) = validate_public_url(ntfy_url).await {
+                return (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(error))).into_response();
             }
             Some(ntfy_url.as_str())
         };

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -29,6 +29,7 @@ pub mod nostr_provider;
 pub mod notification_failure_tracker;
 pub mod notifications;
 pub mod ntfy_provider;
+pub mod outbound_target;
 pub mod stripe_billing;
 pub mod stripe_client_service;
 pub mod subscription;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -216,7 +216,7 @@ async fn main() -> anyhow::Result<()> {
             "🔔 Self-hosted mode: Registering ntfy notifications (server: {})",
             ntfy_server
         );
-        notification_manager.register_provider(Arc::new(NtfyProvider::with_auth(
+        notification_manager.register_provider(Arc::new(NtfyProvider::with_trusted_auth(
             ntfy_server,
             NtfyAuth::None,
         )));
@@ -254,7 +254,7 @@ async fn main() -> anyhow::Result<()> {
         if config.is_ntfy_enabled() {
             let ntfy_server = config.ntfy_server_url();
             println!("  - ntfy notification provider (server: {})", ntfy_server);
-            notification_manager.register_provider(Arc::new(NtfyProvider::with_auth(
+            notification_manager.register_provider(Arc::new(NtfyProvider::with_trusted_auth(
                 ntfy_server,
                 NtfyAuth::None,
             )));
@@ -983,7 +983,11 @@ async fn main() -> anyhow::Result<()> {
                                     user_ntfy_server_url.as_deref(),
                                 );
 
-                                let ntfy_provider = NtfyProvider::with_auth(ntfy_server, ntfy_auth);
+                                let ntfy_provider = if user_ntfy_server_url.is_some() {
+                                    NtfyProvider::with_auth(ntfy_server, ntfy_auth)
+                                } else {
+                                    NtfyProvider::with_trusted_auth(ntfy_server, ntfy_auth)
+                                };
                                 use crate::notifications::NotificationProvider;
                                 Ok(ntfy_provider
                                     .send_notification(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -26,6 +26,7 @@ mod nostr_provider;
 mod notification_failure_tracker;
 mod notifications;
 mod ntfy_provider;
+mod outbound_target;
 mod stripe_billing;
 mod stripe_client_service;
 mod subscription;
@@ -208,8 +209,6 @@ async fn main() -> anyhow::Result<()> {
 
     // Create notification manager and register providers based on operating mode
     let mut notification_manager = NotificationManager::new();
-    let ntfy_http_client = NtfyProvider::default_client();
-
     if config.is_self_hosted_mode() {
         // Self-hosted mode: local notification providers
         let ntfy_server = config.ntfy_server_url();
@@ -217,8 +216,7 @@ async fn main() -> anyhow::Result<()> {
             "🔔 Self-hosted mode: Registering ntfy notifications (server: {})",
             ntfy_server
         );
-        notification_manager.register_provider(Arc::new(NtfyProvider::with_client(
-            ntfy_http_client.clone(),
+        notification_manager.register_provider(Arc::new(NtfyProvider::with_auth(
             ntfy_server,
             NtfyAuth::None,
         )));
@@ -256,8 +254,7 @@ async fn main() -> anyhow::Result<()> {
         if config.is_ntfy_enabled() {
             let ntfy_server = config.ntfy_server_url();
             println!("  - ntfy notification provider (server: {})", ntfy_server);
-            notification_manager.register_provider(Arc::new(NtfyProvider::with_client(
-                ntfy_http_client.clone(),
+            notification_manager.register_provider(Arc::new(NtfyProvider::with_auth(
                 ntfy_server,
                 NtfyAuth::None,
             )));
@@ -986,11 +983,7 @@ async fn main() -> anyhow::Result<()> {
                                     user_ntfy_server_url.as_deref(),
                                 );
 
-                                let ntfy_provider = NtfyProvider::with_client(
-                                    ntfy_http_client.clone(),
-                                    ntfy_server,
-                                    ntfy_auth,
-                                );
+                                let ntfy_provider = NtfyProvider::with_auth(ntfy_server, ntfy_auth);
                                 use crate::notifications::NotificationProvider;
                                 Ok(ntfy_provider
                                     .send_notification(

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -5,15 +5,11 @@ use crate::metadata::{
 use crate::notifications::{
     notification_methods_for_provider, NotificationProvider, NotificationResult, ProviderInfo,
 };
+use crate::outbound_target::{client_for_public_url, validate_public_url};
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use rust_i18n::t;
 use serde_json::json;
-use std::sync::OnceLock;
-use std::time::Duration;
-
-const NTFY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-static NTFY_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 /// Authentication method for ntfy server
 #[derive(Clone, Debug)]
@@ -27,7 +23,6 @@ pub enum NtfyAuth {
 }
 
 pub struct NtfyProvider {
-    client: reqwest::Client,
     server_url: String,
     auth: NtfyAuth,
 }
@@ -38,29 +33,10 @@ impl NtfyProvider {
     }
 
     pub fn with_auth(server_url: String, auth: NtfyAuth) -> Self {
-        Self::with_client(Self::default_client(), server_url, auth)
-    }
-
-    pub fn with_client(client: reqwest::Client, server_url: String, auth: NtfyAuth) -> Self {
-        // Ensure the server URL doesn't have a trailing slash
-        let server_url = server_url.trim_end_matches('/').to_string();
         Self {
-            client,
-            server_url,
+            server_url: server_url.trim_end_matches('/').to_string(),
             auth,
         }
-    }
-
-    pub fn default_client() -> reqwest::Client {
-        NTFY_CLIENT
-            .get_or_init(|| {
-                reqwest::Client::builder()
-                    .timeout(NTFY_REQUEST_TIMEOUT)
-                    .redirect(reqwest::redirect::Policy::none())
-                    .build()
-                    .expect("failed to build ntfy HTTP client")
-            })
-            .clone()
     }
 
     /// Build the Authorization header value based on auth method
@@ -107,6 +83,19 @@ impl NotificationProvider for NtfyProvider {
 
             let topic = &method.notification_target;
             let ntfy_url = format!("{}/{}", self.server_url, topic);
+            let client = match validate_public_url(&ntfy_url).await {
+                Ok(parsed_url) => match client_for_public_url(&parsed_url).await {
+                    Ok(client) => client,
+                    Err(_) => {
+                        results.push((method.clone(), blocked_server_result(), message));
+                        continue;
+                    }
+                },
+                Err(_) => {
+                    results.push((method.clone(), blocked_server_result(), message));
+                    continue;
+                }
+            };
 
             // Create localized title for push notification
             // Note: t!() macro requires string literals, not variables, for compile-time translation lookup
@@ -162,8 +151,7 @@ impl NotificationProvider for NtfyProvider {
             };
 
             // Build the request with optional authentication
-            let mut request = self
-                .client
+            let mut request = client
                 .post(&ntfy_url)
                 .header("Content-Type", "text/plain; charset=utf-8")
                 .header("Title", localized_title)
@@ -209,8 +197,8 @@ impl NotificationProvider for NtfyProvider {
                         }
                     }
                 }
-                Err(e) => {
-                    let error = format!("Request failed: {}", e);
+                Err(_) => {
+                    let error = "Request to ntfy server failed".to_string();
                     NotificationResult {
                         success: false,
                         provider_id: None,
@@ -251,6 +239,14 @@ impl NotificationProvider for NtfyProvider {
 
     fn name(&self) -> &'static str {
         "ntfy"
+    }
+}
+
+fn blocked_server_result() -> NotificationResult {
+    NotificationResult {
+        success: false,
+        provider_id: None,
+        error_message: Some("ntfy server is not publicly reachable".to_string()),
     }
 }
 

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -25,6 +25,7 @@ pub enum NtfyAuth {
 pub struct NtfyProvider {
     server_url: String,
     auth: NtfyAuth,
+    trusted_server: bool,
 }
 
 impl NtfyProvider {
@@ -36,6 +37,15 @@ impl NtfyProvider {
         Self {
             server_url: server_url.trim_end_matches('/').to_string(),
             auth,
+            trusted_server: false,
+        }
+    }
+
+    pub fn with_trusted_auth(server_url: String, auth: NtfyAuth) -> Self {
+        Self {
+            server_url: server_url.trim_end_matches('/').to_string(),
+            auth,
+            trusted_server: true,
         }
     }
 
@@ -83,17 +93,25 @@ impl NotificationProvider for NtfyProvider {
 
             let topic = &method.notification_target;
             let ntfy_url = format!("{}/{}", self.server_url, topic);
-            let client = match validate_public_url(&ntfy_url).await {
-                Ok(parsed_url) => match client_for_public_url(&parsed_url).await {
-                    Ok(client) => client,
+            let client = if self.trusted_server {
+                reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(10))
+                    .redirect(reqwest::redirect::Policy::none())
+                    .build()
+                    .expect("failed to build ntfy HTTP client")
+            } else {
+                match validate_public_url(&ntfy_url).await {
+                    Ok(parsed_url) => match client_for_public_url(&parsed_url).await {
+                        Ok(client) => client,
+                        Err(_) => {
+                            results.push((method.clone(), blocked_server_result(), message));
+                            continue;
+                        }
+                    },
                     Err(_) => {
                         results.push((method.clone(), blocked_server_result(), message));
                         continue;
                     }
-                },
-                Err(_) => {
-                    results.push((method.clone(), blocked_server_result(), message));
-                    continue;
                 }
             };
 

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -26,6 +26,7 @@ pub struct NtfyProvider {
     server_url: String,
     auth: NtfyAuth,
     trusted_server: bool,
+    trusted_client: Option<reqwest::Client>,
 }
 
 impl NtfyProvider {
@@ -38,6 +39,7 @@ impl NtfyProvider {
             server_url: server_url.trim_end_matches('/').to_string(),
             auth,
             trusted_server: false,
+            trusted_client: None,
         }
     }
 
@@ -46,6 +48,13 @@ impl NtfyProvider {
             server_url: server_url.trim_end_matches('/').to_string(),
             auth,
             trusted_server: true,
+            trusted_client: Some(
+                reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(10))
+                    .redirect(reqwest::redirect::Policy::none())
+                    .build()
+                    .expect("failed to build ntfy HTTP client"),
+            ),
         }
     }
 
@@ -94,11 +103,7 @@ impl NotificationProvider for NtfyProvider {
             let topic = &method.notification_target;
             let ntfy_url = format!("{}/{}", self.server_url, topic);
             let client = if self.trusted_server {
-                reqwest::Client::builder()
-                    .timeout(std::time::Duration::from_secs(10))
-                    .redirect(reqwest::redirect::Policy::none())
-                    .build()
-                    .expect("failed to build ntfy HTTP client")
+                self.trusted_client.clone().expect("trusted ntfy client")
             } else {
                 match validate_public_url(&ntfy_url).await {
                     Ok(parsed_url) => match client_for_public_url(&parsed_url).await {

--- a/backend/src/outbound_target.rs
+++ b/backend/src/outbound_target.rs
@@ -54,7 +54,12 @@ fn is_public_ip(ip: IpAddr) -> bool {
                 || ip.is_broadcast()
                 || ip.is_multicast()
                 || ip.octets()[0] == 0
-                || (ip.octets()[0] == 100 && (64..=127).contains(&ip.octets()[1])))
+                || ip.octets()[0] >= 224
+                || (ip.octets()[0] == 100 && (64..=127).contains(&ip.octets()[1]))
+                || (ip.octets()[0] == 192 && matches!(ip.octets()[1], 0 | 168))
+                || (ip.octets()[0] == 198 && matches!(ip.octets()[1], 18 | 19))
+                || (ip.octets()[0] == 198 && ip.octets()[1] == 51 && ip.octets()[2] == 100)
+                || (ip.octets()[0] == 203 && ip.octets()[1] == 0 && ip.octets()[2] == 113))
         }
         IpAddr::V6(ip) => {
             let octets = ip.octets();
@@ -64,6 +69,8 @@ fn is_public_ip(ip: IpAddr) -> bool {
                 || ip.is_unique_local()
                 || ip.is_unicast_link_local()
                 || ip.is_multicast()
+                || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0xc0)
+                || octets[..12] == [0; 12]
                 || mapped_ipv4)
         }
     }
@@ -87,6 +94,11 @@ mod tests {
             "fc00::1",
             "fe80::1",
             "::ffff:127.0.0.1",
+            "192.0.0.1",
+            "198.18.0.1",
+            "240.0.0.1",
+            "fec0::1",
+            "::127.0.0.1",
         ] {
             let url = if address.contains(':') {
                 format!("http://[{address}]/")

--- a/backend/src/outbound_target.rs
+++ b/backend/src/outbound_target.rs
@@ -1,0 +1,100 @@
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+use tokio::net::lookup_host;
+use url::Url;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub async fn validate_public_url(input: &str) -> Result<Url, String> {
+    let url = Url::parse(input).map_err(|_| "URL must be an absolute URL".to_string())?;
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        return Err("URL must use http or https and include a host".to_string());
+    }
+    resolve_public_addresses(&url).await?;
+    Ok(url)
+}
+
+pub async fn client_for_public_url(url: &Url) -> Result<reqwest::Client, String> {
+    let addresses = resolve_public_addresses(url).await?;
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        // Use only the addresses just validated, preventing DNS rebinding.
+        .resolve_to_addrs(url.host_str().expect("validated URL host"), &addresses)
+        .build()
+        .map_err(|_| "Could not create outbound request client".to_string())
+}
+
+async fn resolve_public_addresses(url: &Url) -> Result<Vec<SocketAddr>, String> {
+    let host = url.host_str().expect("validated URL host");
+    let port = url
+        .port_or_known_default()
+        .expect("HTTP URL has a default port");
+    let addresses: Vec<_> = lookup_host((host, port))
+        .await
+        .map_err(|_| "Could not resolve outbound host".to_string())?
+        .collect();
+
+    if addresses.is_empty() || addresses.iter().any(|address| !is_public_ip(address.ip())) {
+        return Err("Outbound URL must resolve only to public addresses".to_string());
+    }
+    Ok(addresses)
+}
+
+fn is_public_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            !(ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_broadcast()
+                || ip.is_multicast()
+                || ip.octets()[0] == 0
+                || (ip.octets()[0] == 100 && (64..=127).contains(&ip.octets()[1])))
+        }
+        IpAddr::V6(ip) => {
+            let octets = ip.octets();
+            let mapped_ipv4 = octets[..10] == [0; 10] && octets[10] == 0xff && octets[11] == 0xff;
+            !(ip.is_loopback()
+                || ip.is_unspecified()
+                || ip.is_unique_local()
+                || ip.is_unicast_link_local()
+                || ip.is_multicast()
+                || mapped_ipv4)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_public_url;
+
+    #[tokio::test]
+    async fn rejects_private_and_special_ranges() {
+        for address in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.0.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "0.0.0.0",
+            "::1",
+            "fc00::1",
+            "fe80::1",
+            "::ffff:127.0.0.1",
+        ] {
+            let url = if address.contains(':') {
+                format!("http://[{address}]/")
+            } else {
+                format!("http://{address}/")
+            };
+            assert!(
+                validate_public_url(&url).await.is_err(),
+                "accepted {address}"
+            );
+        }
+    }
+}

--- a/backend/src/outbound_target.rs
+++ b/backend/src/outbound_target.rs
@@ -71,6 +71,12 @@ fn is_public_ip(ip: IpAddr) -> bool {
                 || ip.is_multicast()
                 || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0xc0)
                 || octets[..12] == [0; 12]
+                || (octets[0] == 0x01 && octets[1] == 0x00 && octets[2..] == [0; 14])
+                || (octets[0] == 0x20
+                    && octets[1] == 0x01
+                    && matches!(octets[2], 0x00 | 0x02 | 0x0d | 0x10))
+                || (octets[0] == 0x20 && octets[1] == 0x02)
+                || (octets[0] == 0x64 && octets[1] == 0xff && octets[2] == 0x9b)
                 || mapped_ipv4)
         }
     }
@@ -99,6 +105,12 @@ mod tests {
             "240.0.0.1",
             "fec0::1",
             "::127.0.0.1",
+            "100::",
+            "2001:db8::1",
+            "2001:2::1",
+            "2001:10::1",
+            "2002::1",
+            "64:ff9b::1",
         ] {
             let url = if address.contains(':') {
                 format!("http://[{address}]/")

--- a/backend/src/outbound_target.rs
+++ b/backend/src/outbound_target.rs
@@ -5,6 +5,7 @@ use tokio::net::lookup_host;
 use url::Url;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub async fn validate_public_url(input: &str) -> Result<Url, String> {
     let url = Url::parse(input).map_err(|_| "URL must be an absolute URL".to_string())?;
@@ -31,8 +32,9 @@ async fn resolve_public_addresses(url: &Url) -> Result<Vec<SocketAddr>, String> 
     let port = url
         .port_or_known_default()
         .expect("HTTP URL has a default port");
-    let addresses: Vec<_> = lookup_host((host, port))
+    let addresses: Vec<_> = tokio::time::timeout(DNS_LOOKUP_TIMEOUT, lookup_host((host, port)))
         .await
+        .map_err(|_| "Timed out resolving outbound host".to_string())?
         .map_err(|_| "Could not resolve outbound host".to_string())?
         .collect();
 

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -2710,6 +2710,12 @@ mod tests {
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
         let webhook_url = format!("http://{address}/hook");
+        let webhook_provider = WebhookProvider::with_client(
+            reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .unwrap(),
+        );
         let contact = Contact {
             id: Some("contact-1".to_string()),
             wallet_checksum: "wallet-checksum".to_string(),
@@ -2748,7 +2754,7 @@ mod tests {
             .unwrap();
         let pending = notification_receiver.recv().await.unwrap();
         assert!(matches!(pending, TransactionNotification::Pending(_)));
-        let pending_results = WebhookProvider::new()
+        let pending_results = webhook_provider
             .send_notification(
                 &pending,
                 "Wallet",
@@ -2772,7 +2778,7 @@ mod tests {
             .unwrap();
         let confirmed = notification_receiver.recv().await.unwrap();
         assert!(matches!(confirmed, TransactionNotification::Confirmed(_)));
-        let confirmed_results = WebhookProvider::new()
+        let confirmed_results = webhook_provider
             .send_notification(&confirmed, "Wallet", &[contact], &Language::English, None)
             .await;
         assert!(confirmed_results[0].1.success);

--- a/backend/src/tests/webhook_provider.rs
+++ b/backend/src/tests/webhook_provider.rs
@@ -69,6 +69,15 @@ fn payload_for(notification: TransactionNotification) -> WebhookPayload {
     )
 }
 
+fn test_provider() -> WebhookProvider {
+    WebhookProvider::with_client(
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap(),
+    )
+}
+
 fn balance_alert() -> BalanceAlertNotification {
     BalanceAlertNotification {
         id: "notification-id".to_string(),
@@ -86,20 +95,20 @@ fn balance_alert() -> BalanceAlertNotification {
     }
 }
 
-#[test]
-fn validates_and_canonicalizes_absolute_http_urls() {
+#[tokio::test]
+async fn validates_and_canonicalizes_public_http_urls() {
     assert_eq!(
-        validate_webhook_url(" https://example.com/hooks/canary?token=secret ").unwrap(),
+        validate_webhook_url(" https://example.com/hooks/canary?token=secret ")
+            .await
+            .unwrap(),
         "https://example.com/hooks/canary?token=secret"
     );
-    assert_eq!(
-        validate_webhook_url("http://127.0.0.1:8080/hook").unwrap(),
-        "http://127.0.0.1:8080/hook"
-    );
-    assert_eq!(
-        validate_webhook_url("http://host.docker.internal:8080").unwrap(),
-        "http://host.docker.internal:8080/"
-    );
+    assert!(validate_webhook_url("http://127.0.0.1:8080/hook")
+        .await
+        .is_err());
+    assert!(validate_webhook_url("http://[::1]:8080/hook")
+        .await
+        .is_err());
 
     for invalid in [
         "",
@@ -109,9 +118,16 @@ fn validates_and_canonicalizes_absolute_http_urls() {
         "https://example.com/hook#fragment",
         "http:///missing-host",
     ] {
-        assert!(validate_webhook_url(invalid).is_err(), "accepted {invalid}");
+        assert!(
+            validate_webhook_url(invalid).await.is_err(),
+            "accepted {invalid}"
+        );
     }
-    assert!(validate_webhook_url(&format!("https://example.com/{}", "x".repeat(2_100))).is_err());
+    assert!(
+        validate_webhook_url(&format!("https://example.com/{}", "x".repeat(2_100)))
+            .await
+            .is_err()
+    );
 }
 
 #[test]
@@ -215,7 +231,7 @@ async fn posts_json_and_accepts_any_2xx_status() {
     let address = listener.local_addr().unwrap();
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-    let provider = WebhookProvider::new();
+    let provider = test_provider();
     let result = provider
         .send_payload(
             &format!("http://{address}/hook"),
@@ -285,7 +301,7 @@ async fn delivers_every_event_variant_to_a_disposable_receiver() {
         WebhookPayload::test(&Language::English),
     ];
 
-    let provider = WebhookProvider::new();
+    let provider = test_provider();
     for payload in &payloads {
         assert!(provider.send_payload(&url, payload).await.success);
     }
@@ -331,7 +347,7 @@ async fn does_not_follow_redirects() {
     let address = listener.local_addr().unwrap();
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-    let result = WebhookProvider::new()
+    let result = test_provider()
         .send_payload(
             &format!("http://{address}/hook"),
             &WebhookPayload::test(&Language::English),
@@ -360,7 +376,7 @@ async fn does_not_retry_failed_deliveries() {
     let address = listener.local_addr().unwrap();
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-    let result = WebhookProvider::new()
+    let result = test_provider()
         .send_payload(
             &format!("http://{address}/hook"),
             &WebhookPayload::test(&Language::English),
@@ -430,7 +446,7 @@ async fn bounds_concurrent_deliveries() {
     let url = format!("http://{address}/hook");
     let contacts: Vec<_> = (0..9).map(|index| contact(&url, index)).collect();
 
-    let results = WebhookProvider::new()
+    let results = test_provider()
         .send_notification(
             &TransactionNotification::Pending(transaction(EventType::Receive, false)),
             "Wallet",

--- a/backend/src/webhook_provider.rs
+++ b/backend/src/webhook_provider.rs
@@ -7,21 +7,18 @@ use crate::notifications::{
     notification_log_type, notification_methods_for_provider, NotificationProvider,
     NotificationResult, ProviderInfo,
 };
+use crate::outbound_target::{client_for_public_url, validate_public_url};
 use async_trait::async_trait;
 use chrono::Utc;
 use futures::{stream, StreamExt};
 use rust_i18n::t;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::sync::OnceLock;
-use std::time::Duration;
 use url::Url;
 
 pub const WEBHOOK_SCHEMA_VERSION: u8 = 1;
 pub const WEBHOOK_MAX_URL_LENGTH: usize = 2_048;
 pub const WEBHOOK_MAX_CONCURRENT_DELIVERIES: usize = 4;
-const WEBHOOK_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-static WEBHOOK_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebhookPayload {
@@ -200,7 +197,7 @@ fn localized_title(event: &str, wallet_name: &str, language: &Language) -> Strin
     format!("{} - {}", title, wallet_name)
 }
 
-pub fn validate_webhook_url(input: &str) -> Result<String, String> {
+pub async fn validate_webhook_url(input: &str) -> Result<String, String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return Err("Webhook URL cannot be empty".to_string());
@@ -242,6 +239,7 @@ pub fn validate_webhook_url(input: &str) -> Result<String, String> {
             WEBHOOK_MAX_URL_LENGTH
         ));
     }
+    validate_public_url(&canonical).await?;
     Ok(canonical)
 }
 
@@ -275,32 +273,33 @@ fn sanitized_request_error(error: &reqwest::Error, webhook_url: &str) -> String 
 }
 
 pub struct WebhookProvider {
-    client: reqwest::Client,
+    test_client: Option<reqwest::Client>,
 }
 
 impl WebhookProvider {
     pub fn new() -> Self {
-        Self::with_client(Self::default_client())
+        Self { test_client: None }
     }
 
+    #[allow(dead_code)] // Used by unit tests with local disposable receivers.
     pub fn with_client(client: reqwest::Client) -> Self {
-        Self { client }
-    }
-
-    pub fn default_client() -> reqwest::Client {
-        WEBHOOK_CLIENT
-            .get_or_init(|| {
-                reqwest::Client::builder()
-                    .timeout(WEBHOOK_REQUEST_TIMEOUT)
-                    .redirect(reqwest::redirect::Policy::none())
-                    .build()
-                    .expect("failed to build webhook HTTP client")
-            })
-            .clone()
+        Self {
+            test_client: Some(client),
+        }
     }
 
     pub async fn send_payload(&self, url: &str, payload: &WebhookPayload) -> NotificationResult {
-        match self.client.post(url).json(payload).send().await {
+        let client = match &self.test_client {
+            Some(client) => client.clone(),
+            None => match validate_public_url(url).await {
+                Ok(parsed_url) => match client_for_public_url(&parsed_url).await {
+                    Ok(client) => client,
+                    Err(_) => return blocked_target_result(),
+                },
+                Err(_) => return blocked_target_result(),
+            },
+        };
+        match client.post(url).json(payload).send().await {
             Ok(response) if response.status().is_success() => NotificationResult {
                 success: true,
                 provider_id: Some(format!("webhook_{}", uuid::Uuid::new_v4())),
@@ -317,6 +316,14 @@ impl WebhookProvider {
                 error_message: Some(sanitized_request_error(&error, url)),
             },
         }
+    }
+}
+
+fn blocked_target_result() -> NotificationResult {
+    NotificationResult {
+        success: false,
+        provider_id: None,
+        error_message: Some("Webhook target is not publicly reachable".to_string()),
     }
 }
 

--- a/backend/tests/resource_limit_handlers_tests.rs
+++ b/backend/tests/resource_limit_handlers_tests.rs
@@ -656,7 +656,7 @@ async fn test_self_hosted_webhook_provider_validation_reuse_and_redacted_display
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(body["error_code"], "invalid_webhook_url");
 
-    let full_url = "http://receiver.local:8080/hooks/canary?token=secret";
+    let full_url = "https://example.com/hooks/canary?token=secret";
     for _ in 0..2 {
         let (status, _) =
             create_contact_with_provider(&app, &token, checksum, "webhook", full_url).await;
@@ -689,27 +689,19 @@ async fn test_self_hosted_webhook_provider_validation_reuse_and_redacted_display
         .all(|method| method["notification_target"] == full_url));
     assert!(webhook_methods
         .iter()
-        .all(|method| method["display_target"] == "http://receiver.local:8080"));
+        .all(|method| method["display_target"] == "https://example.com"));
 
     let (status, _) = post_webhook_test(&app, None, full_url).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 
-    let receiver = axum::Router::new().route(
-        "/hook",
-        axum::routing::post(|| async { StatusCode::NO_CONTENT }),
-    );
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let address = listener.local_addr().unwrap();
-    tokio::spawn(async move { axum::serve(listener, receiver).await.unwrap() });
     let (status, body) = post_webhook_test(
         &app,
         Some(&token),
-        &format!("http://{address}/hook?token=secret"),
+        "http://127.0.0.1:8080/hook?token=secret",
     )
     .await;
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["success"], true);
-    assert!(body.get("error").is_none());
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error_code"], "invalid_webhook_url");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary\n\n- validate self-hosted ntfy and webhook targets after DNS resolution, rejecting private and special-use addresses\n- pin validated DNS results into outbound reqwest clients and disable redirects\n- stop returning upstream ntfy bodies and raw request errors\n- cover private IPv4/IPv6 and loopback webhook targets in regression tests\n\nComplements #459 with the remaining SSRF protections from #451.\n\n## Validation\n\n- 
running 313 tests
test admin_notifications::tests::is_enabled_for_env_requires_cloud_mode_and_topic ... ok
test admin_notifications::tests::spawn_if_enabled_does_not_run_when_disabled ... ok
test admin_notifications::tests::spawn_if_enabled_runs_when_enabled ... ok
test config::tests::test_bdk_network_conversion ... ok
test config::tests::test_cloud_mode_ignores_detected_ntfy_default ... ok
test config::tests::test_cloud_mode_sync_interval_fallback ... ok
test config::tests::test_custom_electrum_url_override ... ok
test config::tests::test_default_electrum_urls ... ok
test config::tests::test_detected_ntfy_server_becomes_self_hosted_default ... ok
test config::tests::test_detected_ntfy_server_takes_precedence_over_fallback_url ... ok
test config::tests::test_detected_umbrel_ntfy_url_takes_precedence_over_fallback_env ... ok
test config::tests::test_effective_paths ... ok
test config::tests::test_get_jwt_secret_cloud_mode_with_secret ... ok
test config::tests::test_get_jwt_secret_cloud_mode_without_secret ... ok
test config::tests::test_get_jwt_secret_rejects_blank_self_hosted_secret ... ok
test config::tests::test_get_jwt_secret_self_hosted_mode ... ok
test config::tests::test_get_self_hosted_admin_password_cloud_mode ... ok
test config::tests::test_get_self_hosted_admin_password_rejects_blank_password ... ok
test config::tests::test_get_self_hosted_admin_password_self_hosted_mode ... ok
test config::tests::test_is_cloud_mode ... ok
test config::tests::test_load_detects_startos_managed_ntfy_defaults_in_self_hosted_mode ... ok
test config::tests::test_load_detects_tx_explorer_url_lists_in_self_hosted_mode ... ok
test config::tests::test_load_detects_umbrel_ntfy_url_in_self_hosted_mode ... ok
test config::tests::test_load_does_not_guess_default_when_multiple_local_ntfy_servers_exist ... ok
test config::tests::test_load_ignores_invalid_startos_ntfy_topic ... ok
test config::tests::test_load_ignores_startos_ntfy_defaults_in_cloud_mode ... ok
test config::tests::test_load_ignores_startos_ntfy_token_without_server_url ... ok
test config::tests::test_load_registers_startos_ntfy_url_without_managed_auth ... ok
test config::tests::test_network_config_parsing ... ok
test config::tests::test_network_database_isolation ... ok
test config::tests::test_network_electrum_url_defaults ... ok
test config::tests::test_network_specific_paths ... ok
test config::tests::test_ntfy_auth_allowed_for_matching_configured_url_in_cloud_mode ... ok
test config::tests::test_ntfy_auth_only_allowed_for_matching_saved_or_detected_url ... ok
test config::tests::test_ntfy_fallback_url_env_validates_configured_url ... ok
test config::tests::test_ntfy_server_config_rejects_blank_url ... ok
test config::tests::test_ntfy_server_url_falls_back_to_env_without_detected_local ... ok
test config::tests::test_operating_mode_parsing ... ok
test config::tests::test_self_hosted_mode_sync_interval_legacy_fallback ... ok
test config::tests::test_self_hosted_mode_sync_interval_network_defaults ... ok
test config::tests::test_tx_explorer_config_ignores_blank_platform ... ok
test config::tests::test_tx_explorer_config_rejects_blank_base_url ... ok
test config::tests::test_tx_explorer_url_list_env_validates_and_deduplicates_urls ... ok
test config::tests::test_with_managed_ntfy_auth_only_fills_empty_auth_for_managed_server ... ok
test electrum::tests::operation_gate_is_scoped_to_subscription_enabled_self_hosted_clients ... ok
test electrum::tests::test_is_transport_error ... ok
test electrum::tests::timeout_cancels_worker_and_allows_work_gate_release ... ok
test electrum_history::tests::cancelled_work_stops_before_the_next_electrum_rpc ... ok
test electrum_history::tests::changed_and_multiple_queued_notifications_refresh_once ... ok
test electrum_history::tests::consumed_notification_remains_dirty_after_failed_history_refresh ... ok
test electrum_history::tests::electrs_warning_condition_is_avoided_and_warm_history_is_cached ... ok
test electrum_history::tests::large_cold_cache_subscribes_once_per_bdk_batch ... ok
test electrum_history::tests::malformed_history_batch_lengths_return_errors ... ok
test electrum_history::tests::not_subscribed_after_hidden_reconnect_resubscribes_and_compares_status ... ok
test electrum_history::tests::notification_drain_has_a_safety_bound ... ok
test electrum_history::tests::null_status_after_hidden_reconnect_clears_non_empty_history ... ok
test electrum_history::tests::partial_batch_subscription_is_reconciled_without_an_already_subscribed_loop ... ok
test electrum_history::tests::polling_and_recurring_clients_share_timeout_state ... ok
test electrum_history::tests::reconnect_resubscribes_without_refetching_unchanged_history ... ok
test electrum_history::tests::safety_revalidation_clears_non_empty_history_after_ambiguous_null ... ok
test electrum_history::tests::six_hour_revalidation_and_polling_fallback_preserve_order ... ok
test electrum_history::tests::sparse_batch_refresh_keeps_status_with_its_original_script ... ok
test electrum_history::tests::wallet_cleanup_error_requires_connection_replacement ... ok
test electrum_history::tests::wallet_cleanup_handles_large_subscription_sets ... ok
test electrum_history::tests::wallet_cleanup_stops_between_rpcs_after_cancellation ... ok
test electrum_history::tests::wallet_cleanup_unsubscribes_and_evicts_only_removed_scripts ... ok
test exchange_rates::tests::fetch_rates_retries_connect_failures_with_backoff ... ok
test exchange_rates::tests::retryable_status_includes_429_and_5xx_only ... ok
test exchange_rates::tests::test_locale_to_currency_case_insensitive ... ok
test exchange_rates::tests::test_locale_to_currency_simple_language ... ok
test exchange_rates::tests::test_locale_to_currency_unknown_falls_back_to_usd ... ok
test exchange_rates::tests::test_locale_to_currency_with_encoding ... ok
test exchange_rates::tests::test_locale_to_currency_with_quality ... ok
test exchange_rates::tests::test_locale_to_currency_with_region ... ok
test exchange_rates::tests::test_locale_to_currency_with_script ... ok
test exchange_rates::tests::test_locale_to_currency_with_underscore ... ok
test handlers::auth::tests::pad_response_to_duration_waits_until_floor ... ok
test handlers::config::tests::cloud_config_does_not_expose_self_hosted_ntfy_servers ... ok
test handlers::helpers::tests::fixed_database_error_message_does_not_leak_internal_details ... ok
test metadata::integrity::tests::cleanup_rolls_back_when_audit_insert_fails ... ok
test metadata::integrity::tests::cleanup_writes_admin_audit_log_for_noop ... ok
test metadata::integrity::tests::cleanup_writes_admin_audit_log_with_counts ... ok
test metadata::wallet::tests::map_wallet_metadata_row_can_decode_is_active_strictly_or_with_fallback ... ok
test metadata::wallet::tests::map_wallet_metadata_row_defaults_optional_values_to_zero_when_requested ... ok
test metadata::wallet::tests::map_wallet_metadata_row_preserves_none_for_balance_total_without_zero_default ... ok
test models::responses::tests::coded_error_response_serializes_error_code ... ok
test models::responses::tests::new_error_response_omits_error_code ... ok
test nostr_provider::tests::builds_legacy_nip04_dm_events ... ok
test nostr_provider::tests::canonicalizes_npub_and_hex_public_keys ... ok
test nostr_provider::tests::formats_display_target_from_stored_hex_public_key ... ok
test nostr_provider::tests::formats_test_message_with_delivery_mode ... ok
test nostr_provider::tests::limits_recipient_inbox_relay_attempts ... ok
test nostr_provider::tests::maps_known_test_send_errors_to_codes ... ok
test nostr_provider::tests::parses_nostr_dm_modes ... ok
test nostr_provider::tests::rejects_empty_invalid_and_private_keys ... ok
test notification_failure_tracker::tests::test_display_formatting ... ok
test notification_failure_tracker::tests::test_error_categorization ... ok
test notification_failure_tracker::tests::test_failure_tracking ... ok
test notification_failure_tracker::tests::test_recovery_notification ... ok
test notification_failure_tracker::tests::test_suggested_actions ... ok
test outbound_target::tests::rejects_private_and_special_ranges ... ok
test subscription::tests::test_defaults_when_no_env_vars ... ok
test subscription::tests::test_get_effective_subscription_status_active ... ok
test subscription::tests::test_get_effective_subscription_status_expired_trial ... ok
test subscription::tests::test_get_effective_subscription_status_other_statuses ... ok
test subscription::tests::test_get_effective_subscription_status_valid_trial ... ok
test subscription::tests::test_is_subscription_active_with_active_status ... ok
test subscription::tests::test_is_subscription_active_with_canceled_future_end ... ok
test subscription::tests::test_is_subscription_active_with_canceled_invalid_date ... ok
test subscription::tests::test_is_subscription_active_with_canceled_past_end ... ok
test subscription::tests::test_is_subscription_active_with_expired_trial ... ok
test subscription::tests::test_is_subscription_active_with_other_statuses ... ok
test subscription::tests::test_is_subscription_active_with_valid_trial ... ok
test subscription::tests::test_tier_specific_intervals ... ok
test sync::tests::sync_pending_and_confirmation_events_flow_to_webhook_delivery ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_adds_coinbase_when_history_present ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_avoids_double_counting ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_does_not_adjust_without_history_entry ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_requires_exact_script ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_requires_mainnet ... ok
test sync::tests::test_confirmed_block_height_accepts_genesis_height ... ok
test sync::tests::test_detect_address_watch_cpfp_relationships ... ok
test sync::tests::test_detect_address_watch_rbf_replacements ... ok
test sync::tests::test_detect_address_watch_rbf_replacements_accepts_confirmed_candidate ... ok
test sync::tests::test_genesis_block_timestamp_is_mainnet_only ... ok
test sync::tests::test_is_tx_confirmed_genesis_coinbase ... ok
test sync::tests::test_is_tx_confirmed_genesis_coinbase_requires_mainnet ... ok
test sync::tests::test_is_tx_confirmed_mempool ... ok
test sync::tests::test_is_tx_confirmed_positive_height ... ok
test sync::tests::test_is_tx_confirmed_unconfirmed_parents ... ok
test sync::tests::test_mainnet_genesis_coinbase_tx_state ... ok
test sync::tests::test_mainnet_genesis_coinbase_tx_state_requires_exact_match ... ok
test sync::tests::test_mainnet_genesis_p2pk_script_includes_checksig ... ok
test tests::address::tests::test_address_to_descriptor_deterministic ... ok
test tests::address::tests::test_address_to_descriptor_format ... ok
test tests::address::tests::test_is_bitcoin_address_regtest_p2pkh ... ok
test tests::address::tests::test_is_bitcoin_address_regtest_p2sh ... ok
test tests::address::tests::test_is_bitcoin_address_regtest_p2tr ... ok
test tests::address::tests::test_is_bitcoin_address_regtest_p2wpkh ... ok
test tests::address::tests::test_is_bitcoin_address_rejects_non_addresses ... ok
test tests::address::tests::test_validate_address_network_accepts_regtest ... ok
test tests::address::tests::test_validate_address_network_rejects_invalid_string ... ok
test tests::address::tests::test_validate_address_network_rejects_mainnet_on_regtest ... ok
test tests::auth::authenticate_user_accepts_self_hosted_token_with_active_session ... ok
test tests::auth::authenticate_user_rejects_self_hosted_token_without_active_session ... ok
test tests::auth::authenticate_user_rejects_token_after_logout ... ok
test tests::auth::authenticate_user_rejects_token_with_expired_session ... ok
test tests::auth::authenticate_user_rejects_token_without_active_session ... ok
test tests::auth::password_reset_helper_revokes_all_existing_tokens ... ok
test tests::donations::test_btcpay_client_creation_with_full_config ... ok
test tests::donations::test_btcpay_client_creation_without_recurring ... ok
test tests::donations::test_btcpay_enabled_with_required_fields ... ok
test tests::donations::test_btcpay_not_enabled_by_default ... ok
test tests::donations::test_btcpay_not_enabled_with_partial_config ... ok
test tests::donations::test_btcpay_recurring_enabled_with_full_config ... ok
test tests::donations::test_btcpay_recurring_requires_non_empty_fields ... ok
test tests::donations::test_redirect_response_invalid_url ... ok
test tests::donations::test_redirect_response_valid_url ... ok
test tests::donations::test_thank_you_url_fallback_without_frontend_url ... ok
test tests::donations::test_thank_you_url_strips_trailing_slash ... ok
test tests::donations::test_thank_you_url_with_frontend_url ... ok
test tests::message_formatter::test_create_english_message_includes_wallet_balance ... ok
test tests::message_formatter::test_create_english_message_receive_confirmed ... ok
test tests::message_formatter::test_create_english_message_receive_unconfirmed ... ok
test tests::message_formatter::test_create_english_message_send_confirmed ... ok
test tests::message_formatter::test_create_english_message_send_cpfp ... ok
test tests::message_formatter::test_create_english_message_send_unconfirmed ... ok
test tests::message_formatter::test_create_english_subject_send_cpfp ... ok
test tests::message_formatter::test_create_norwegian_message_receive_confirmed ... ok
test tests::message_formatter::test_create_norwegian_message_receive_unconfirmed ... ok
test tests::message_formatter::test_create_norwegian_message_send_confirmed ... ok
test tests::message_formatter::test_create_norwegian_message_send_unconfirmed ... ok
test tests::message_formatter::test_format_btc_amount_all_decimals_significant ... ok
test tests::message_formatter::test_format_btc_amount_large_english ... ok
test tests::message_formatter::test_format_btc_amount_large_norwegian ... ok
test tests::message_formatter::test_format_btc_amount_max_supply ... ok
test tests::message_formatter::test_format_btc_amount_mixed_trailing_zeros ... ok
test tests::message_formatter::test_format_btc_amount_one_satoshi ... ok
test tests::message_formatter::test_format_btc_amount_small_english ... ok
test tests::message_formatter::test_format_btc_amount_small_norwegian ... ok
test tests::message_formatter::test_format_btc_amount_trailing_zeros_trimmed ... ok
test tests::message_formatter::test_format_btc_amount_zero ... ok
test tests::metadata::test_auth_rate_limit_blocks_after_threshold_within_window ... ok
test tests::metadata::test_auth_rate_limit_is_scoped_by_endpoint_and_identifier ... ok
test tests::metadata::test_auth_rate_limit_normalizes_identifier ... ok
test tests::metadata::test_auth_rate_limit_resets_after_block_expires ... ok
test tests::metadata::test_auth_rate_limit_resets_after_window_expires ... ok
test tests::metadata::test_auth_rate_limit_stays_blocked_until_expiry ... ok
test tests::metadata::test_cross_wallet_verification_different_users ... ok
test tests::metadata::test_cross_wallet_verification_email_case_insensitive ... ok
test tests::metadata::test_cross_wallet_verification_same_user_email ... ok
test tests::metadata::test_cross_wallet_verification_same_user_sms ... ok
test tests::metadata::test_cross_wallet_verification_sms_exact_match ... ok
test tests::metadata::test_delete_wallet_contact_authorization ... ok
test tests::metadata::test_delete_wallet_contact_nonexistent ... ok
test tests::metadata::test_delete_wallet_contact_wrong_wallet ... ok
test tests::metadata::test_deleted_wallets_do_not_consume_limit_slots ... ok
test tests::metadata::test_deleted_wallets_excluded_from_subscription_limits ... ok
test tests::metadata::test_failed_wallets_do_not_consume_active_limit_slots ... ok
test tests::metadata::test_failed_wallets_do_not_count_toward_wallet_limit ... ok
test tests::metadata::test_get_user_preferred_language_default ... ok
test tests::metadata::test_get_user_preferred_language_japanese ... ok
test tests::metadata::test_get_user_preferred_language_nonexistent_user ... ok
test tests::metadata::test_get_user_preferred_language_norwegian ... ok
test tests::metadata::test_get_wallets_for_tier_sync_excludes_pending_descriptor_wallets ... ok
test tests::metadata::test_get_wallets_for_tier_sync_uses_transaction_last_activity ... ok
test tests::metadata::test_inactive_contacts_do_not_consume_limit_slots ... ok
test tests::metadata::test_include_notifications_batches_correctly ... ok
test tests::metadata::test_legacy_wallet_level_balance_alerts_remain_active_and_manageable ... ok
test tests::metadata::test_rate_limit_reports_remaining_retry_after_seconds ... ok
test tests::metadata::test_transaction_ordering_expression_index_is_applied ... ok
test tests::metadata::test_transaction_ordering_prefers_confirmed_at ... ok
test tests::metadata::test_transaction_pagination_since_timestamp_returns_changed_rows ... ok
test tests::metadata::test_transaction_pagination_uses_cursor ... ok
test tests::metadata::test_twilio_locale_all_languages_are_valid ... ok
test tests::metadata::test_twilio_locale_danish ... ok
test tests::metadata::test_twilio_locale_english ... ok
test tests::metadata::test_twilio_locale_french ... ok
test tests::metadata::test_twilio_locale_german ... ok
test tests::metadata::test_twilio_locale_japanese ... ok
test tests::metadata::test_twilio_locale_norwegian ... ok
test tests::metadata::test_twilio_locale_portuguese ... ok
test tests::metadata::test_twilio_locale_spanish ... ok
test tests::metadata::test_twilio_locale_swedish ... ok
test tests::metadata::test_update_contact_preserves_matching_notification_method_ids ... ok
test tests::metadata::test_update_user_preferred_tx_explorer_id ... ok
test tests::metadata::test_wallet_last_activity_falls_back_to_first_seen_at_for_pending_transactions ... ok
test tests::metadata::test_wallet_last_activity_uses_confirmed_at_for_confirmed_transactions ... ok
test tests::metadata::test_wallet_status_accepts_failed_and_rejects_invalid_statuses ... ok
test tests::metadata::test_wallet_status_if_not_deleted_does_not_overwrite_deleted_wallets ... ok
test tests::notifications::test_contact_allows_notification_rejects_contact_specific_balance_alert_without_contact_id ... ok
test tests::notifications::test_contact_allows_notification_rejects_inactive_contacts ... ok
test tests::notifications::test_contact_allows_notification_respects_replacement_and_fee_bump_checkboxes ... ok
test tests::notifications::test_contact_allows_notification_respects_transaction_type_checkboxes ... ok
test tests::notifications::test_contact_allows_notification_routes_legacy_wallet_level_balance_alerts_to_active_contacts ... ok
test tests::notifications::test_contact_allows_notification_treats_replaced_cpfp_as_rbf ... ok
test tests::notifications::test_create_contact_request_defaults_wallet_balance_notifications_off ... ok
test tests::notifications::test_email_provider_unconfigured_filters_only_email_methods ... ok
test tests::notifications::test_notification_manager ... ok
test tests::notifications::test_notification_manager_unknown_provider ... ok
test tests::notifications::test_notification_methods_for_provider_excludes_disabled_methods ... ok
test tests::notifications::test_notification_methods_for_provider_filters_and_preserves_contacts ... ok
test tests::notifications::test_ntfy_filters_only_ntfy_methods ... ok
test tests::notifications::test_ntfy_provider_custom_server ... ok
test tests::notifications::test_ntfy_provider_info ... ok
test tests::notifications::test_ntfy_send_notification ... ok
test tests::notifications::test_twilio_filters_only_sms_methods ... ok
test tests::notifications::test_twilio_provider_creation ... ok
test tests::notifications::test_twilio_provider_missing_env ... ok
test tests::notifications::test_twilio_send_notification ... ok
test tests::notifications::test_update_contact_request_preserves_omitted_notification_settings ... ok
test tests::wallet::tests::test_custom_stop_gap_requires_script_type ... ok
test tests::wallet::tests::test_descriptor_network_validation ... ok
test tests::wallet::tests::test_fresh_wallet_xpub_requires_script_type ... ok
test tests::wallet::tests::test_key_network_validation ... ok
test tests::wallet::tests::test_network_detection ... ok
test tests::wallet::tests::test_stop_gap_valid_values ... ok
test tests::wallet::tests::test_strip_key_origin_logic ... ok
test tests::wallet::tests::test_xpub_address_derivation_mock ... ok
test tests::wallet::tests::test_xpub_conversion_integration ... ignored, functionality moved to create_from_xpub_with_probing in wallet creation
test tests::wallet::tests::test_xpub_detection ... ok
test tests::wallet::tests::test_xpub_normalization ... ok
test tests::wallet::tests::test_xpub_script_type_detection ... ok
test tests::webhook_provider::bounds_concurrent_deliveries ... ok
test tests::webhook_provider::builds_balance_alert_and_test_payloads ... ok
test tests::webhook_provider::builds_every_transaction_payload_variant ... ok
test tests::webhook_provider::delivers_every_event_variant_to_a_disposable_receiver ... ok
test tests::webhook_provider::does_not_follow_redirects ... ok
test tests::webhook_provider::does_not_retry_failed_deliveries ... ok
test tests::webhook_provider::posts_json_and_accepts_any_2xx_status ... ok
test tests::webhook_provider::redacts_webhook_secrets_to_the_origin ... ok
test tests::webhook_provider::reports_timeouts_without_exposing_url_secrets ... ok
test tests::webhook_provider::validates_and_canonicalizes_public_http_urls ... ok
test tls::tests::rustls_crypto_provider_install_is_idempotent ... ok
test utils::descriptor::tests::test_extract_address_from_descriptor_rejects_pk ... ok
test utils::descriptor::tests::test_extract_address_from_descriptor_valid ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_rejects_addr ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_rejects_invalid ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_with_checksum ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_without_checksum ... ok
test utils::descriptor::tests::test_parse_descriptor_rejects_single_path_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_accepts_account_level_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_accepts_key_origin_hardened_path ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_derivation_in_sh_wpkh ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_wildcard_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_non_multipath ... ok
test utils::descriptor::tests::test_strip_key_origin_accepts_uppercase_h_hardened_path ... ok
test utils::descriptor::tests::test_strip_key_origin_rejects_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_strip_key_origin_with_origin ... ok
test utils::descriptor::tests::test_strip_key_origin_without_origin ... ok
test utils::time::tests::current_unix_timestamp_returns_current_time ... ok
test utils::time::tests::unix_timestamp_rejects_pre_epoch_times ... ok
test utils::time::tests::unix_timestamp_returns_seconds_since_epoch ... ok
test wallet::tests::bdk_two_path_creation_matches_canarys_former_split ... ok
test wallet::tests::bdk_two_path_creation_rejects_wrong_path_shapes ... ok
test wallet::tests::bdk_v2_sqlite_wallet_migrates_and_reloads ... ok
test wallet::tests::deferred_failure_does_not_starve_healthy_wallets ... ok
test wallet::tests::mixed_address_watch_group_suppresses_only_pending_watcher ... ok
test wallet::tests::pending_address_watches_keep_shared_subscriptions_active ... ok
test wallet::tests::persisted_wallet_load_checks_descriptor_and_network ... ok
test wallet::tests::recovery_scan_gap_uses_bdk_full_scan_depths ... ok
test wallet::tests::self_hosted_due_time_is_measured_from_completion ... ok
test wallet::tests::self_hosted_queue_orders_never_synced_then_oldest_with_stable_tie_breaker ... ok
test wallet::tests::self_hosted_queue_scales_oldest_first_for_reported_wallet_counts ... ok
test wallet::tests::self_hosted_work_gate_keeps_peak_concurrency_at_one ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_compressed ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_rejects_invalid ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_trims_whitespace ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_uncompressed ... ok
test xpub_converter::tests::test_pubkey_to_descriptor ... ok
test xpub_converter::tests::test_pubkey_to_descriptor_invalid ... ok
test xpub_converter::tests::test_validate_descriptor_network_bypasses_pubkey ... ok

test result: ok. 312 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 22.15s


running 173 tests
test admin_notifications::tests::is_enabled_for_env_requires_cloud_mode_and_topic ... ok
test admin_notifications::tests::spawn_if_enabled_does_not_run_when_disabled ... ok
test admin_notifications::tests::spawn_if_enabled_runs_when_enabled ... ok
test config::tests::test_bdk_network_conversion ... ok
test config::tests::test_cloud_mode_ignores_detected_ntfy_default ... ok
test config::tests::test_cloud_mode_sync_interval_fallback ... ok
test config::tests::test_custom_electrum_url_override ... ok
test config::tests::test_default_electrum_urls ... ok
test config::tests::test_detected_ntfy_server_becomes_self_hosted_default ... ok
test config::tests::test_detected_ntfy_server_takes_precedence_over_fallback_url ... ok
test config::tests::test_detected_umbrel_ntfy_url_takes_precedence_over_fallback_env ... ok
test config::tests::test_effective_paths ... ok
test config::tests::test_get_jwt_secret_cloud_mode_with_secret ... ok
test config::tests::test_get_jwt_secret_cloud_mode_without_secret ... ok
test config::tests::test_get_jwt_secret_rejects_blank_self_hosted_secret ... ok
test config::tests::test_get_jwt_secret_self_hosted_mode ... ok
test config::tests::test_get_self_hosted_admin_password_cloud_mode ... ok
test config::tests::test_get_self_hosted_admin_password_rejects_blank_password ... ok
test config::tests::test_get_self_hosted_admin_password_self_hosted_mode ... ok
test config::tests::test_is_cloud_mode ... ok
test config::tests::test_load_detects_startos_managed_ntfy_defaults_in_self_hosted_mode ... ok
test config::tests::test_load_detects_tx_explorer_url_lists_in_self_hosted_mode ... ok
test config::tests::test_load_detects_umbrel_ntfy_url_in_self_hosted_mode ... ok
test config::tests::test_load_does_not_guess_default_when_multiple_local_ntfy_servers_exist ... ok
test config::tests::test_load_ignores_invalid_startos_ntfy_topic ... ok
test config::tests::test_load_ignores_startos_ntfy_defaults_in_cloud_mode ... ok
test config::tests::test_load_ignores_startos_ntfy_token_without_server_url ... ok
test config::tests::test_load_registers_startos_ntfy_url_without_managed_auth ... ok
test config::tests::test_network_config_parsing ... ok
test config::tests::test_network_database_isolation ... ok
test config::tests::test_network_electrum_url_defaults ... ok
test config::tests::test_network_specific_paths ... ok
test config::tests::test_ntfy_auth_allowed_for_matching_configured_url_in_cloud_mode ... ok
test config::tests::test_ntfy_auth_only_allowed_for_matching_saved_or_detected_url ... ok
test config::tests::test_ntfy_fallback_url_env_validates_configured_url ... ok
test config::tests::test_ntfy_server_config_rejects_blank_url ... ok
test config::tests::test_ntfy_server_url_falls_back_to_env_without_detected_local ... ok
test config::tests::test_operating_mode_parsing ... ok
test config::tests::test_self_hosted_mode_sync_interval_legacy_fallback ... ok
test config::tests::test_self_hosted_mode_sync_interval_network_defaults ... ok
test config::tests::test_tx_explorer_config_ignores_blank_platform ... ok
test config::tests::test_tx_explorer_config_rejects_blank_base_url ... ok
test config::tests::test_tx_explorer_url_list_env_validates_and_deduplicates_urls ... ok
test config::tests::test_with_managed_ntfy_auth_only_fills_empty_auth_for_managed_server ... ok
test electrum::tests::operation_gate_is_scoped_to_subscription_enabled_self_hosted_clients ... ok
test electrum::tests::test_is_transport_error ... ok
test electrum::tests::timeout_cancels_worker_and_allows_work_gate_release ... ok
test electrum_history::tests::cancelled_work_stops_before_the_next_electrum_rpc ... ok
test electrum_history::tests::changed_and_multiple_queued_notifications_refresh_once ... ok
test electrum_history::tests::consumed_notification_remains_dirty_after_failed_history_refresh ... ok
test electrum_history::tests::electrs_warning_condition_is_avoided_and_warm_history_is_cached ... ok
test electrum_history::tests::large_cold_cache_subscribes_once_per_bdk_batch ... ok
test electrum_history::tests::malformed_history_batch_lengths_return_errors ... ok
test electrum_history::tests::not_subscribed_after_hidden_reconnect_resubscribes_and_compares_status ... ok
test electrum_history::tests::notification_drain_has_a_safety_bound ... ok
test electrum_history::tests::null_status_after_hidden_reconnect_clears_non_empty_history ... ok
test electrum_history::tests::partial_batch_subscription_is_reconciled_without_an_already_subscribed_loop ... ok
test electrum_history::tests::polling_and_recurring_clients_share_timeout_state ... ok
test electrum_history::tests::reconnect_resubscribes_without_refetching_unchanged_history ... ok
test electrum_history::tests::safety_revalidation_clears_non_empty_history_after_ambiguous_null ... ok
test electrum_history::tests::six_hour_revalidation_and_polling_fallback_preserve_order ... ok
test electrum_history::tests::sparse_batch_refresh_keeps_status_with_its_original_script ... ok
test electrum_history::tests::wallet_cleanup_error_requires_connection_replacement ... ok
test electrum_history::tests::wallet_cleanup_handles_large_subscription_sets ... ok
test electrum_history::tests::wallet_cleanup_stops_between_rpcs_after_cancellation ... ok
test electrum_history::tests::wallet_cleanup_unsubscribes_and_evicts_only_removed_scripts ... ok
test exchange_rates::tests::fetch_rates_retries_connect_failures_with_backoff ... ok
test exchange_rates::tests::retryable_status_includes_429_and_5xx_only ... ok
test exchange_rates::tests::test_locale_to_currency_case_insensitive ... ok
test exchange_rates::tests::test_locale_to_currency_simple_language ... ok
test exchange_rates::tests::test_locale_to_currency_unknown_falls_back_to_usd ... ok
test exchange_rates::tests::test_locale_to_currency_with_encoding ... ok
test exchange_rates::tests::test_locale_to_currency_with_quality ... ok
test exchange_rates::tests::test_locale_to_currency_with_region ... ok
test exchange_rates::tests::test_locale_to_currency_with_script ... ok
test exchange_rates::tests::test_locale_to_currency_with_underscore ... ok
test handlers::auth::tests::pad_response_to_duration_waits_until_floor ... ok
test handlers::config::tests::cloud_config_does_not_expose_self_hosted_ntfy_servers ... ok
test handlers::helpers::tests::fixed_database_error_message_does_not_leak_internal_details ... ok
test metadata::integrity::tests::cleanup_rolls_back_when_audit_insert_fails ... ok
test metadata::integrity::tests::cleanup_writes_admin_audit_log_for_noop ... ok
test metadata::integrity::tests::cleanup_writes_admin_audit_log_with_counts ... ok
test metadata::wallet::tests::map_wallet_metadata_row_can_decode_is_active_strictly_or_with_fallback ... ok
test metadata::wallet::tests::map_wallet_metadata_row_defaults_optional_values_to_zero_when_requested ... ok
test metadata::wallet::tests::map_wallet_metadata_row_preserves_none_for_balance_total_without_zero_default ... ok
test models::responses::tests::coded_error_response_serializes_error_code ... ok
test models::responses::tests::new_error_response_omits_error_code ... ok
test nostr_provider::tests::builds_legacy_nip04_dm_events ... ok
test nostr_provider::tests::canonicalizes_npub_and_hex_public_keys ... ok
test nostr_provider::tests::formats_display_target_from_stored_hex_public_key ... ok
test nostr_provider::tests::formats_test_message_with_delivery_mode ... ok
test nostr_provider::tests::limits_recipient_inbox_relay_attempts ... ok
test nostr_provider::tests::maps_known_test_send_errors_to_codes ... ok
test nostr_provider::tests::parses_nostr_dm_modes ... ok
test nostr_provider::tests::rejects_empty_invalid_and_private_keys ... ok
test notification_failure_tracker::tests::test_display_formatting ... ok
test notification_failure_tracker::tests::test_error_categorization ... ok
test notification_failure_tracker::tests::test_failure_tracking ... ok
test notification_failure_tracker::tests::test_recovery_notification ... ok
test notification_failure_tracker::tests::test_suggested_actions ... ok
test outbound_target::tests::rejects_private_and_special_ranges ... ok
test subscription::tests::test_defaults_when_no_env_vars ... ok
test subscription::tests::test_get_effective_subscription_status_active ... ok
test subscription::tests::test_get_effective_subscription_status_expired_trial ... ok
test subscription::tests::test_get_effective_subscription_status_other_statuses ... ok
test subscription::tests::test_get_effective_subscription_status_valid_trial ... ok
test subscription::tests::test_is_subscription_active_with_active_status ... ok
test subscription::tests::test_is_subscription_active_with_canceled_future_end ... ok
test subscription::tests::test_is_subscription_active_with_canceled_invalid_date ... ok
test subscription::tests::test_is_subscription_active_with_canceled_past_end ... ok
test subscription::tests::test_is_subscription_active_with_expired_trial ... ok
test subscription::tests::test_is_subscription_active_with_other_statuses ... ok
test subscription::tests::test_is_subscription_active_with_valid_trial ... ok
test subscription::tests::test_tier_specific_intervals ... ok
test sync::tests::sync_pending_and_confirmation_events_flow_to_webhook_delivery ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_adds_coinbase_when_history_present ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_avoids_double_counting ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_does_not_adjust_without_history_entry ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_requires_exact_script ... ok
test sync::tests::test_balance_with_mainnet_genesis_coinbase_requires_mainnet ... ok
test sync::tests::test_confirmed_block_height_accepts_genesis_height ... ok
test sync::tests::test_detect_address_watch_cpfp_relationships ... ok
test sync::tests::test_detect_address_watch_rbf_replacements ... ok
test sync::tests::test_detect_address_watch_rbf_replacements_accepts_confirmed_candidate ... ok
test sync::tests::test_genesis_block_timestamp_is_mainnet_only ... ok
test sync::tests::test_is_tx_confirmed_genesis_coinbase ... ok
test sync::tests::test_is_tx_confirmed_genesis_coinbase_requires_mainnet ... ok
test sync::tests::test_is_tx_confirmed_mempool ... ok
test sync::tests::test_is_tx_confirmed_positive_height ... ok
test sync::tests::test_is_tx_confirmed_unconfirmed_parents ... ok
test sync::tests::test_mainnet_genesis_coinbase_tx_state ... ok
test sync::tests::test_mainnet_genesis_coinbase_tx_state_requires_exact_match ... ok
test sync::tests::test_mainnet_genesis_p2pk_script_includes_checksig ... ok
test tls::tests::rustls_crypto_provider_install_is_idempotent ... ok
test utils::descriptor::tests::test_extract_address_from_descriptor_rejects_pk ... ok
test utils::descriptor::tests::test_extract_address_from_descriptor_valid ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_rejects_addr ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_rejects_invalid ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_with_checksum ... ok
test utils::descriptor::tests::test_extract_pubkey_from_descriptor_without_checksum ... ok
test utils::descriptor::tests::test_parse_descriptor_rejects_single_path_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_accepts_account_level_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_accepts_key_origin_hardened_path ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_derivation_in_sh_wpkh ... ok
test utils::descriptor::tests::test_parse_multipath_descriptor_rejects_hardened_wildcard_after_xpub ... ok
test utils::descriptor::tests::test_parse_multipath_non_multipath ... ok
test utils::descriptor::tests::test_strip_key_origin_accepts_uppercase_h_hardened_path ... ok
test utils::descriptor::tests::test_strip_key_origin_rejects_hardened_derivation_after_xpub ... ok
test utils::descriptor::tests::test_strip_key_origin_with_origin ... ok
test utils::descriptor::tests::test_strip_key_origin_without_origin ... ok
test utils::time::tests::current_unix_timestamp_returns_current_time ... ok
test utils::time::tests::unix_timestamp_rejects_pre_epoch_times ... ok
test utils::time::tests::unix_timestamp_returns_seconds_since_epoch ... ok
test wallet::tests::bdk_two_path_creation_matches_canarys_former_split ... ok
test wallet::tests::bdk_two_path_creation_rejects_wrong_path_shapes ... ok
test wallet::tests::bdk_v2_sqlite_wallet_migrates_and_reloads ... ok
test wallet::tests::deferred_failure_does_not_starve_healthy_wallets ... ok
test wallet::tests::mixed_address_watch_group_suppresses_only_pending_watcher ... ok
test wallet::tests::pending_address_watches_keep_shared_subscriptions_active ... ok
test wallet::tests::persisted_wallet_load_checks_descriptor_and_network ... ok
test wallet::tests::recovery_scan_gap_uses_bdk_full_scan_depths ... ok
test wallet::tests::self_hosted_due_time_is_measured_from_completion ... ok
test wallet::tests::self_hosted_queue_orders_never_synced_then_oldest_with_stable_tie_breaker ... ok
test wallet::tests::self_hosted_queue_scales_oldest_first_for_reported_wallet_counts ... ok
test wallet::tests::self_hosted_work_gate_keeps_peak_concurrency_at_one ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_compressed ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_rejects_invalid ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_trims_whitespace ... ok
test xpub_converter::tests::test_is_bitcoin_public_key_uncompressed ... ok
test xpub_converter::tests::test_pubkey_to_descriptor ... ok
test xpub_converter::tests::test_pubkey_to_descriptor_invalid ... ok
test xpub_converter::tests::test_validate_descriptor_network_bypasses_pubkey ... ok

test result: ok. 173 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.63s


running 1 test
test test_unused_bech32_address_watch_becomes_ready_after_empty_sync ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test test_cpfp_detection_and_tracking ... ignored
test test_multiple_rbf_sender_and_receiver_perspective ... ignored
test test_single_rbf_sender_and_receiver_perspective ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 9 tests
test test_cloud_mode_accepts_valid_bearer_token_with_session ... ok
test test_cloud_mode_rejects_invalid_jwt ... ok
test test_cookie_auth_ignores_malformed_authorization_header ... ok
test test_login_me_logout_invalidates_session ... ok
test test_login_rejects_invalid_password_and_unverified_email ... ok
test test_reset_password_endpoint_updates_password_and_clears_token ... ok
test test_self_hosted_login_me_logout_invalidates_session ... ok
test test_self_hosted_rejects_jwt_without_session ... ok
test test_verify_email_endpoint_marks_user_verified ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.74s


running 5 tests
test test_balance_alert_above_threshold ... ignored
test test_balance_alert_below_threshold ... ignored
test test_balance_alert_deactivation ... ignored
test test_balance_drain_alert_equals_zero ... ignored
test test_multiple_balance_alerts ... ignored

test result: ok. 0 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 11 tests
test test_balance_alert_database_operations ... ok
test test_balance_alert_edge_cases ... ok
test test_balance_alert_performance ... ok
test test_balance_alert_threshold_crossing_detection ... ok
test test_balance_alert_types ... ok
test test_balance_alert_wallet_isolation ... ok
test test_below_zero_alert_validation ... ok
test test_duplicate_alert_all_types ... ok
test test_duplicate_balance_alert_checking ... ok
test test_fiat_alert_fires_on_exchange_rate_change ... ignored
test test_wallet_drain_alert_special_case ... ok

test result: ok. 10 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 3.61s


running 1 test
test test_batch_send_to_bob_and_charlie ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 13 tests
test test_config_endpoint_cloud_mode_ignores_self_hosted_tx_explorers ... ok
test test_config_endpoint_self_hosted_no_mempool_config ... ok
test test_config_endpoint_self_hosted_serializes_tx_explorer_base_urls ... ok
test test_config_endpoint_self_hosted_with_multiple_tx_explorers ... ok
test test_config_endpoint_self_hosted_with_single_tx_explorer ... ok
test test_user_preferences_accepts_custom_tx_explorer_template ... ok
test test_user_preferences_accepts_custom_tx_explorer_template_in_cloud_mode ... ok
test test_user_preferences_accepts_supported_tx_explorer_ids ... ok
test test_user_preferences_clears_tx_explorer_preference ... ok
test test_user_preferences_clears_tx_explorer_preference_with_null ... ok
test test_user_preferences_cloud_mode_rejects_local_tx_explorer_ids ... ok
test test_user_preferences_rejects_invalid_custom_tx_explorer_template ... ok
test test_user_preferences_rejects_unsupported_tx_explorer_id ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.51s


running 6 tests
test test_duplicate_email_prevention ... ok
test test_duplicate_nostr_recipient_prevention ... ok
test test_duplicate_phone_prevention ... ok
test test_mixed_provider_types_allowed ... ok
test test_ntfy_topics_excluded_from_duplicate_check ... ok
test test_verification_endpoint_rejects_duplicates ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.20s


running 10 tests
test database_health_and_integrity_require_admin_access ... ok
test database_health_reports_degraded_for_orphans_without_fk_violations ... ok
test database_health_reports_no_orphans_for_clean_database ... ok
test database_health_reports_orphans_without_cleanup ... ok
test integrity_check_handles_logs_for_soft_deleted_wallet_transactions ... ok
test integrity_check_rejects_malformed_payload ... ok
test integrity_check_with_auto_fix_deletes_orphans_and_preserves_valid_rows ... ok
test integrity_check_with_auto_fix_on_clean_database_reports_zero_deletions ... ok
test integrity_check_without_auto_fix_reports_orphans_and_leaves_rows ... ok
test integrity_check_without_body_defaults_to_no_cleanup ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.74s


running 1 test
test debug_wallet_drain_detection ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test database_health_endpoint_is_rate_limited ... ok
test database_integrity_endpoint_has_separate_rate_limit_scope ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.83s


running 1 test
test test_high_index_fund_detection ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test test_chain_of_unconfirmed_transactions ... ignored
test test_unconfirmed_chain_with_separate_confirmations ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test migration_031_handles_clean_first_run_and_wallets_without_contacts ... ok
test migration_031_recovers_from_partially_applied_schema ... ok
test migration_033_cleans_active_wallet_level_alerts_with_contacts ... ok
test migration_035_preserves_notification_log_method_references ... ok
test migration_037_preserves_methods_indexes_and_foreign_keys_and_allows_reused_urls ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.59s


running 3 tests
test test_alice_full_send_bob_mined_directly ... ignored
test test_alice_partial_send_bob_mined_directly ... ignored
test test_multiple_partial_sends_mined_directly ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 9 tests
test test_admin_user_bypasses_contact_limits ... ok
test test_admin_user_bypasses_wallet_limits ... ok
test test_cloud_mode_rejects_nostr_contact_method ... ok
test test_cloud_mode_rejects_webhook_create_update_and_test ... ok
test test_personal_user_contact_limit_is_enforced ... ok
test test_personal_user_wallet_limit_is_enforced ... ok
test test_self_hosted_mode_bypasses_contact_limits ... ok
test test_self_hosted_mode_bypasses_wallet_limits ... ok
test test_self_hosted_webhook_provider_validation_reuse_and_redacted_display ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 12.54s


running 2 tests
test test_self_send_full_amount ... ignored
test test_self_send_partial ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test test_checkout_endpoint_without_stripe ... ok
test test_checkout_invalid_json ... ok
test test_checkout_invalid_tier ... ok
test test_checkout_missing_fields ... ok
test test_cors_headers ... ok
test test_pricing_endpoint_without_stripe ... ok
test test_session_details_without_stripe ... ok
test test_webhook_endpoint_without_stripe ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.41s


running 2 tests
test test_direct_mining_transaction_timestamp ... ignored
test test_mempool_first_transaction_timestamp ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test test_alice_full_send_bob_two_stage ... ignored
test test_alice_partial_send_bob_two_stage ... ignored
test test_multiple_partial_sends_bob_two_stage ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test test_utxo_consolidation_send_all_to_bob ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 43 tests
test test_create_address_wallet_duplicate_address ... ok
test test_create_address_wallet_network_mismatch ... ok
test test_create_address_wallet_p2pkh ... ok
test test_create_address_wallet_p2sh ... ok
test test_create_address_wallet_p2tr ... ok
test test_create_address_wallet_p2wpkh ... ok
test test_create_balance_alert_rejects_missing_contact_id ... ok
test test_create_wallet_custom_stop_gap_without_script_type ... ok
test test_create_wallet_duplicate_descriptor ... ok
test test_create_wallet_invalid_descriptor ... ok
test test_create_wallet_invalid_descriptor_returns_coded_generic_error ... ok
test test_create_wallet_network_mismatch ... ok
test test_create_wallet_non_multipath_descriptor_returns_specific_error ... ok
test test_create_wallet_rejects_hardened_derivation_after_xpub_before_insert ... ok
test test_create_wallet_success ... ok
test test_create_wallet_xpub_fresh_no_script_type ... ok
test test_delete_wallet_not_found ... ok
test test_delete_wallet_success ... ok
test test_get_transaction_notifications_forbidden_for_non_owner ... ok
test test_get_transaction_notifications_success_for_non_admin_owner ... ok
test test_get_transaction_notifications_transaction_not_found ... ok
test test_get_transaction_notifications_wallet_not_found ... ok
test test_get_wallet_detail_not_found ... ok
test test_get_wallet_detail_omits_notification_status_and_endpoint_loads_it ... ok
test test_get_wallet_detail_rejects_combined_cursor_and_since_timestamp ... ok
test test_get_wallet_detail_rejects_invalid_cursor ... ok
test test_get_wallet_detail_rejects_out_of_range_cursor_timestamp ... ok
test test_get_wallet_detail_rejects_out_of_range_since_timestamp ... ok
test test_get_wallet_detail_returns_pagination_metadata ... ok
test test_get_wallet_detail_success ... ok
test test_get_wallet_not_found ... ok
test test_get_wallet_success ... ok
test test_get_wallets_list_empty ... ok
test test_get_wallets_list_with_wallets ... ok
test test_self_hosted_forgot_password_is_forbidden ... ok
test test_self_hosted_register_is_forbidden ... ok
test test_self_hosted_reset_password_is_forbidden ... ok
test test_self_hosted_verify_email_is_forbidden ... ok
test test_update_wallet_empty_name ... ok
test test_update_wallet_not_found ... ok
test test_update_wallet_success ... ok
test test_validate_balance_alert_rejects_immediate_trigger ... ok
test test_validate_balance_alert_success_does_not_create_alert ... ok

test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 26.68s


running 7 tests
test test_descriptors_from_vpub_tpub_have_same_checksum ... ok
test test_descriptors_from_zpub_xpub_have_same_checksum ... ok
test test_duplicate_wallet_detection_vpub_tpub ... ok
test test_duplicate_wallet_detection_zpub_xpub ... ok
test test_vpub_tpub_normalize_to_same_value ... ok
test test_vpub_tpub_normalize_to_same_value_regtest ... ok
test test_zpub_xpub_normalize_to_same_value ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.77s


running 2 tests
test test_no_duplicate_events_after_restart ... ignored
test test_recovery_detects_transactions_during_downtime ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test webhook_notification_log_snapshots_store_only_the_origin ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.43s


running 2 tests
test src/extractors/auth.rs - extractors::auth::AuthenticatedUser (line 20) ... ignored
test src/extractors/auth.rs - extractors::auth::require_non_demo (line 86) ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 3.4s
  Running TypeScript ...
  Collecting page data using 13 workers ...
  Generating static pages using 13 workers (0/20) ...
  Generating static pages using 13 workers (5/20) 
  Generating static pages using 13 workers (10/20) 
  Generating static pages using 13 workers (15/20) 
✓ Generating static pages using 13 workers (20/20) in 126.3ms
  Finalizing page optimization ...

Route (app)
┌ ƒ /
├ ƒ /_not-found
├ ƒ /api/[...slug]
├ ○ /apple-icon.png
├ ƒ /contact
├ ƒ /demo
├ ƒ /donations
├ ƒ /donations/thank-you
├ ƒ /forgot-password
├ ○ /icon.png
├ ○ /icon.svg
├ ○ /manifest.json
├ ƒ /reset-password/[token]
├ ƒ /settings
├ ƒ /sign-in
├ ƒ /sign-out
├ ƒ /sign-up
├ ƒ /sign-up/success
├ ƒ /subscription
├ ƒ /verify-email/[token]
├ ƒ /wallets
├ ƒ /wallets/[checksum]
├ ƒ /wallets/[checksum]/notifications
├ ƒ /wallets/[checksum]/transactions
└ ƒ /wallets/add/[[...slug]]


ƒ Proxy (Middleware)

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand (all test suites passed; the wrapper timed out during doc-test shutdown)\n- 