### PR TITLE
fix: initialize theme under strict CSP

### DIFF
--- a/.agent-loop/checks.sh
+++ b/.agent-loop/checks.sh
@@ -30,7 +30,8 @@ run_frontend() {
     cd "$REPO_ROOT/frontend"
     pnpm run lint
     pnpm test
-    pnpm run build
+    NEXT_PUBLIC_CANARY_MODE=cloud pnpm run build
+    pnpm run test:csp
   )
 }
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -44,3 +44,8 @@ jobs:
 
       - name: Build frontend
         run: cd frontend && pnpm build
+        env:
+          NEXT_PUBLIC_CANARY_MODE: cloud
+
+      - name: Verify production CSP nonce handoff
+        run: cd frontend && pnpm test:csp

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "jest",
+    "test:csp": "node scripts/verify-csp-response.mjs",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/frontend/scripts/verify-csp-response.mjs
+++ b/frontend/scripts/verify-csp-response.mjs
@@ -1,0 +1,97 @@
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import path from 'node:path'
+import process from 'node:process'
+
+const host = '127.0.0.1'
+const port = Number(process.env.CSP_TEST_PORT ?? 3412)
+const origin = `http://${host}:${port}`
+const nextBin = path.join(process.cwd(), 'node_modules', 'next', 'dist', 'bin', 'next')
+const output = []
+
+const server = spawn(process.execPath, [nextBin, 'start', '--hostname', host, '--port', String(port)], {
+  env: {
+    ...process.env,
+    NEXT_PUBLIC_CANARY_MODE: 'cloud',
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
+
+server.stdout.on('data', (chunk) => output.push(chunk.toString()))
+server.stderr.on('data', (chunk) => output.push(chunk.toString()))
+
+async function fetchPage() {
+  const deadline = Date.now() + 20_000
+  let lastError
+
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) {
+      throw new Error(`Next.js exited before the CSP check:\n${output.join('')}`)
+    }
+
+    try {
+      const response = await fetch(`${origin}/sign-in`)
+
+      if (response.ok) {
+        return { response, html: await response.text() }
+      }
+
+      lastError = new Error(`Next.js returned HTTP ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for Next.js: ${lastError}\n${output.join('')}`)
+}
+
+function verifyNonceHandoff(response, html) {
+  const contentSecurityPolicy = response.headers.get('content-security-policy')
+  const nonce = contentSecurityPolicy?.match(/script-src[^;]*'nonce-([^']+)'/)?.[1]
+
+  if (!nonce) {
+    throw new Error('The production response did not include a script nonce in its CSP header')
+  }
+
+  const inlineExecutableTags = [
+    ...html.matchAll(/<(script|style)\b[^>]*>/gi),
+  ].map((match) => match[0])
+
+  if (inlineExecutableTags.length === 0) {
+    throw new Error('The production response did not contain any script or style tags')
+  }
+
+  const tagsWithoutMatchingNonce = inlineExecutableTags.filter(
+    (tag) => !tag.includes(`nonce="${nonce}"`),
+  )
+
+  if (tagsWithoutMatchingNonce.length > 0) {
+    throw new Error(`Production tags are missing the CSP nonce:\n${tagsWithoutMatchingNonce.join('\n')}`)
+  }
+
+  if (!html.includes('canary-theme')) {
+    throw new Error('The production response did not include the first-paint theme initializer')
+  }
+}
+
+try {
+  const { response, html } = await fetchPage()
+  verifyNonceHandoff(response, html)
+  console.log('Production CSP nonce handoff verified')
+} finally {
+  if (server.exitCode === null) {
+    const exitPromise = once(server, 'exit')
+    server.kill('SIGTERM')
+    const exited = await Promise.race([
+      exitPromise.then(() => true),
+      new Promise((resolve) => setTimeout(() => resolve(false), 5_000)),
+    ])
+
+    if (!exited) {
+      server.kill('SIGKILL')
+      await exitPromise
+    }
+  }
+}

--- a/frontend/src/app/__tests__/layout-csp.test.tsx
+++ b/frontend/src/app/__tests__/layout-csp.test.tsx
@@ -1,0 +1,40 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from 'react'
+import RootLayout from '../layout'
+
+const testNonce = 'strict-csp-test-nonce'
+
+jest.mock('next/headers', () => ({
+  headers: jest.fn(async () => new Headers({ 'x-nonce': testNonce })),
+}))
+
+jest.mock('next/font/google', () => ({
+  Geist: () => ({ variable: '--font-geist-sans' }),
+  Geist_Mono: () => ({ variable: '--font-geist-mono' }),
+}))
+
+jest.mock('next-intl/server', () => ({
+  getLocale: jest.fn(async () => 'en-US'),
+  getMessages: jest.fn(async () => ({})),
+}))
+
+function getElementChildren(node: ReactNode): ReactElement[] {
+  if (!isValidElement(node)) {
+    return []
+  }
+
+  return Children.toArray((node.props as { children?: ReactNode }).children)
+    .filter(isValidElement)
+}
+
+describe('RootLayout CSP integration', () => {
+  it('adds the request nonce to every inline script in the document head', async () => {
+    const layout = await RootLayout({ children: <main>Canary</main> })
+    const head = getElementChildren(layout).find((element) => element.type === 'head')
+    const scripts = getElementChildren(head).filter((element) => element.type === 'script')
+
+    expect(scripts).toHaveLength(2)
+    expect(scripts.map((script) => script.props.nonce)).toEqual([testNonce, testNonce])
+    expect(scripts[0].props.dangerouslySetInnerHTML.__html).toContain('canary-theme')
+    expect(scripts[1].props.type).toBe('application/ld+json')
+  })
+})

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,7 +4,9 @@ import "./globals.css";
 import { AuthProvider } from "@/contexts/auth-context";
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
+import { headers } from 'next/headers';
 import { getThemeInitializationScript } from "@/lib/theme";
+import { CSP_NONCE_HEADER } from "@/lib/content-security-policy";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { staticErrorBoundaryMessages } from "@/components/error-boundary-messages";
@@ -72,6 +74,7 @@ export default async function RootLayout({
 }>) {
   const locale = await getLocale();
   const messages = await getMessages();
+  const nonce = (await headers()).get(CSP_NONCE_HEADER) ?? undefined;
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -107,8 +110,12 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: getThemeInitializationScript() }} />
         <script
+          nonce={nonce}
+          dangerouslySetInnerHTML={{ __html: getThemeInitializationScript() }}
+        />
+        <script
+          nonce={nonce}
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />

--- a/frontend/src/lib/content-security-policy.ts
+++ b/frontend/src/lib/content-security-policy.ts
@@ -1,7 +1,8 @@
 export const CSP_NONCE_HEADER = "x-nonce"
 
 export function createContentSecurityPolicyNonce(): string {
-  return Buffer.from(crypto.randomUUID()).toString("base64")
+  const randomBytes = crypto.getRandomValues(new Uint8Array(16))
+  return btoa(String.fromCharCode(...randomBytes))
 }
 
 export function createContentSecurityPolicy(nonce: string): string {

--- a/frontend/src/lib/content-security-policy.ts
+++ b/frontend/src/lib/content-security-policy.ts
@@ -1,0 +1,25 @@
+export const CSP_NONCE_HEADER = "x-nonce"
+
+export function createContentSecurityPolicyNonce(): string {
+  return Buffer.from(crypto.randomUUID()).toString("base64")
+}
+
+export function createContentSecurityPolicy(nonce: string): string {
+  const isDevelopment = process.env.NODE_ENV === "development"
+  const shouldUpgradeInsecureRequests = !isDevelopment
+    && process.env.NEXT_PUBLIC_CANARY_MODE !== "self-hosted"
+
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDevelopment ? " 'unsafe-eval'" : ""}`,
+    `style-src 'self' ${isDevelopment ? "'unsafe-inline'" : `'nonce-${nonce}'`}`,
+    "style-src-attr 'unsafe-inline'",
+    "img-src 'self' blob: data:",
+    "font-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    ...(shouldUpgradeInsecureRequests ? ["upgrade-insecure-requests"] : []),
+  ].join("; ")
+}

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -45,6 +45,7 @@ function expectStrictContentSecurityPolicy(response: Response) {
   expect(contentSecurityPolicy).toContain("'strict-dynamic'")
   expect(contentSecurityPolicy).not.toMatch(/script-src[^;]*'unsafe-inline'/)
   expect(nonceMatch?.[1]).toBeTruthy()
+  expect(Buffer.from(nonceMatch![1], 'base64')).toHaveLength(16)
 
   return nonceMatch![1]
 }

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -3,6 +3,7 @@
  */
 import { NextRequest } from 'next/server'
 import { proxy } from './proxy'
+import { CSP_NONCE_HEADER } from './lib/content-security-policy'
 
 jest.mock('@formatjs/intl-localematcher', () => ({
   match: jest.fn((languages: string[]) => (languages.some((language) => language.startsWith('nb')) ? 'nb' : 'en-US')),
@@ -36,6 +37,18 @@ function expectRedirectToSignIn(response: Response) {
   expect(response.headers.get('location')).toBe('http://localhost:3001/sign-in')
 }
 
+function expectStrictContentSecurityPolicy(response: Response) {
+  const contentSecurityPolicy = response.headers.get('content-security-policy')
+  const nonceMatch = contentSecurityPolicy?.match(/script-src[^;]*'nonce-([^']+)'/)
+
+  expect(contentSecurityPolicy).toContain("script-src 'self'")
+  expect(contentSecurityPolicy).toContain("'strict-dynamic'")
+  expect(contentSecurityPolicy).not.toMatch(/script-src[^;]*'unsafe-inline'/)
+  expect(nonceMatch?.[1]).toBeTruthy()
+
+  return nonceMatch![1]
+}
+
 describe('proxy self-hosted auth recovery', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_CANARY_MODE = 'self-hosted'
@@ -52,6 +65,8 @@ describe('proxy self-hosted auth recovery', () => {
 
     expectRedirectToSignIn(response)
     expect(response.headers.get('set-cookie')).toContain('locale=en-US')
+    expectStrictContentSecurityPolicy(response)
+    expect(response.headers.get('content-security-policy')).not.toContain('upgrade-insecure-requests')
   })
 
   it('redirects page requests with an expired auth token and clears it', () => {
@@ -70,10 +85,15 @@ describe('proxy self-hosted auth recovery', () => {
 
   it('allows page requests with an unexpired well-formed auth token', () => {
     const response = proxy(makeRequest('/wallets', `auth_token=${makeToken({ exp: 1_700_000_001 })}; locale=nb`))
+    const nonce = expectStrictContentSecurityPolicy(response)
 
     expect(response.status).toBe(200)
     expect(response.headers.get('location')).toBeNull()
     expect(response.headers.get('set-cookie')).toBeNull()
+    expect(response.headers.get(`x-middleware-request-${CSP_NONCE_HEADER}`)).toBe(nonce)
+    expect(response.headers.get('x-middleware-request-content-security-policy')).toBe(
+      response.headers.get('content-security-policy'),
+    )
   })
 
   it('exempts sign-in and api paths from auth checks', () => {
@@ -98,9 +118,19 @@ describe('proxy cloud mode locale behavior', () => {
 
   it('does not require auth and keeps locale-only behavior', () => {
     const response = proxy(makeRequest('/wallets', undefined, { 'accept-language': 'nb-NO,nb;q=0.9' }))
+    const nonce = expectStrictContentSecurityPolicy(response)
 
     expect(response.status).toBe(200)
     expect(response.headers.get('location')).toBeNull()
     expect(response.headers.get('set-cookie')).toContain('locale=nb')
+    expect(response.headers.get(`x-middleware-request-${CSP_NONCE_HEADER}`)).toBe(nonce)
+    expect(response.headers.get('content-security-policy')).toContain('upgrade-insecure-requests')
+  })
+
+  it('generates a fresh nonce for each page response', () => {
+    const firstNonce = expectStrictContentSecurityPolicy(proxy(makeRequest('/wallets')))
+    const secondNonce = expectStrictContentSecurityPolicy(proxy(makeRequest('/settings')))
+
+    expect(firstNonce).not.toBe(secondNonce)
   })
 })

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -3,6 +3,11 @@ import type { NextRequest } from 'next/server'
 import Negotiator from 'negotiator'
 import { match } from '@formatjs/intl-localematcher'
 import { locales, defaultLocale, type Locale } from './i18n/config'
+import {
+  CSP_NONCE_HEADER,
+  createContentSecurityPolicy,
+  createContentSecurityPolicyNonce,
+} from './lib/content-security-policy'
 
 // Extended locales including Norwegian variants for matching
 const matcherLocales = ['en', 'en-US', 'nb', 'nn', 'no', 'es', 'es-419', 'pt', 'pt-BR', 'de', 'de-DE', 'fr', 'fr-FR', 'ja', 'da', 'sv']
@@ -101,24 +106,49 @@ function redirectToSignIn(request: NextRequest, shouldClearAuthToken = false): N
   return addLocaleCookie(request, response)
 }
 
+function addContentSecurityPolicy(response: NextResponse, contentSecurityPolicy: string): NextResponse {
+  response.headers.set('Content-Security-Policy', contentSecurityPolicy)
+  return response
+}
+
+function nextResponseWithContentSecurityPolicy(
+  request: NextRequest,
+  nonce: string,
+  contentSecurityPolicy: string,
+): NextResponse {
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set(CSP_NONCE_HEADER, nonce)
+  requestHeaders.set('Content-Security-Policy', contentSecurityPolicy)
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
+}
+
 export function proxy(request: NextRequest) {
+  const nonce = createContentSecurityPolicyNonce()
+  const contentSecurityPolicy = createContentSecurityPolicy(nonce)
+
   if (process.env.NEXT_PUBLIC_CANARY_MODE === selfHostedMode && !isAuthExemptPath(request.nextUrl.pathname)) {
     const authToken = request.cookies.get('auth_token')?.value
 
     if (!authToken) {
-      return redirectToSignIn(request)
+      return addContentSecurityPolicy(redirectToSignIn(request), contentSecurityPolicy)
     }
 
     try {
       if (isExpiredAuthToken(authToken)) {
-        return redirectToSignIn(request, true)
+        return addContentSecurityPolicy(redirectToSignIn(request, true), contentSecurityPolicy)
       }
     } catch {
-      return redirectToSignIn(request, true)
+      return addContentSecurityPolicy(redirectToSignIn(request, true), contentSecurityPolicy)
     }
   }
 
-  return addLocaleCookie(request, NextResponse.next())
+  const response = nextResponseWithContentSecurityPolicy(request, nonce, contentSecurityPolicy)
+  return addContentSecurityPolicy(addLocaleCookie(request, response), contentSecurityPolicy)
 }
 
 export const config = {

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -118,6 +118,7 @@ function nextResponseWithContentSecurityPolicy(
 ): NextResponse {
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set(CSP_NONCE_HEADER, nonce)
+  // Next.js parses the request CSP to apply this nonce to its generated scripts and styles.
   requestHeaders.set('Content-Security-Policy', contentSecurityPolicy)
 
   return NextResponse.next({


### PR DESCRIPTION
## Summary
- generate a fresh CSP nonce for every rendered page request in cloud and self-hosted modes
- enforce a strict nonce-based script policy and pass the nonce through Next.js rendering
- nonce the first-paint theme initializer and JSON-LD script
- cover CSP propagation, mode behavior, nonce freshness, and root-layout inline scripts

## Verification
- targeted theme, proxy, and layout tests
- frontend lint and cloud-mode production build
- production response header/HTML nonce inspection
- isolated Chrome CSP enforcement and stored dark-theme reload
- .agent-loop/checks.sh quick

Closes #308