### PR TITLE
fix: add fallback for admin endpoint rate limits

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -16,6 +16,7 @@ use crate::handlers::{
 };
 use crate::metadata::{MetadataDb, WalletsListResponse};
 use crate::notifications::NotificationManager;
+use crate::rate_limit::InMemoryRateLimiter;
 use crate::stripe_billing::StripeBilling;
 use crate::utils::current_unix_timestamp;
 use crate::wallet::WalletCreationService;
@@ -226,6 +227,7 @@ pub struct AppState {
     pub config: ConfigState,
     pub electrum_manager: ElectrumClientManagerState,
     pub btcpay_client: BtcPayClientState,
+    pub(crate) admin_rate_limit_fallback: Arc<Mutex<InMemoryRateLimiter>>,
 }
 
 // FromRef implementations allow extractors to access individual state components
@@ -385,6 +387,7 @@ pub fn create_router_with_services(
         config: config_state.clone(),
         electrum_manager,
         btcpay_client: btcpay_client.map(Arc::new),
+        admin_rate_limit_fallback: Arc::new(Mutex::new(InMemoryRateLimiter::default())),
     };
 
     // Routes using unified AppState with domain handlers

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -28,7 +28,7 @@ use axum::{
     routing::{get, post, put},
     Json, Router,
 };
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use tokio::sync::Mutex;
 use tower_http::cors::CorsLayer;
 
@@ -227,7 +227,7 @@ pub struct AppState {
     pub config: ConfigState,
     pub electrum_manager: ElectrumClientManagerState,
     pub btcpay_client: BtcPayClientState,
-    pub(crate) admin_rate_limit_fallback: Arc<Mutex<InMemoryRateLimiter>>,
+    pub(crate) admin_rate_limit_fallback: Arc<StdMutex<InMemoryRateLimiter>>,
 }
 
 // FromRef implementations allow extractors to access individual state components
@@ -387,7 +387,7 @@ pub fn create_router_with_services(
         config: config_state.clone(),
         electrum_manager,
         btcpay_client: btcpay_client.map(Arc::new),
-        admin_rate_limit_fallback: Arc::new(Mutex::new(InMemoryRateLimiter::default())),
+        admin_rate_limit_fallback: Arc::new(StdMutex::new(InMemoryRateLimiter::default())),
     };
 
     // Routes using unified AppState with domain handlers

--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -30,28 +30,42 @@ async fn enforce_admin_endpoint_rate_limit(
     // Reuse the existing DB-backed limiter with admin-specific scopes. Keeping
     // it persistent is useful here because these endpoints are expensive enough
     // that a restart should not immediately reset an aggressive caller's quota.
+    let fallback_window = Duration::from_secs((window_minutes * 60) as u64);
     match app_state
         .app_services
         .metadata_db
         .check_endpoint_rate_limit(scope, user_id, max_attempts, window_minutes)
         .await
     {
-        Ok(decision) if decision.allowed => Ok(()),
-        Ok(decision) => Err(rate_limited_response(
-            decision.retry_after_seconds,
-            window_minutes,
-        )),
+        Ok(decision) => {
+            // Shadow persistent decisions so a storage failure cannot reset an
+            // active caller's effective quota. The persistent decision remains
+            // authoritative while it is available.
+            let _ = app_state
+                .admin_rate_limit_fallback
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .check(scope, user_id, max_attempts, fallback_window);
+
+            if decision.allowed {
+                Ok(())
+            } else {
+                Err(rate_limited_response(
+                    decision.retry_after_seconds,
+                    window_minutes,
+                ))
+            }
+        }
         Err(e) => {
             warn!(
                 "Failed to check admin endpoint rate limit for scope {}; using in-memory fallback: {}",
                 scope, e
             );
-            let fallback_decision = app_state.admin_rate_limit_fallback.lock().await.check(
-                scope,
-                user_id,
-                max_attempts,
-                Duration::from_secs((window_minutes * 60) as u64),
-            );
+            let fallback_decision = app_state
+                .admin_rate_limit_fallback
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .check(scope, user_id, max_attempts, fallback_window);
 
             if fallback_decision.allowed {
                 Ok(())

--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -1,4 +1,4 @@
-use crate::api::AppServicesState;
+use crate::api::{AppServicesState, AppState};
 use crate::extractors::AuthenticatedUser;
 use crate::models::{
     CheckResult, CleanupReport, DatabaseHealthResponse, DuplicatesReport, ErrorResponse,
@@ -10,6 +10,7 @@ use axum::{
     http::{header, StatusCode},
     response::{IntoResponse, Json, Response},
 };
+use std::time::Duration;
 use tracing::{info, warn};
 
 const DATABASE_HEALTH_RATE_LIMIT_SCOPE: &str = "database_health";
@@ -20,7 +21,7 @@ const MAX_DATABASE_INTEGRITY_REQUESTS_PER_WINDOW: i64 = 2;
 const DATABASE_INTEGRITY_RATE_LIMIT_WINDOW_MINUTES: i64 = 10;
 
 async fn enforce_admin_endpoint_rate_limit(
-    app_services: &AppServicesState,
+    app_state: &AppState,
     scope: &str,
     user_id: &str,
     max_attempts: i64,
@@ -29,35 +30,56 @@ async fn enforce_admin_endpoint_rate_limit(
     // Reuse the existing DB-backed limiter with admin-specific scopes. Keeping
     // it persistent is useful here because these endpoints are expensive enough
     // that a restart should not immediately reset an aggressive caller's quota.
-    match app_services
+    match app_state
+        .app_services
         .metadata_db
         .check_endpoint_rate_limit(scope, user_id, max_attempts, window_minutes)
         .await
     {
         Ok(decision) if decision.allowed => Ok(()),
-        Ok(decision) => Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            [(
-                header::RETRY_AFTER,
-                decision
-                    .retry_after_seconds
-                    .unwrap_or(window_minutes * 60)
-                    .to_string(),
-            )],
-            Json(ErrorResponse::coded(
-                "admin_endpoint_rate_limit",
-                "Too many admin endpoint requests. Please try again later.",
-            )),
-        )
-            .into_response()),
+        Ok(decision) => Err(rate_limited_response(
+            decision.retry_after_seconds,
+            window_minutes,
+        )),
         Err(e) => {
             warn!(
-                "Failed to check admin endpoint rate limit for scope {}: {}",
+                "Failed to check admin endpoint rate limit for scope {}; using in-memory fallback: {}",
                 scope, e
             );
-            Ok(())
+            let fallback_decision = app_state.admin_rate_limit_fallback.lock().await.check(
+                scope,
+                user_id,
+                max_attempts,
+                Duration::from_secs((window_minutes * 60) as u64),
+            );
+
+            if fallback_decision.allowed {
+                Ok(())
+            } else {
+                Err(rate_limited_response(
+                    fallback_decision.retry_after_seconds,
+                    window_minutes,
+                ))
+            }
         }
     }
+}
+
+fn rate_limited_response(retry_after_seconds: Option<i64>, window_minutes: i64) -> Response {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [(
+            header::RETRY_AFTER,
+            retry_after_seconds
+                .unwrap_or(window_minutes * 60)
+                .to_string(),
+        )],
+        Json(ErrorResponse::coded(
+            "admin_endpoint_rate_limit",
+            "Too many admin endpoint requests. Please try again later.",
+        )),
+    )
+        .into_response()
 }
 
 /// Build the full database health report (shared by both endpoints)
@@ -240,7 +262,7 @@ async fn build_health_report(
 /// GET /api/health/database - Database health check (admin only)
 pub async fn get_database_health(
     AuthenticatedUser(user): AuthenticatedUser,
-    State(app_services): State<AppServicesState>,
+    State(app_state): State<AppState>,
 ) -> Response {
     if !user.is_admin {
         return (
@@ -254,7 +276,7 @@ pub async fn get_database_health(
     }
 
     if let Err(response) = enforce_admin_endpoint_rate_limit(
-        &app_services,
+        &app_state,
         DATABASE_HEALTH_RATE_LIMIT_SCOPE,
         &user.user_id,
         MAX_DATABASE_HEALTH_REQUESTS_PER_WINDOW,
@@ -265,7 +287,7 @@ pub async fn get_database_health(
         return response;
     }
 
-    match build_health_report(&app_services).await {
+    match build_health_report(&app_state.app_services).await {
         Ok(report) => Json(report).into_response(),
         Err(err_response) => err_response,
     }
@@ -274,7 +296,7 @@ pub async fn get_database_health(
 /// POST /api/admin/database/integrity - Full integrity check with optional auto-fix (admin only)
 pub async fn run_integrity_check(
     AuthenticatedUser(user): AuthenticatedUser,
-    State(app_services): State<AppServicesState>,
+    State(app_state): State<AppState>,
     request: Option<Json<IntegrityCheckRequest>>,
 ) -> Response {
     if !user.is_admin {
@@ -289,7 +311,7 @@ pub async fn run_integrity_check(
     }
 
     if let Err(response) = enforce_admin_endpoint_rate_limit(
-        &app_services,
+        &app_state,
         DATABASE_INTEGRITY_RATE_LIMIT_SCOPE,
         &user.user_id,
         MAX_DATABASE_INTEGRITY_REQUESTS_PER_WINDOW,
@@ -307,7 +329,7 @@ pub async fn run_integrity_check(
             "Admin user {} triggered database auto-fix cleanup",
             user.user_id
         );
-        let db = &app_services.metadata_db;
+        let db = &app_state.app_services.metadata_db;
 
         match db.run_cleanup(&user.user_id).await {
             Ok(counts) => {
@@ -349,7 +371,7 @@ pub async fn run_integrity_check(
     };
 
     // Build health report after cleanup so it reflects the post-cleanup state
-    let health = match build_health_report(&app_services).await {
+    let health = match build_health_report(&app_state.app_services).await {
         Ok(report) => report,
         Err(err_response) => return err_response,
     };

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -30,6 +30,7 @@ pub mod notification_failure_tracker;
 pub mod notifications;
 pub mod ntfy_provider;
 pub mod outbound_target;
+mod rate_limit;
 pub mod stripe_billing;
 pub mod stripe_client_service;
 pub mod subscription;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -27,6 +27,7 @@ mod notification_failure_tracker;
 mod notifications;
 mod ntfy_provider;
 mod outbound_target;
+mod rate_limit;
 mod stripe_billing;
 mod stripe_client_service;
 mod subscription;

--- a/backend/src/rate_limit.rs
+++ b/backend/src/rate_limit.rs
@@ -1,0 +1,188 @@
+//! Process-local rate limiting used only when a persistent limiter is unavailable.
+
+use crate::metadata::RateLimitDecision;
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+const MAX_TRACKED_IDENTIFIERS: usize = 1_024;
+
+#[derive(Debug)]
+struct RateLimitWindow {
+    attempt_count: i64,
+    window_expires_at: Instant,
+    blocked_until: Option<Instant>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct InMemoryRateLimiter {
+    windows: HashMap<(String, String), RateLimitWindow>,
+}
+
+impl InMemoryRateLimiter {
+    pub(crate) fn check(
+        &mut self,
+        scope: &str,
+        identifier: &str,
+        max_attempts: i64,
+        window: Duration,
+    ) -> RateLimitDecision {
+        self.check_at(scope, identifier, max_attempts, window, Instant::now())
+    }
+
+    fn check_at(
+        &mut self,
+        scope: &str,
+        identifier: &str,
+        max_attempts: i64,
+        window: Duration,
+        now: Instant,
+    ) -> RateLimitDecision {
+        self.windows
+            .retain(|_, entry| entry.blocked_until.unwrap_or(entry.window_expires_at) > now);
+
+        let key = (
+            scope.trim().to_lowercase(),
+            identifier.trim().to_lowercase(),
+        );
+        if !self.windows.contains_key(&key) && self.windows.len() >= MAX_TRACKED_IDENTIFIERS {
+            return RateLimitDecision {
+                allowed: false,
+                retry_after_seconds: Some(duration_seconds_rounded_up(window)),
+            };
+        }
+
+        let entry = self.windows.entry(key).or_insert(RateLimitWindow {
+            attempt_count: 0,
+            window_expires_at: now + window,
+            blocked_until: None,
+        });
+
+        if let Some(blocked_until) = entry.blocked_until {
+            if blocked_until > now {
+                return RateLimitDecision {
+                    allowed: false,
+                    retry_after_seconds: Some(retry_after_seconds(blocked_until, now)),
+                };
+            }
+        }
+
+        if entry.window_expires_at <= now {
+            entry.attempt_count = 0;
+            entry.window_expires_at = now + window;
+            entry.blocked_until = None;
+        }
+
+        entry.attempt_count += 1;
+        if entry.attempt_count > max_attempts {
+            let blocked_until = now + window;
+            entry.attempt_count = max_attempts;
+            entry.window_expires_at = blocked_until;
+            entry.blocked_until = Some(blocked_until);
+            RateLimitDecision {
+                allowed: false,
+                retry_after_seconds: Some(retry_after_seconds(blocked_until, now)),
+            }
+        } else {
+            RateLimitDecision {
+                allowed: true,
+                retry_after_seconds: None,
+            }
+        }
+    }
+}
+
+fn retry_after_seconds(blocked_until: Instant, now: Instant) -> i64 {
+    duration_seconds_rounded_up(blocked_until.saturating_duration_since(now))
+}
+
+fn duration_seconds_rounded_up(duration: Duration) -> i64 {
+    let rounded_up = duration
+        .as_secs()
+        .saturating_add(u64::from(duration.subsec_nanos() > 0))
+        .max(1);
+    i64::try_from(rounded_up).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn limits_are_isolated_by_scope_and_identifier() {
+        let mut limiter = InMemoryRateLimiter::default();
+        let now = Instant::now();
+        let window = Duration::from_secs(300);
+
+        assert!(
+            limiter
+                .check_at("database_health", "admin-1", 2, window, now)
+                .allowed
+        );
+        assert!(
+            limiter
+                .check_at("database_health", "admin-1", 2, window, now)
+                .allowed
+        );
+
+        let blocked = limiter.check_at("database_health", "admin-1", 2, window, now);
+        assert_eq!(
+            blocked,
+            RateLimitDecision {
+                allowed: false,
+                retry_after_seconds: Some(300),
+            }
+        );
+        assert!(
+            limiter
+                .check_at("database_integrity", "admin-1", 2, window, now)
+                .allowed
+        );
+        assert!(
+            limiter
+                .check_at("database_health", "admin-2", 2, window, now)
+                .allowed
+        );
+    }
+
+    #[test]
+    fn expired_fallback_window_resets() {
+        let mut limiter = InMemoryRateLimiter::default();
+        let now = Instant::now();
+        let window = Duration::from_secs(60);
+
+        assert!(limiter.check_at("scope", "admin", 1, window, now).allowed);
+        assert!(!limiter.check_at("scope", "admin", 1, window, now).allowed);
+        assert!(
+            limiter
+                .check_at("scope", "admin", 1, window, now + window)
+                .allowed
+        );
+    }
+
+    #[test]
+    fn identifier_storage_is_bounded_and_fails_closed_at_capacity() {
+        let mut limiter = InMemoryRateLimiter::default();
+        let now = Instant::now();
+        let window = Duration::from_secs(60);
+
+        for index in 0..MAX_TRACKED_IDENTIFIERS {
+            assert!(
+                limiter
+                    .check_at("scope", &format!("admin-{index}"), 1, window, now)
+                    .allowed
+            );
+        }
+
+        assert_eq!(limiter.windows.len(), MAX_TRACKED_IDENTIFIERS);
+        assert_eq!(
+            limiter.check_at("scope", "overflow-admin", 1, window, now),
+            RateLimitDecision {
+                allowed: false,
+                retry_after_seconds: Some(60),
+            }
+        );
+        assert_eq!(limiter.windows.len(), MAX_TRACKED_IDENTIFIERS);
+    }
+}

--- a/backend/src/rate_limit.rs
+++ b/backend/src/rate_limit.rs
@@ -1,4 +1,5 @@
 //! Process-local rate limiting used only when a persistent limiter is unavailable.
+//! Each application replica intentionally keeps an independent fallback quota.
 
 use crate::metadata::RateLimitDecision;
 use std::{
@@ -60,18 +61,10 @@ impl InMemoryRateLimiter {
         });
 
         if let Some(blocked_until) = entry.blocked_until {
-            if blocked_until > now {
-                return RateLimitDecision {
-                    allowed: false,
-                    retry_after_seconds: Some(retry_after_seconds(blocked_until, now)),
-                };
-            }
-        }
-
-        if entry.window_expires_at <= now {
-            entry.attempt_count = 0;
-            entry.window_expires_at = now + window;
-            entry.blocked_until = None;
+            return RateLimitDecision {
+                allowed: false,
+                retry_after_seconds: Some(retry_after_seconds(blocked_until, now)),
+            };
         }
 
         entry.attempt_count += 1;

--- a/backend/tests/health_rate_limit_tests.rs
+++ b/backend/tests/health_rate_limit_tests.rs
@@ -263,3 +263,21 @@ async fn limiter_backend_failure_uses_per_user_per_scope_fallback() {
     let (status, headers, body) = post_database_integrity(&test_app.router, &primary_token).await;
     assert_rate_limited(status, headers, body, "600");
 }
+
+#[tokio::test]
+async fn fallback_preserves_quota_consumed_before_limiter_backend_failure() {
+    let test_app = create_self_hosted_test_app().await;
+    let token = self_hosted_admin_token();
+
+    for _ in 0..6 {
+        let (status, _, _) = get_database_health(&test_app.router, &token).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    let conn = Connection::open(&test_app.db_path).unwrap();
+    conn.execute("DROP TABLE auth_rate_limits", []).unwrap();
+    drop(conn);
+
+    let (status, headers, body) = get_database_health(&test_app.router, &token).await;
+    assert_rate_limited(status, headers, body, "300");
+}

--- a/backend/tests/health_rate_limit_tests.rs
+++ b/backend/tests/health_rate_limit_tests.rs
@@ -2,6 +2,7 @@ use axum::{
     body::Body,
     http::{header, HeaderMap, Request, StatusCode},
 };
+use bdk_wallet::rusqlite::{params, Connection};
 use canary::{
     api::{create_router_with_services, AppServices},
     auth::{AuthService, Claims},
@@ -22,12 +23,14 @@ const TEST_JWT_SECRET: &str = "test-jwt-secret";
 struct TestApp {
     router: axum::Router,
     _temp_dir: TempDir,
+    app_services: Arc<AppServices>,
+    db_path: String,
 }
 
 async fn create_self_hosted_test_app() -> TestApp {
     let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path().to_str().unwrap();
-    let test_db_path = format!("{}/test_metadata.sqlite", temp_path);
+    let db_path = format!("{}/test_metadata.sqlite", temp_path);
 
     let config = AppConfig::new_for_test(
         NetworkConfig::Regtest,
@@ -45,7 +48,7 @@ async fn create_self_hosted_test_app() -> TestApp {
         WalletManager::new(
             event_tx,
             temp_path.into(),
-            &test_db_path,
+            &db_path,
             bdk_wallet::bitcoin::Network::Regtest,
             "tcp://127.0.0.1:50001",
             &config,
@@ -70,24 +73,35 @@ async fn create_self_hosted_test_app() -> TestApp {
     create_self_hosted_admin_session(&app_services).await;
 
     let notification_manager = Arc::new(Mutex::new(NotificationManager::new()));
-    let router =
-        create_router_with_services(app_services, notification_manager, None, config, None);
+    let router = create_router_with_services(
+        app_services.clone(),
+        notification_manager,
+        None,
+        config,
+        None,
+    );
 
     TestApp {
         router,
         _temp_dir: temp_dir,
+        app_services,
+        db_path,
     }
 }
 
 fn self_hosted_admin_token() -> String {
+    admin_token("foss-user", "admin@local")
+}
+
+fn admin_token(user_id: &str, email: &str) -> String {
     let claims = Claims {
-        sub: "foss-user".to_string(),
-        email: "admin@local".to_string(),
+        sub: user_id.to_string(),
+        email: email.to_string(),
         is_admin: true,
         is_demo: false,
         exp: 4_102_444_800,
         iat: 1_700_000_000,
-        jti: "test-foss-user-admin".to_string(),
+        jti: format!("test-{user_id}-admin"),
     };
 
     encode(
@@ -100,11 +114,15 @@ fn self_hosted_admin_token() -> String {
 
 async fn create_self_hosted_admin_session(app_services: &AppServices) {
     let token = self_hosted_admin_token();
+    create_admin_session(app_services, "foss-user", &token).await;
+}
+
+async fn create_admin_session(app_services: &AppServices, user_id: &str, token: &str) {
     app_services
         .metadata_db
         .create_session(
-            "foss-user",
-            &AuthService::hash_token(&token),
+            user_id,
+            &AuthService::hash_token(token),
             chrono::Utc::now() + chrono::Duration::days(7),
         )
         .await
@@ -195,5 +213,53 @@ async fn database_integrity_endpoint_has_separate_rate_limit_scope() {
     let (status, _headers, _body) = post_database_integrity(&test_app.router, &token).await;
     assert_eq!(status, StatusCode::OK);
     let (status, headers, body) = post_database_integrity(&test_app.router, &token).await;
+    assert_rate_limited(status, headers, body, "600");
+}
+
+#[tokio::test]
+async fn limiter_backend_failure_uses_per_user_per_scope_fallback() {
+    let test_app = create_self_hosted_test_app().await;
+    let primary_token = self_hosted_admin_token();
+    let secondary_email = "secondary-admin@example.com";
+    let secondary_user_id = test_app
+        .app_services
+        .metadata_db
+        .create_user(
+            secondary_email,
+            "hash",
+            Some("Secondary Admin"),
+            true,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let secondary_token = admin_token(&secondary_user_id, secondary_email);
+    create_admin_session(&test_app.app_services, &secondary_user_id, &secondary_token).await;
+
+    let conn = Connection::open(&test_app.db_path).unwrap();
+    conn.execute(
+        "UPDATE users SET is_admin = 1 WHERE id = ?1",
+        params![&secondary_user_id],
+    )
+    .unwrap();
+    conn.execute("DROP TABLE auth_rate_limits", []).unwrap();
+    drop(conn);
+
+    for _ in 0..6 {
+        let (status, _, _) = get_database_health(&test_app.router, &primary_token).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let (status, headers, body) = get_database_health(&test_app.router, &primary_token).await;
+    assert_rate_limited(status, headers, body, "300");
+
+    let (status, _, _) = get_database_health(&test_app.router, &secondary_token).await;
+    assert_eq!(status, StatusCode::OK);
+
+    for _ in 0..2 {
+        let (status, _, _) = post_database_integrity(&test_app.router, &primary_token).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let (status, headers, body) = post_database_integrity(&test_app.router, &primary_token).await;
     assert_rate_limited(status, headers, body, "600");
 }


### PR DESCRIPTION
## Summary

- fall back to an application-scoped in-memory limiter when the persistent admin endpoint limiter fails
- isolate fallback quotas by admin user and endpoint scope, preserve `Retry-After`, and bound memory with fail-closed capacity handling
- exercise the real storage-failure handler path plus deterministic scope, user, expiry, and capacity behavior

## Testing

- `cd backend && cargo test rate_limit::tests --lib`
- `cd backend && cargo test --test health_rate_limit_tests -- --test-threads=1`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `.agent-loop/checks.sh quick`

Closes #354