### PR TITLE
Remove fabricated aggregate rating metadata

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -91,11 +91,6 @@ export default async function RootLayout({
         "unitText": "monthly"
       }
     },
-    "aggregateRating": {
-      "@type": "AggregateRating",
-      "ratingValue": "4.8",
-      "reviewCount": "127"
-    },
     "featureList": [
       "Bitcoin wallet monitoring",
       "Instant transaction notifications",


### PR DESCRIPTION
Summary:
- Remove the unsupported 4.8 aggregate rating and 127 review count from homepage JSON-LD.
- Retain factual offer and feature metadata.

Verification:
- ESLint passed for src/app/layout.tsx.
- git diff --check passed.

This PR will be merged immediately because fabricated rating data should not remain published.