### PR TITLE
Add per-delivery notification privacy levels

### DIFF
--- a/backend/locales/da.yml
+++ b/backend/locales/da.yml
@@ -15,6 +15,10 @@ common:
   footer: "Denne notifikation blev sendt af Canary Wallet"
   wallet: "Wallet"
 
+privacy:
+  activity_detected: "Walletaktivitet registreret"
+  activity_confirmed: "Walletaktivitet bekræftet"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "Wallet-saldo: %{balance_btc} BTC"

--- a/backend/locales/de-DE.yml
+++ b/backend/locales/de-DE.yml
@@ -15,6 +15,10 @@ common:
   footer: "Diese Benachrichtigung wurde von Canary Wallet gesendet"
   wallet: "Wallet"
 
+privacy:
+  activity_detected: "Wallet-Aktivität erkannt"
+  activity_confirmed: "Wallet-Aktivität bestätigt"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "Wallet-Guthaben: %{balance_btc} BTC"

--- a/backend/locales/en-US.yml
+++ b/backend/locales/en-US.yml
@@ -15,6 +15,10 @@ common:
   footer: "This notification was sent by Canary Wallet"
   wallet: "Wallet"
 
+privacy:
+  activity_detected: "Wallet activity detected"
+  activity_confirmed: "Wallet activity confirmed"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "Wallet balance: %{balance_btc} BTC"

--- a/backend/locales/es-419.yml
+++ b/backend/locales/es-419.yml
@@ -15,6 +15,10 @@ common:
   footer: "Esta notificacion fue enviada por Canary Wallet"
   wallet: "Billetera"
 
+privacy:
+  activity_detected: "Actividad de billetera detectada"
+  activity_confirmed: "Actividad de billetera confirmada"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "Saldo de la billetera: %{balance_btc} BTC"

--- a/backend/locales/fr-FR.yml
+++ b/backend/locales/fr-FR.yml
@@ -15,6 +15,10 @@ common:
   footer: "Cette notification a été envoyée par Canary Wallet"
   wallet: "Portefeuille"
 
+privacy:
+  activity_detected: "Activité du portefeuille détectée"
+  activity_confirmed: "Activité du portefeuille confirmée"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "Solde du portefeuille : %{balance_btc} BTC"

--- a/backend/locales/ja.yml
+++ b/backend/locales/ja.yml
@@ -15,6 +15,10 @@ common:
   footer: "この通知はCanary Walletから送信されました"
   wallet: "ウォレット"
 
+privacy:
+  activity_detected: "ウォレットのアクティビティを検出しました"
+  activity_confirmed: "ウォレットのアクティビティが承認されました"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "ウォレット残高: %{balance_btc} BTC"

--- a/backend/locales/nb.yml
+++ b/backend/locales/nb.yml
@@ -15,6 +15,10 @@ common:
   footer: "Dette varselet ble sendt av Canary Wallet"
   wallet: "Lommebok"
 
+privacy:
+  activity_detected: "Lommebokaktivitet oppdaget"
+  activity_confirmed: "Lommebokaktivitet bekreftet"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "Lommeboksaldo: %{balance_btc} BTC"

--- a/backend/locales/pt-BR.yml
+++ b/backend/locales/pt-BR.yml
@@ -15,6 +15,10 @@ common:
   footer: "Esta notificação foi enviada por Canary Wallet"
   wallet: "Carteira"
 
+privacy:
+  activity_detected: "Atividade da carteira detectada"
+  activity_confirmed: "Atividade da carteira confirmada"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "Saldo da carteira: %{balance_btc} BTC"

--- a/backend/locales/sv.yml
+++ b/backend/locales/sv.yml
@@ -15,6 +15,10 @@ common:
   footer: "Denna avisering skickades av Canary Wallet"
   wallet: "Plånbok"
 
+privacy:
+  activity_detected: "Plånboksaktivitet upptäckt"
+  activity_confirmed: "Plånboksaktivitet bekräftad"
+
 # Transaction notification messages (message_formatter.rs)
 transaction:
   wallet_balance: "Plånbokssaldo: %{balance_btc} BTC"

--- a/backend/migrations/043_add_notification_content_privacy_levels.sql
+++ b/backend/migrations/043_add_notification_content_privacy_levels.sql
@@ -1,0 +1,6 @@
+-- Existing delivery methods retain their current rich content. Application
+-- creation paths explicitly store the privacy-conscious `standard` default for
+-- new methods.
+ALTER TABLE contact_notification_methods
+ADD COLUMN content_privacy_level TEXT NOT NULL DEFAULT 'detailed'
+CHECK (content_privacy_level IN ('minimal', 'standard', 'detailed'));

--- a/backend/src/email_provider.rs
+++ b/backend/src/email_provider.rs
@@ -1,7 +1,8 @@
 use crate::email_service::{BatchEmailRequest, EmailService};
 use crate::message_formatter::MessageFormatter;
 use crate::metadata::{
-    Contact, Language, NotificationMethod, ProviderType, TransactionNotification,
+    Contact, ContentPrivacyLevel, Language, NotificationMethod, ProviderType,
+    TransactionNotification,
 };
 use crate::notifications::{
     notification_methods_for_provider, NotificationProvider, NotificationResult, ProviderInfo,
@@ -50,12 +51,13 @@ impl NotificationProvider for EmailProvider {
             for (contact, method) in
                 notification_methods_for_provider(contacts, &ProviderType::Email)
             {
-                let message = MessageFormatter::create_localized_message(
+                let message = MessageFormatter::create_localized_message_for_level(
                     notification,
                     wallet_name,
                     user_language,
                     contact.include_wallet_balance_in_tx_notifications,
                     wallet_balance_sats,
+                    method.content_privacy_level,
                 );
                 results.push((
                     method.clone(),
@@ -74,26 +76,31 @@ impl NotificationProvider for EmailProvider {
         let mut batch_data = Vec::new();
 
         for (contact, method) in notification_methods_for_provider(contacts, &ProviderType::Email) {
-            let message = MessageFormatter::create_localized_message(
+            let message = MessageFormatter::create_localized_message_for_level(
                 notification,
                 wallet_name,
                 user_language,
                 contact.include_wallet_balance_in_tx_notifications,
                 wallet_balance_sats,
+                method.content_privacy_level,
             );
 
             // Build email subject and body based on notification type
-            let subject = MessageFormatter::create_localized_email_subject(
+            let subject = MessageFormatter::create_localized_email_subject_for_level(
                 notification,
                 wallet_name,
                 user_language,
+                method.content_privacy_level,
             );
 
             let (html_body, text_body) = match notification {
                 TransactionNotification::Pending(tx) | TransactionNotification::Confirmed(tx) => {
-                    let emoji = match tx.transaction_type {
-                        crate::metadata::EventType::Receive => "💸",
-                        crate::metadata::EventType::Send => "📤",
+                    let emoji = match method.content_privacy_level {
+                        ContentPrivacyLevel::Minimal => "🔔",
+                        _ => match tx.transaction_type {
+                            crate::metadata::EventType::Receive => "💸",
+                            crate::metadata::EventType::Send => "📤",
+                        },
                     };
 
                     let html_body = Self::build_transaction_html(
@@ -113,7 +120,9 @@ impl NotificationProvider for EmailProvider {
 
                     (html_body, text_body)
                 }
-                TransactionNotification::BalanceAlert(_) => {
+                TransactionNotification::BalanceAlert(_)
+                    if method.content_privacy_level == ContentPrivacyLevel::Detailed =>
+                {
                     let html_body = Self::build_balance_alert_html(
                         wallet_name,
                         &contact.name,
@@ -128,6 +137,16 @@ impl NotificationProvider for EmailProvider {
                     );
                     (html_body, text_body)
                 }
+                TransactionNotification::BalanceAlert(_) => (
+                    Self::build_transaction_html(
+                        &subject,
+                        "🔔",
+                        &contact.name,
+                        &message,
+                        user_language,
+                    ),
+                    Self::build_transaction_text(&subject, &contact.name, &message, user_language),
+                ),
             };
 
             batch_data.push((

--- a/backend/src/handlers/contact.rs
+++ b/backend/src/handlers/contact.rs
@@ -8,7 +8,7 @@ use crate::handlers::helpers::{
     reject_webhook_in_cloud_mode, require_recent_verification, verify_wallet_access,
     DatabaseErrorMessage, ResourceLimit,
 };
-use crate::metadata::{ContactNotificationSettings, ProviderType};
+use crate::metadata::{ContactNotificationSettings, ContentPrivacyLevel, ProviderType};
 use crate::models::{
     validate_phone_number, CreateContactResponse, CreateContactWithMethodsRequest, ErrorResponse,
     NotificationMethodRequest, UpdateContactRequest,
@@ -324,6 +324,21 @@ pub async fn create_wallet_contact(
                 .into_response();
         }
     }
+
+    let processed_methods = processed_methods
+        .into_iter()
+        .zip(payload.notification_methods.iter())
+        .map(|((provider, target, is_enabled), request)| {
+            (
+                provider,
+                target,
+                is_enabled,
+                request
+                    .content_privacy_level
+                    .unwrap_or(ContentPrivacyLevel::Standard),
+            )
+        })
+        .collect();
 
     let create_result = app_services
         .metadata_db
@@ -763,6 +778,32 @@ pub async fn update_wallet_contact(
                 .into_response();
         }
     }
+
+    // An omitted level on update preserves the existing method so older clients
+    // cannot silently downgrade a migrated Detailed delivery. A genuinely new
+    // method receives the documented Standard default.
+    let processed_methods = processed_methods
+        .into_iter()
+        .zip(payload.notification_methods.iter())
+        .map(|((provider, target, is_enabled), request)| {
+            let existing_level = existing_contact
+                .notification_methods
+                .iter()
+                .find(|method| {
+                    method.provider_type == provider && method.notification_target == target
+                })
+                .map(|method| method.content_privacy_level);
+            (
+                provider,
+                target,
+                is_enabled,
+                request
+                    .content_privacy_level
+                    .or(existing_level)
+                    .unwrap_or(ContentPrivacyLevel::Standard),
+            )
+        })
+        .collect();
 
     // Update contact using transaction
     match app_services

--- a/backend/src/handlers/contact.rs
+++ b/backend/src/handlers/contact.rs
@@ -109,6 +109,7 @@ pub async fn create_wallet_contact(
     let mut processed_methods = Vec::new();
 
     for method in &payload.notification_methods {
+        let requested_privacy_level = method.content_privacy_level;
         match method.provider_type {
             ProviderType::Sms => {
                 // Validate and normalize the phone number
@@ -139,6 +140,7 @@ pub async fn create_wallet_contact(
                             ProviderType::Sms,
                             normalized_phone,
                             method.is_enabled,
+                            requested_privacy_level,
                         ));
                         continue;
                     }
@@ -166,6 +168,7 @@ pub async fn create_wallet_contact(
                         ProviderType::Sms,
                         normalized_phone,
                         method.is_enabled,
+                        requested_privacy_level,
                     )),
                     Err(response) => return response,
                 }
@@ -174,9 +177,12 @@ pub async fn create_wallet_contact(
                 // Push notifications are always allowed (ntfy is free)
                 // Use user-provided topic from request
                 match validate_ntfy_topic(&method.notification_target) {
-                    Ok(topic) => {
-                        processed_methods.push((ProviderType::Ntfy, topic, method.is_enabled))
-                    }
+                    Ok(topic) => processed_methods.push((
+                        ProviderType::Ntfy,
+                        topic,
+                        method.is_enabled,
+                        requested_privacy_level,
+                    )),
                     Err(e) => {
                         return (
                             StatusCode::BAD_REQUEST,
@@ -208,7 +214,12 @@ pub async fn create_wallet_contact(
                 {
                     Ok(true) => {
                         // Email already verified for another wallet, skip OTP
-                        processed_methods.push((ProviderType::Email, email, method.is_enabled));
+                        processed_methods.push((
+                            ProviderType::Email,
+                            email,
+                            method.is_enabled,
+                            requested_privacy_level,
+                        ));
                         continue;
                     }
                     Ok(false) => {} // Not verified for another wallet, check wallet-specific verification
@@ -231,9 +242,12 @@ pub async fn create_wallet_contact(
                 )
                 .await
                 {
-                    Ok(()) => {
-                        processed_methods.push((ProviderType::Email, email, method.is_enabled))
-                    }
+                    Ok(()) => processed_methods.push((
+                        ProviderType::Email,
+                        email,
+                        method.is_enabled,
+                        requested_privacy_level,
+                    )),
                     Err(response) => return response,
                 }
             }
@@ -247,6 +261,7 @@ pub async fn create_wallet_contact(
                         ProviderType::Nostr,
                         public_key_hex,
                         method.is_enabled,
+                        requested_privacy_level,
                     )),
                     Err(e) => {
                         return (
@@ -263,9 +278,12 @@ pub async fn create_wallet_contact(
                 }
 
                 match validate_webhook_url(&method.notification_target).await {
-                    Ok(url) => {
-                        processed_methods.push((ProviderType::Webhook, url, method.is_enabled))
-                    }
+                    Ok(url) => processed_methods.push((
+                        ProviderType::Webhook,
+                        url,
+                        method.is_enabled,
+                        requested_privacy_level,
+                    )),
                     Err(e) => {
                         return (
                             StatusCode::BAD_REQUEST,
@@ -293,7 +311,7 @@ pub async fn create_wallet_contact(
     // Check for duplicate notification targets (email/phone) within the same wallet
     let methods_for_validation: Vec<(String, String)> = processed_methods
         .iter()
-        .map(|(provider, target, _)| (provider.as_str().to_string(), target.clone()))
+        .map(|(provider, target, _, _)| (provider.as_str().to_string(), target.clone()))
         .collect();
 
     match app_services
@@ -327,15 +345,12 @@ pub async fn create_wallet_contact(
 
     let processed_methods = processed_methods
         .into_iter()
-        .zip(payload.notification_methods.iter())
-        .map(|((provider, target, is_enabled), request)| {
+        .map(|(provider, target, is_enabled, requested_privacy_level)| {
             (
                 provider,
                 target,
                 is_enabled,
-                request
-                    .content_privacy_level
-                    .unwrap_or(ContentPrivacyLevel::Standard),
+                requested_privacy_level.unwrap_or(ContentPrivacyLevel::Standard),
             )
         })
         .collect();
@@ -525,6 +540,7 @@ pub async fn update_wallet_contact(
     let mut processed_methods = Vec::new();
 
     for method in &payload.notification_methods {
+        let requested_privacy_level = method.content_privacy_level;
         match method.provider_type {
             ProviderType::Sms => {
                 // Validate and normalize the phone number
@@ -566,6 +582,7 @@ pub async fn update_wallet_contact(
                                 ProviderType::Sms,
                                 normalized_phone,
                                 method.is_enabled,
+                                requested_privacy_level,
                             ));
                             continue;
                         }
@@ -593,6 +610,7 @@ pub async fn update_wallet_contact(
                             ProviderType::Sms,
                             normalized_phone,
                             method.is_enabled,
+                            requested_privacy_level,
                         )),
                         Err(response) => return response,
                     }
@@ -602,6 +620,7 @@ pub async fn update_wallet_contact(
                         ProviderType::Sms,
                         normalized_phone,
                         method.is_enabled,
+                        requested_privacy_level,
                     ));
                 }
             }
@@ -609,9 +628,12 @@ pub async fn update_wallet_contact(
                 // Push notifications are always allowed (ntfy is free)
                 // Use user-provided topic from request
                 match validate_ntfy_topic(&method.notification_target) {
-                    Ok(topic) => {
-                        processed_methods.push((ProviderType::Ntfy, topic, method.is_enabled))
-                    }
+                    Ok(topic) => processed_methods.push((
+                        ProviderType::Ntfy,
+                        topic,
+                        method.is_enabled,
+                        requested_privacy_level,
+                    )),
                     Err(e) => {
                         return (
                             StatusCode::BAD_REQUEST,
@@ -654,7 +676,12 @@ pub async fn update_wallet_contact(
                         .await
                     {
                         Ok(true) => {
-                            processed_methods.push((ProviderType::Email, email, method.is_enabled));
+                            processed_methods.push((
+                                ProviderType::Email,
+                                email,
+                                method.is_enabled,
+                                requested_privacy_level,
+                            ));
                             continue;
                         }
                         Ok(false) => {} // Not verified for another wallet, check wallet-specific verification
@@ -677,14 +704,22 @@ pub async fn update_wallet_contact(
                     )
                     .await
                     {
-                        Ok(()) => {
-                            processed_methods.push((ProviderType::Email, email, method.is_enabled))
-                        }
+                        Ok(()) => processed_methods.push((
+                            ProviderType::Email,
+                            email,
+                            method.is_enabled,
+                            requested_privacy_level,
+                        )),
                         Err(response) => return response,
                     }
                 } else {
                     // Email address hasn't changed, so we can reuse it without verification
-                    processed_methods.push((ProviderType::Email, email, method.is_enabled));
+                    processed_methods.push((
+                        ProviderType::Email,
+                        email,
+                        method.is_enabled,
+                        requested_privacy_level,
+                    ));
                 }
             }
             ProviderType::Nostr => {
@@ -697,6 +732,7 @@ pub async fn update_wallet_contact(
                         ProviderType::Nostr,
                         public_key_hex,
                         method.is_enabled,
+                        requested_privacy_level,
                     )),
                     Err(e) => {
                         return (
@@ -713,9 +749,12 @@ pub async fn update_wallet_contact(
                 }
 
                 match validate_webhook_url(&method.notification_target).await {
-                    Ok(url) => {
-                        processed_methods.push((ProviderType::Webhook, url, method.is_enabled))
-                    }
+                    Ok(url) => processed_methods.push((
+                        ProviderType::Webhook,
+                        url,
+                        method.is_enabled,
+                        requested_privacy_level,
+                    )),
                     Err(e) => {
                         return (
                             StatusCode::BAD_REQUEST,
@@ -743,7 +782,7 @@ pub async fn update_wallet_contact(
     // Check for duplicate notification targets (email/phone) within the same wallet, excluding current contact
     let methods_for_validation: Vec<(String, String)> = processed_methods
         .iter()
-        .map(|(provider, target, _)| (provider.as_str().to_string(), target.clone()))
+        .map(|(provider, target, _, _)| (provider.as_str().to_string(), target.clone()))
         .collect();
 
     match app_services
@@ -784,8 +823,7 @@ pub async fn update_wallet_contact(
     // method receives the documented Standard default.
     let processed_methods = processed_methods
         .into_iter()
-        .zip(payload.notification_methods.iter())
-        .map(|((provider, target, is_enabled), request)| {
+        .map(|(provider, target, is_enabled, requested_privacy_level)| {
             let existing_level = existing_contact
                 .notification_methods
                 .iter()
@@ -797,8 +835,7 @@ pub async fn update_wallet_contact(
                 provider,
                 target,
                 is_enabled,
-                request
-                    .content_privacy_level
+                requested_privacy_level
                     .or(existing_level)
                     .unwrap_or(ContentPrivacyLevel::Standard),
             )

--- a/backend/src/message_formatter.rs
+++ b/backend/src/message_formatter.rs
@@ -1,4 +1,4 @@
-use crate::metadata::{EventType, Language, TransactionNotification};
+use crate::metadata::{ContentPrivacyLevel, EventType, Language, TransactionNotification};
 use icu::decimal::input::Decimal;
 use icu::decimal::DecimalFormatter;
 use icu::locale::{locale, Locale};
@@ -8,6 +8,96 @@ use writeable::Writeable;
 pub struct MessageFormatter;
 
 impl MessageFormatter {
+    pub fn create_localized_message_for_level(
+        notification: &TransactionNotification,
+        wallet_name: &str,
+        language: &Language,
+        include_wallet_balance: bool,
+        wallet_balance_sats: Option<i64>,
+        content_privacy_level: ContentPrivacyLevel,
+    ) -> String {
+        match content_privacy_level {
+            ContentPrivacyLevel::Minimal => {
+                let locale = language.as_str();
+                match notification {
+                    TransactionNotification::Confirmed(_) => {
+                        t!("privacy.activity_confirmed", locale = locale).to_string()
+                    }
+                    TransactionNotification::Pending(_)
+                    | TransactionNotification::BalanceAlert(_) => {
+                        t!("privacy.activity_detected", locale = locale).to_string()
+                    }
+                }
+            }
+            ContentPrivacyLevel::Standard => Self::create_localized_title(
+                notification,
+                wallet_name,
+                language,
+                content_privacy_level,
+            ),
+            ContentPrivacyLevel::Detailed => Self::create_localized_message(
+                notification,
+                wallet_name,
+                language,
+                include_wallet_balance,
+                wallet_balance_sats,
+            ),
+        }
+    }
+
+    pub fn create_localized_title(
+        notification: &TransactionNotification,
+        wallet_name: &str,
+        language: &Language,
+        content_privacy_level: ContentPrivacyLevel,
+    ) -> String {
+        let locale = language.as_str();
+        if content_privacy_level == ContentPrivacyLevel::Minimal {
+            return match notification {
+                TransactionNotification::Confirmed(_) => {
+                    t!("privacy.activity_confirmed", locale = locale).to_string()
+                }
+                TransactionNotification::Pending(_) | TransactionNotification::BalanceAlert(_) => {
+                    t!("privacy.activity_detected", locale = locale).to_string()
+                }
+            };
+        }
+
+        let title = match notification {
+            TransactionNotification::Pending(tx) if tx.transaction_status == "replaced" => {
+                t!("titles.rbf", locale = locale).to_string()
+            }
+            TransactionNotification::Pending(tx) if tx.parent_txid.is_some() => {
+                t!("titles.send.cpfp", locale = locale).to_string()
+            }
+            TransactionNotification::Pending(tx) => match tx.transaction_type {
+                EventType::Receive => t!("titles.receive.pending", locale = locale).to_string(),
+                EventType::Send => t!("titles.send.pending", locale = locale).to_string(),
+            },
+            TransactionNotification::Confirmed(tx) => match tx.transaction_type {
+                EventType::Receive => t!("titles.receive.confirmed", locale = locale).to_string(),
+                EventType::Send => t!("titles.send.confirmed", locale = locale).to_string(),
+            },
+            TransactionNotification::BalanceAlert(_) => {
+                t!("titles.balance_alert", locale = locale).to_string()
+            }
+        };
+        format!("{} - {}", title, wallet_name)
+    }
+
+    pub fn create_localized_email_subject_for_level(
+        notification: &TransactionNotification,
+        wallet_name: &str,
+        language: &Language,
+        content_privacy_level: ContentPrivacyLevel,
+    ) -> String {
+        if content_privacy_level == ContentPrivacyLevel::Detailed {
+            Self::create_localized_email_subject(notification, wallet_name, language)
+        } else {
+            Self::create_localized_title(notification, wallet_name, language, content_privacy_level)
+        }
+    }
+
     /// Convert Language enum to ICU4X Locale
     fn language_to_locale(language: &Language) -> Locale {
         match language {

--- a/backend/src/metadata/contact.rs
+++ b/backend/src/metadata/contact.rs
@@ -232,7 +232,7 @@ impl MetadataDb {
             name,
             notification_methods
                 .into_iter()
-                .map(|(provider, target)| (provider, target, true))
+                .map(|(provider, target)| (provider, target, true, ContentPrivacyLevel::Standard))
                 .collect(),
             ContactNotificationSettings::defaults_for_new_contact(),
         )
@@ -243,7 +243,7 @@ impl MetadataDb {
         &self,
         wallet_checksum: &str,
         name: &str,
-        notification_methods: Vec<(ProviderType, String, bool)>,
+        notification_methods: Vec<(ProviderType, String, bool, ContentPrivacyLevel)>,
         notification_settings: ContactNotificationSettings,
     ) -> Result<String> {
         let pool = self.pool.clone();
@@ -276,11 +276,13 @@ impl MetadataDb {
             )?;
 
             // Insert notification methods
-            for (provider_type, notification_target, is_enabled) in notification_methods {
+            for (provider_type, notification_target, is_enabled, content_privacy_level) in
+                notification_methods
+            {
                 let method_id = Uuid::new_v4().to_string();
                 tx.execute(
-                    "INSERT INTO contact_notification_methods (id, contact_id, provider_type, notification_target, wallet_checksum, is_enabled) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                    params![&method_id, &contact_id, provider_type.as_str(), &notification_target, &checksum, is_enabled],
+                    "INSERT INTO contact_notification_methods (id, contact_id, provider_type, notification_target, wallet_checksum, is_enabled, content_privacy_level) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    params![&method_id, &contact_id, provider_type.as_str(), &notification_target, &checksum, is_enabled, content_privacy_level.as_str()],
                 )?;
             }
 
@@ -354,7 +356,7 @@ impl MetadataDb {
             for ids_chunk in contact_ids.chunks(500) {
                 let placeholders = ids_chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
                 let methods_query = format!(
-                    "SELECT id, contact_id, provider_type, notification_target, created_at, is_enabled
+                    "SELECT id, contact_id, provider_type, notification_target, created_at, is_enabled, content_privacy_level
                      FROM contact_notification_methods
                      WHERE contact_id IN ({}) ORDER BY contact_id",
                     placeholders
@@ -374,6 +376,9 @@ impl MetadataDb {
                         display_target: None,
                         created_at: row.get(4)?,
                         is_enabled: row.get::<_, i64>(5).unwrap_or(1) != 0,
+                        content_privacy_level: ContentPrivacyLevel::from(
+                            row.get::<_, String>(6)?.as_str(),
+                        ),
                     })
                 })?;
 
@@ -464,7 +469,7 @@ impl MetadataDb {
                     .collect::<Vec<_>>()
                     .join(",");
                 let query = format!(
-                    "SELECT id, contact_id, provider_type, notification_target, created_at, is_enabled
+                    "SELECT id, contact_id, provider_type, notification_target, created_at, is_enabled, content_privacy_level
                      FROM contact_notification_methods
                      WHERE contact_id IN ({}) ORDER BY contact_id, provider_type",
                     placeholders
@@ -490,6 +495,9 @@ impl MetadataDb {
                         display_target,
                         created_at: row.get(4)?,
                         is_enabled: row.get::<_, i64>(5).unwrap_or(1) != 0,
+                        content_privacy_level: ContentPrivacyLevel::from(
+                            row.get::<_, String>(6)?.as_str(),
+                        ),
                     })
                 })?;
 
@@ -581,7 +589,7 @@ impl MetadataDb {
 
             // Get notification methods for this contact
             let methods_query =
-                "SELECT id, provider_type, notification_target, created_at, is_enabled
+                "SELECT id, provider_type, notification_target, created_at, is_enabled, content_privacy_level
                                FROM contact_notification_methods
                                WHERE contact_id = ?1";
             let mut methods_stmt = conn.prepare(methods_query)?;
@@ -601,6 +609,9 @@ impl MetadataDb {
                     display_target,
                     created_at: row.get(3)?,
                     is_enabled: row.get::<_, i64>(4).unwrap_or(1) != 0,
+                    content_privacy_level: ContentPrivacyLevel::from(
+                        row.get::<_, String>(5)?.as_str(),
+                    ),
                 })
             })?;
 
@@ -644,7 +655,7 @@ impl MetadataDb {
         contact_id: &str,
         wallet_checksum: &str,
         name: &str,
-        new_methods: Vec<(ProviderType, String, bool)>,
+        new_methods: Vec<(ProviderType, String, bool, ContentPrivacyLevel)>,
         notification_settings: ContactNotificationSettings,
     ) -> Result<()> {
         let pool = self.pool.clone();
@@ -692,7 +703,7 @@ impl MetadataDb {
             }
 
             let mut retained_method_ids = Vec::new();
-            for (provider_type, target, is_enabled) in new_methods {
+            for (provider_type, target, is_enabled, content_privacy_level) in new_methods {
                 let provider = provider_type.as_str();
                 let existing_method_id = tx
                     .query_row(
@@ -707,18 +718,18 @@ impl MetadataDb {
                 let method_id = if let Some(method_id) = existing_method_id {
                     tx.execute(
                         "UPDATE contact_notification_methods
-                         SET wallet_checksum = ?1, is_enabled = ?2
-                         WHERE id = ?3",
-                        params![checksum, is_enabled, method_id],
+                         SET wallet_checksum = ?1, is_enabled = ?2, content_privacy_level = ?3
+                         WHERE id = ?4",
+                        params![checksum, is_enabled, content_privacy_level.as_str(), method_id],
                     )?;
                     method_id
                 } else {
                     let method_id = uuid::Uuid::new_v4().to_string();
                     tx.execute(
                         "INSERT INTO contact_notification_methods
-                         (id, contact_id, provider_type, notification_target, wallet_checksum, is_enabled)
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                        params![method_id, contact_id, provider, target, checksum, is_enabled],
+                         (id, contact_id, provider_type, notification_target, wallet_checksum, is_enabled, content_privacy_level)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                        params![method_id, contact_id, provider, target, checksum, is_enabled, content_privacy_level.as_str()],
                     )?;
                     method_id
                 };

--- a/backend/src/metadata/types.rs
+++ b/backend/src/metadata/types.rs
@@ -229,6 +229,36 @@ pub struct NotificationMethod {
     pub display_target: Option<String>, // formatted version for display
     pub created_at: String,
     pub is_enabled: bool,
+    pub content_privacy_level: ContentPrivacyLevel,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ContentPrivacyLevel {
+    Minimal,
+    #[default]
+    Standard,
+    Detailed,
+}
+
+impl ContentPrivacyLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Minimal => "minimal",
+            Self::Standard => "standard",
+            Self::Detailed => "detailed",
+        }
+    }
+}
+
+impl From<&str> for ContentPrivacyLevel {
+    fn from(value: &str) -> Self {
+        match value {
+            "minimal" => Self::Minimal,
+            "detailed" => Self::Detailed,
+            _ => Self::Standard,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/backend/src/models/requests.rs
+++ b/backend/src/models/requests.rs
@@ -1,6 +1,6 @@
 //! Request DTOs for API endpoints
 
-use crate::metadata::{BalanceAlertType, ProviderType};
+use crate::metadata::{BalanceAlertType, ContentPrivacyLevel, ProviderType};
 use crate::nostr_provider::NostrDmMode;
 use serde::{Deserialize, Serialize};
 
@@ -38,6 +38,10 @@ pub struct NotificationMethodRequest {
     pub notification_target: String,
     #[serde(default = "default_true")]
     pub is_enabled: bool,
+    /// Omitted on create defaults to Standard. Omitted on update preserves the
+    /// existing method level.
+    #[serde(default)]
+    pub content_privacy_level: Option<ContentPrivacyLevel>,
 }
 
 fn default_true() -> bool {

--- a/backend/src/nostr_provider.rs
+++ b/backend/src/nostr_provider.rs
@@ -653,12 +653,13 @@ impl NotificationProvider for NostrProvider {
         let send_jobs: Vec<(NotificationMethod, String)> =
             notification_methods_for_provider(contacts, &ProviderType::Nostr)
                 .map(|(contact, method)| {
-                    let message = MessageFormatter::create_localized_message(
+                    let message = MessageFormatter::create_localized_message_for_level(
                         notification,
                         wallet_name,
                         user_language,
                         contact.include_wallet_balance_in_tx_notifications,
                         wallet_balance_sats,
+                        method.content_privacy_level,
                     );
                     (method.clone(), message)
                 })

--- a/backend/src/ntfy_provider.rs
+++ b/backend/src/ntfy_provider.rs
@@ -1,6 +1,7 @@
 use crate::message_formatter::MessageFormatter;
 use crate::metadata::{
-    Contact, EventType, Language, NotificationMethod, ProviderType, TransactionNotification,
+    Contact, ContentPrivacyLevel, EventType, Language, NotificationMethod, ProviderType,
+    TransactionNotification,
 };
 use crate::notifications::{
     notification_methods_for_provider, NotificationProvider, NotificationResult, ProviderInfo,
@@ -8,7 +9,6 @@ use crate::notifications::{
 use crate::outbound_target::{client_for_public_url, validate_public_url};
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use rust_i18n::t;
 use serde_json::json;
 
 /// Authentication method for ntfy server
@@ -85,19 +85,23 @@ impl NotificationProvider for NtfyProvider {
         let mut results = Vec::new();
 
         for (contact, method) in notification_methods_for_provider(contacts, &ProviderType::Ntfy) {
-            let message = MessageFormatter::create_localized_message(
+            let message = MessageFormatter::create_localized_message_for_level(
                 notification,
                 wallet_name,
                 user_language,
                 contact.include_wallet_balance_in_tx_notifications,
                 wallet_balance_sats,
+                method.content_privacy_level,
             );
 
             // Extract priority for ntfy headers
-            let priority = match notification {
-                TransactionNotification::Pending(_) => "high",
-                TransactionNotification::Confirmed(_) => "default",
-                TransactionNotification::BalanceAlert(_) => "urgent",
+            let priority = match method.content_privacy_level {
+                ContentPrivacyLevel::Minimal => "default",
+                _ => match notification {
+                    TransactionNotification::Pending(_) => "high",
+                    TransactionNotification::Confirmed(_) => "default",
+                    TransactionNotification::BalanceAlert(_) => "urgent",
+                },
             };
 
             let topic = &method.notification_target;
@@ -120,58 +124,12 @@ impl NotificationProvider for NtfyProvider {
                 }
             };
 
-            // Create localized title for push notification
-            // Note: t!() macro requires string literals, not variables, for compile-time translation lookup
-            let locale = user_language.as_str();
-            let localized_title = match notification {
-                TransactionNotification::Pending(tx) => match tx.transaction_type {
-                    EventType::Receive => {
-                        format!(
-                            "{} - {}",
-                            t!("titles.receive.pending", locale = locale),
-                            wallet_name
-                        )
-                    }
-                    EventType::Send => {
-                        if tx.parent_txid.is_some() {
-                            format!(
-                                "{} - {}",
-                                t!("titles.send.cpfp", locale = locale),
-                                wallet_name
-                            )
-                        } else {
-                            format!(
-                                "{} - {}",
-                                t!("titles.send.pending", locale = locale),
-                                wallet_name
-                            )
-                        }
-                    }
-                },
-                TransactionNotification::Confirmed(tx) => match tx.transaction_type {
-                    EventType::Receive => {
-                        format!(
-                            "{} - {}",
-                            t!("titles.receive.confirmed", locale = locale),
-                            wallet_name
-                        )
-                    }
-                    EventType::Send => {
-                        format!(
-                            "{} - {}",
-                            t!("titles.send.confirmed", locale = locale),
-                            wallet_name
-                        )
-                    }
-                },
-                TransactionNotification::BalanceAlert(_) => {
-                    format!(
-                        "{} - {}",
-                        t!("titles.balance_alert", locale = locale),
-                        wallet_name
-                    )
-                }
-            };
+            let localized_title = MessageFormatter::create_localized_title(
+                notification,
+                wallet_name,
+                user_language,
+                method.content_privacy_level,
+            );
 
             // Build the request with optional authentication
             let mut request = client
@@ -181,16 +139,19 @@ impl NotificationProvider for NtfyProvider {
                 .header("Priority", priority)
                 .header(
                     "Tags",
-                    match notification {
-                        TransactionNotification::Pending(tx)
-                        | TransactionNotification::Confirmed(tx) => {
-                            if tx.transaction_type == EventType::Receive {
-                                "money_with_wings"
-                            } else {
-                                "arrow_right"
+                    match method.content_privacy_level {
+                        ContentPrivacyLevel::Minimal => "bell",
+                        _ => match notification {
+                            TransactionNotification::Pending(tx)
+                            | TransactionNotification::Confirmed(tx) => {
+                                if tx.transaction_type == EventType::Receive {
+                                    "money_with_wings"
+                                } else {
+                                    "arrow_right"
+                                }
                             }
-                        }
-                        TransactionNotification::BalanceAlert(_) => "chart_with_upwards_trend",
+                            TransactionNotification::BalanceAlert(_) => "chart_with_upwards_trend",
+                        },
                     },
                 );
 

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -2728,6 +2728,7 @@ mod tests {
                 display_target: None,
                 created_at: "2026-01-01T00:00:00Z".to_string(),
                 is_enabled: true,
+                content_privacy_level: crate::metadata::ContentPrivacyLevel::Detailed,
             }],
             created_at: "2026-01-01T00:00:00Z".to_string(),
             is_active: true,

--- a/backend/src/tests/message_formatter.rs
+++ b/backend/src/tests/message_formatter.rs
@@ -1,5 +1,8 @@
 use crate::message_formatter::MessageFormatter;
-use crate::metadata::{EventType, Language, Transaction, TransactionNotification};
+use crate::metadata::{
+    BalanceAlertNotification, BalanceAlertType, ContentPrivacyLevel, EventType, Language,
+    Transaction, TransactionNotification,
+};
 
 fn create_test_transaction(
     transaction_type: EventType,
@@ -315,4 +318,137 @@ fn test_create_english_subject_send_cpfp() {
         &Language::English,
     );
     assert_eq!(subject, "⚡ CPFP Fee Bump - Test Wallet");
+}
+
+fn privacy_test_notifications() -> Vec<TransactionNotification> {
+    let mut sending = create_test_transaction(EventType::Send, 123_456_789, false);
+    sending.txid = "feedface".repeat(8);
+    let mut receiving = create_test_transaction(EventType::Receive, 123_456_789, false);
+    receiving.txid = "feedface".repeat(8);
+    let mut sent = sending.clone();
+    sent.transaction_status = "confirmed".to_string();
+    let mut received = receiving.clone();
+    received.transaction_status = "confirmed".to_string();
+    let mut rbf = sending.clone();
+    rbf.transaction_status = "replaced".to_string();
+    rbf.replaced_by_txid = Some("deadbeef".repeat(8));
+    let mut cpfp = sending.clone();
+    cpfp.parent_txid = Some("cafebabe".repeat(8));
+
+    vec![
+        TransactionNotification::Pending(sending),
+        TransactionNotification::Confirmed(sent),
+        TransactionNotification::Pending(receiving),
+        TransactionNotification::Confirmed(received),
+        TransactionNotification::Pending(rbf),
+        TransactionNotification::Pending(cpfp),
+        TransactionNotification::BalanceAlert(BalanceAlertNotification {
+            id: "balance-notification-secret".to_string(),
+            balance_alert_id: "balance-alert-secret".to_string(),
+            wallet_checksum: "wallet-checksum-secret".to_string(),
+            contact_id: Some("contact-secret".to_string()),
+            threshold_sats: 500_000_000,
+            current_balance_sats: 987_654_321,
+            alert_type: BalanceAlertType::Above,
+            notification_sent_at: 1_700_000_000,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            threshold_currency: Some("USD".to_string()),
+            threshold_fiat_amount: Some(50_000.0),
+            exchange_rate_snapshot: Some(60_000.0),
+        }),
+    ]
+}
+
+#[test]
+fn privacy_levels_exclude_sensitive_content_for_every_event_and_locale() {
+    let languages = [
+        Language::English,
+        Language::Norwegian,
+        Language::Spanish,
+        Language::Portuguese,
+        Language::German,
+        Language::French,
+        Language::Japanese,
+        Language::Danish,
+        Language::Swedish,
+    ];
+
+    for language in languages {
+        let transaction_amount = MessageFormatter::format_btc_amount(123_456_789, &language);
+        let current_balance = MessageFormatter::format_btc_amount(987_654_321, &language);
+        for notification in privacy_test_notifications() {
+            let minimal = MessageFormatter::create_localized_message_for_level(
+                &notification,
+                "Cold Storage Secret",
+                &language,
+                true,
+                Some(987_654_321),
+                ContentPrivacyLevel::Minimal,
+            );
+            assert!(!minimal.is_empty());
+            for excluded in [
+                "Cold Storage Secret",
+                transaction_amount.as_str(),
+                current_balance.as_str(),
+                "feedface",
+                "deadbeef",
+                "wallet-checksum-secret",
+                "USD",
+            ] {
+                assert!(
+                    !minimal.contains(excluded),
+                    "Minimal {language:?} leaked {excluded:?}: {minimal}"
+                );
+            }
+
+            let standard = MessageFormatter::create_localized_message_for_level(
+                &notification,
+                "Cold Storage Secret",
+                &language,
+                true,
+                Some(987_654_321),
+                ContentPrivacyLevel::Standard,
+            );
+            assert!(standard.contains("Cold Storage Secret"));
+            for excluded in [
+                transaction_amount.as_str(),
+                current_balance.as_str(),
+                "feedface",
+                "deadbeef",
+                "wallet-checksum-secret",
+                "USD",
+            ] {
+                assert!(
+                    !standard.contains(excluded),
+                    "Standard {language:?} leaked {excluded:?}: {standard}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn detailed_privacy_level_preserves_current_rich_message() {
+    let notification = TransactionNotification::Pending(create_test_transaction(
+        EventType::Receive,
+        50_000_000,
+        false,
+    ));
+    assert_eq!(
+        MessageFormatter::create_localized_message_for_level(
+            &notification,
+            "Test Wallet",
+            &Language::English,
+            true,
+            Some(123_456_789),
+            ContentPrivacyLevel::Detailed,
+        ),
+        MessageFormatter::create_localized_message(
+            &notification,
+            "Test Wallet",
+            &Language::English,
+            true,
+            Some(123_456_789),
+        )
+    );
 }

--- a/backend/src/tests/metadata.rs
+++ b/backend/src/tests/metadata.rs
@@ -1,7 +1,7 @@
 use crate::config::{AppConfig, NetworkConfig, OperatingMode};
 use crate::metadata::{
-    BalanceAlertType, ContactNotificationSettings, CreateBalanceAlertInput, EventType, Language,
-    MetadataDb, ProviderType, SubscriptionUpdateParams, TransactionInsert,
+    BalanceAlertType, ContactNotificationSettings, ContentPrivacyLevel, CreateBalanceAlertInput,
+    EventType, Language, MetadataDb, ProviderType, SubscriptionUpdateParams, TransactionInsert,
 };
 use tempfile::tempdir;
 
@@ -127,8 +127,18 @@ async fn test_update_contact_preserves_matching_notification_method_ids() {
             &wallet_checksum,
             "Alice",
             vec![
-                (ProviderType::Email, "alice@example.com".to_string(), true),
-                (ProviderType::Ntfy, "canary-alice".to_string(), true),
+                (
+                    ProviderType::Email,
+                    "alice@example.com".to_string(),
+                    true,
+                    ContentPrivacyLevel::Detailed,
+                ),
+                (
+                    ProviderType::Ntfy,
+                    "canary-alice".to_string(),
+                    true,
+                    ContentPrivacyLevel::Standard,
+                ),
             ],
             ContactNotificationSettings::defaults_for_new_contact(),
         )
@@ -152,8 +162,18 @@ async fn test_update_contact_preserves_matching_notification_method_ids() {
         &wallet_checksum,
         "Alice Updated",
         vec![
-            (ProviderType::Email, "alice@example.com".to_string(), false),
-            (ProviderType::Ntfy, "canary-alice-new".to_string(), true),
+            (
+                ProviderType::Email,
+                "alice@example.com".to_string(),
+                false,
+                ContentPrivacyLevel::Minimal,
+            ),
+            (
+                ProviderType::Ntfy,
+                "canary-alice-new".to_string(),
+                true,
+                ContentPrivacyLevel::Standard,
+            ),
         ],
         ContactNotificationSettings {
             notify_cpfp: false,
@@ -180,6 +200,10 @@ async fn test_update_contact_preserves_matching_notification_method_ids() {
         &original_email_method_id
     );
     assert!(!updated_email_method.is_enabled);
+    assert_eq!(
+        updated_email_method.content_privacy_level,
+        ContentPrivacyLevel::Minimal
+    );
     assert!(!updated_contact
         .notification_methods
         .iter()

--- a/backend/src/tests/notifications.rs
+++ b/backend/src/tests/notifications.rs
@@ -68,6 +68,7 @@ fn create_notification_method(provider_type: ProviderType, target: &str) -> Noti
         display_target: None,
         created_at: "2023-01-01 12:00:00".to_string(),
         is_enabled: true,
+        content_privacy_level: crate::metadata::ContentPrivacyLevel::Detailed,
     }
 }
 

--- a/backend/src/tests/webhook_provider.rs
+++ b/backend/src/tests/webhook_provider.rs
@@ -198,6 +198,49 @@ fn builds_every_transaction_payload_variant() {
 }
 
 #[test]
+fn detailed_serialization_preserves_the_v1_webhook_shape() {
+    let payload = payload_for(TransactionNotification::Pending(transaction(
+        EventType::Send,
+        false,
+    )));
+    let serialized = serde_json::to_value(&payload).unwrap();
+
+    assert_eq!(
+        serialized,
+        serde_json::json!({
+            "schema_version": WEBHOOK_SCHEMA_VERSION,
+            "event": "sending",
+            "title": payload.title,
+            "message": payload.message,
+            "sent_at": payload.sent_at,
+            "wallet": {
+                "checksum": "wallet-checksum",
+                "name": "Cold Storage",
+                "balance_sats": 250_000,
+            },
+            "contact": {
+                "id": "contact-1",
+                "name": "Contact 1",
+            },
+            "transaction": {
+                "txid": "11".repeat(32),
+                "direction": "send",
+                "amount_sats": 125_000,
+                "fee_sats": 500,
+                "block_height": null,
+                "first_seen_at": 1_700_000_000_u64,
+                "confirmed_at": null,
+                "status": "pending",
+                "parent_txid": null,
+                "replaced_by_txid": null,
+                "replaced_at": null,
+            },
+            "balance_alert": null,
+        })
+    );
+}
+
+#[test]
 fn builds_balance_alert_and_test_payloads() {
     let payload = payload_for(TransactionNotification::BalanceAlert(balance_alert()));
     assert_eq!(payload.event, "balance_alert");

--- a/backend/src/tests/webhook_provider.rs
+++ b/backend/src/tests/webhook_provider.rs
@@ -1,6 +1,6 @@
 use crate::metadata::{
-    BalanceAlertNotification, BalanceAlertType, Contact, EventType, Language, NotificationMethod,
-    ProviderType, Transaction, TransactionNotification,
+    BalanceAlertNotification, BalanceAlertType, Contact, ContentPrivacyLevel, EventType, Language,
+    NotificationMethod, ProviderType, Transaction, TransactionNotification,
 };
 use crate::notifications::NotificationProvider;
 use crate::webhook_provider::{
@@ -46,6 +46,7 @@ fn contact(url: &str, suffix: usize) -> Contact {
             display_target: None,
             created_at: "2026-01-01T00:00:00Z".to_string(),
             is_enabled: true,
+            content_privacy_level: ContentPrivacyLevel::Detailed,
         }],
         created_at: "2026-01-01T00:00:00Z".to_string(),
         is_active: true,
@@ -60,12 +61,20 @@ fn contact(url: &str, suffix: usize) -> Contact {
 }
 
 fn payload_for(notification: TransactionNotification) -> WebhookPayload {
+    payload_for_level(notification, ContentPrivacyLevel::Detailed)
+}
+
+fn payload_for_level(
+    notification: TransactionNotification,
+    content_privacy_level: ContentPrivacyLevel,
+) -> WebhookPayload {
     WebhookPayload::for_notification(
         &notification,
         "Cold Storage",
         &contact("http://localhost/hook", 1),
         &Language::English,
         Some(250_000),
+        content_privacy_level,
     )
 }
 
@@ -164,12 +173,12 @@ fn builds_every_transaction_payload_variant() {
     assert_eq!(received_payload.schema_version, WEBHOOK_SCHEMA_VERSION);
     assert_eq!(
         received_payload.wallet.as_ref().unwrap().name,
-        "Cold Storage"
+        Some("Cold Storage".to_string())
     );
     assert_eq!(received_payload.contact.as_ref().unwrap().name, "Contact 1");
     assert_eq!(
         received_payload.transaction.as_ref().unwrap().amount_sats,
-        125_000
+        Some(125_000)
     );
     assert!(chrono::DateTime::parse_from_rfc3339(&received_payload.sent_at).is_ok());
 
@@ -204,6 +213,101 @@ fn builds_balance_alert_and_test_payloads() {
     assert!(test.contact.is_none());
     assert!(test.transaction.is_none());
     assert!(test.balance_alert.is_none());
+}
+
+#[test]
+fn privacy_levels_omit_excluded_webhook_fields_for_every_event() {
+    let mut rbf = transaction(EventType::Send, false);
+    rbf.transaction_status = "replaced".to_string();
+    rbf.replaced_by_txid = Some("22".repeat(32));
+    let mut cpfp = transaction(EventType::Send, false);
+    cpfp.parent_txid = Some("33".repeat(32));
+    let notifications = vec![
+        TransactionNotification::Pending(transaction(EventType::Send, false)),
+        TransactionNotification::Confirmed(transaction(EventType::Send, true)),
+        TransactionNotification::Pending(transaction(EventType::Receive, false)),
+        TransactionNotification::Confirmed(transaction(EventType::Receive, true)),
+        TransactionNotification::Pending(rbf),
+        TransactionNotification::Pending(cpfp),
+        TransactionNotification::BalanceAlert(balance_alert()),
+    ];
+
+    for notification in notifications {
+        let minimal = serde_json::to_value(payload_for_level(
+            notification.clone(),
+            ContentPrivacyLevel::Minimal,
+        ))
+        .unwrap();
+        assert!(minimal.get("wallet").is_none());
+        assert!(minimal.get("contact").is_none());
+        assert!(minimal.get("transaction").is_none());
+        assert!(minimal.get("balance_alert").is_none());
+        let minimal_text = minimal.to_string();
+        for excluded in [
+            "Cold Storage",
+            "wallet-checksum",
+            "Contact 1",
+            "125000",
+            "250000",
+            &"11".repeat(32),
+            &"22".repeat(32),
+            &"33".repeat(32),
+        ] {
+            assert!(
+                !minimal_text.contains(excluded),
+                "Minimal leaked {excluded}"
+            );
+        }
+
+        let standard = serde_json::to_value(payload_for_level(
+            notification,
+            ContentPrivacyLevel::Standard,
+        ))
+        .unwrap();
+        assert_eq!(standard["wallet"]["name"], "Cold Storage");
+        assert!(standard["wallet"].get("checksum").is_none());
+        assert!(standard["wallet"].get("balance_sats").is_none());
+        assert!(standard.get("contact").is_none());
+        if let Some(transaction) = standard.get("transaction") {
+            assert!(transaction.get("direction").is_some());
+            assert!(transaction.get("status").is_some());
+            for key in [
+                "txid",
+                "amount_sats",
+                "fee_sats",
+                "block_height",
+                "first_seen_at",
+                "confirmed_at",
+                "parent_txid",
+                "replaced_by_txid",
+                "replaced_at",
+            ] {
+                assert!(transaction.get(key).is_none(), "Standard included {key}");
+            }
+        }
+        if let Some(alert) = standard.get("balance_alert") {
+            assert!(alert.get("alert_type").is_some());
+            for key in [
+                "id",
+                "alert_id",
+                "threshold_sats",
+                "current_balance_sats",
+                "threshold_currency",
+                "threshold_fiat_amount",
+                "exchange_rate_snapshot",
+                "current_fiat_amount",
+            ] {
+                assert!(alert.get(key).is_none(), "Standard included {key}");
+            }
+        }
+        let standard_text = standard.to_string();
+        for excluded in ["wallet-checksum", "Contact 1", "125000", "250000"] {
+            assert!(
+                !standard_text.contains(excluded),
+                "Standard leaked {excluded}"
+            );
+        }
+    }
 }
 
 async fn capture_payload(

--- a/backend/src/twilio_provider.rs
+++ b/backend/src/twilio_provider.rs
@@ -154,12 +154,13 @@ impl NotificationProvider for TwilioProvider {
         let mut results = Vec::new();
 
         for (contact, method) in notification_methods_for_provider(contacts, &ProviderType::Sms) {
-            let message = MessageFormatter::create_localized_message(
+            let message = MessageFormatter::create_localized_message_for_level(
                 notification,
                 wallet_name,
                 user_language,
                 contact.include_wallet_balance_in_tx_notifications,
                 wallet_balance_sats,
+                method.content_privacy_level,
             );
             let result = self.send_sms(&method.notification_target, &message).await;
             results.push((method.clone(), result, message));

--- a/backend/src/webhook_provider.rs
+++ b/backend/src/webhook_provider.rs
@@ -12,38 +12,33 @@ use async_trait::async_trait;
 use chrono::Utc;
 use futures::{stream, StreamExt};
 use rust_i18n::t;
-use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
+use serde_json::{json, Map, Value};
 use url::Url;
 
 pub const WEBHOOK_SCHEMA_VERSION: u8 = 1;
 pub const WEBHOOK_MAX_URL_LENGTH: usize = 2_048;
 pub const WEBHOOK_MAX_CONCURRENT_DELIVERIES: usize = 4;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct WebhookPayload {
     pub schema_version: u8,
     pub event: String,
     pub title: String,
     pub message: String,
     pub sent_at: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub wallet: Option<WebhookWallet>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub contact: Option<WebhookContact>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction: Option<WebhookTransaction>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_alert: Option<WebhookBalanceAlert>,
+    #[serde(skip)]
+    content_privacy_level: ContentPrivacyLevel,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebhookWallet {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub checksum: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_sats: Option<i64>,
 }
 
@@ -55,50 +50,84 @@ pub struct WebhookContact {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebhookTransaction {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub txid: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub direction: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub amount_sats: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub fee_sats: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub block_height: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub first_seen_at: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub confirmed_at: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_txid: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub replaced_by_txid: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub replaced_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebhookBalanceAlert {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub alert_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub alert_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold_sats: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub current_balance_sats: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold_currency: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold_fiat_amount: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub exchange_rate_snapshot: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub current_fiat_amount: Option<f64>,
+}
+
+impl Serialize for WebhookPayload {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut payload = serializer.serialize_map(None)?;
+        payload.serialize_entry("schema_version", &self.schema_version)?;
+        payload.serialize_entry("event", &self.event)?;
+        payload.serialize_entry("title", &self.title)?;
+        payload.serialize_entry("message", &self.message)?;
+        payload.serialize_entry("sent_at", &self.sent_at)?;
+
+        match self.content_privacy_level {
+            ContentPrivacyLevel::Minimal => {}
+            ContentPrivacyLevel::Standard => {
+                if let Some(wallet) = &self.wallet {
+                    let mut fields = Map::new();
+                    if let Some(name) = &wallet.name {
+                        fields.insert("name".to_string(), Value::String(name.clone()));
+                    }
+                    payload.serialize_entry("wallet", &fields)?;
+                }
+                if let Some(transaction) = &self.transaction {
+                    let mut fields = Map::new();
+                    if let Some(direction) = &transaction.direction {
+                        fields.insert("direction".to_string(), Value::String(direction.clone()));
+                    }
+                    if let Some(status) = &transaction.status {
+                        fields.insert("status".to_string(), Value::String(status.clone()));
+                    }
+                    payload.serialize_entry("transaction", &fields)?;
+                }
+                if let Some(balance_alert) = &self.balance_alert {
+                    let mut fields = Map::new();
+                    if let Some(alert_type) = &balance_alert.alert_type {
+                        fields.insert("alert_type".to_string(), Value::String(alert_type.clone()));
+                    }
+                    payload.serialize_entry("balance_alert", &fields)?;
+                }
+            }
+            ContentPrivacyLevel::Detailed => {
+                // Detailed is the pre-privacy v1 contract: all top-level and
+                // nested fields remain present, including explicit nulls.
+                payload.serialize_entry("wallet", &self.wallet)?;
+                payload.serialize_entry("contact", &self.contact)?;
+                payload.serialize_entry("transaction", &self.transaction)?;
+                payload.serialize_entry("balance_alert", &self.balance_alert)?;
+            }
+        }
+
+        payload.end()
+    }
 }
 
 impl From<&Transaction> for WebhookTransaction {
@@ -246,6 +275,7 @@ impl WebhookPayload {
                 }
                 ContentPrivacyLevel::Detailed => detailed_balance_alert,
             },
+            content_privacy_level,
         }
     }
 
@@ -261,6 +291,7 @@ impl WebhookPayload {
             contact: None,
             transaction: None,
             balance_alert: None,
+            content_privacy_level: ContentPrivacyLevel::Detailed,
         }
     }
 }

--- a/backend/src/webhook_provider.rs
+++ b/backend/src/webhook_provider.rs
@@ -1,7 +1,7 @@
 use crate::message_formatter::MessageFormatter;
 use crate::metadata::{
-    BalanceAlertNotification, Contact, Language, NotificationMethod, ProviderType, Transaction,
-    TransactionNotification,
+    BalanceAlertNotification, Contact, ContentPrivacyLevel, Language, NotificationMethod,
+    ProviderType, Transaction, TransactionNotification,
 };
 use crate::notifications::{
     notification_log_type, notification_methods_for_provider, NotificationProvider,
@@ -27,16 +27,23 @@ pub struct WebhookPayload {
     pub title: String,
     pub message: String,
     pub sent_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub wallet: Option<WebhookWallet>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub contact: Option<WebhookContact>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction: Option<WebhookTransaction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_alert: Option<WebhookBalanceAlert>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebhookWallet {
-    pub checksum: String,
-    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checksum: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_sats: Option<i64>,
 }
 
@@ -48,43 +55,63 @@ pub struct WebhookContact {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebhookTransaction {
-    pub txid: String,
-    pub direction: String,
-    pub amount_sats: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub txid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount_sats: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fee_sats: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub block_height: Option<u32>,
-    pub first_seen_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_seen_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub confirmed_at: Option<u64>,
-    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_txid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub replaced_by_txid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub replaced_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebhookBalanceAlert {
-    pub id: String,
-    pub alert_id: String,
-    pub alert_type: String,
-    pub threshold_sats: i64,
-    pub current_balance_sats: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alert_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alert_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threshold_sats: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_balance_sats: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold_currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold_fiat_amount: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exchange_rate_snapshot: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub current_fiat_amount: Option<f64>,
 }
 
 impl From<&Transaction> for WebhookTransaction {
     fn from(transaction: &Transaction) -> Self {
         Self {
-            txid: transaction.txid.clone(),
-            direction: transaction.transaction_type.as_str().to_string(),
-            amount_sats: transaction.amount_sats,
+            txid: Some(transaction.txid.clone()),
+            direction: Some(transaction.transaction_type.as_str().to_string()),
+            amount_sats: Some(transaction.amount_sats),
             fee_sats: transaction.fee_sats,
             block_height: transaction.block_height,
-            first_seen_at: transaction.first_seen_at,
+            first_seen_at: Some(transaction.first_seen_at),
             confirmed_at: transaction.confirmed_at,
-            status: transaction.transaction_status.clone(),
+            status: Some(transaction.transaction_status.clone()),
             parent_txid: transaction.parent_txid.clone(),
             replaced_by_txid: transaction.replaced_by_txid.clone(),
             replaced_at: transaction.replaced_at,
@@ -99,11 +126,11 @@ impl From<&BalanceAlertNotification> for WebhookBalanceAlert {
             .map(|rate| alert.current_balance_sats as f64 / 100_000_000.0 * rate);
 
         Self {
-            id: alert.id.clone(),
-            alert_id: alert.balance_alert_id.clone(),
-            alert_type: alert.alert_type.as_str().to_string(),
-            threshold_sats: alert.threshold_sats,
-            current_balance_sats: alert.current_balance_sats,
+            id: Some(alert.id.clone()),
+            alert_id: Some(alert.balance_alert_id.clone()),
+            alert_type: Some(alert.alert_type.as_str().to_string()),
+            threshold_sats: Some(alert.threshold_sats),
+            current_balance_sats: Some(alert.current_balance_sats),
             threshold_currency: alert.threshold_currency.clone(),
             threshold_fiat_amount: alert.threshold_fiat_amount,
             exchange_rate_snapshot: alert.exchange_rate_snapshot,
@@ -119,27 +146,41 @@ impl WebhookPayload {
         contact: &Contact,
         language: &Language,
         wallet_balance_sats: Option<i64>,
+        content_privacy_level: ContentPrivacyLevel,
     ) -> Self {
-        let message = MessageFormatter::create_localized_message(
+        let message = MessageFormatter::create_localized_message_for_level(
             notification,
             wallet_name,
             language,
             contact.include_wallet_balance_in_tx_notifications,
             wallet_balance_sats,
+            content_privacy_level,
         );
-        let event = notification_log_type(notification);
-        let title = localized_title(event, wallet_name, language);
+        let event = if content_privacy_level == ContentPrivacyLevel::Minimal {
+            match notification {
+                TransactionNotification::Confirmed(_) => "activity_confirmed",
+                _ => "activity_detected",
+            }
+        } else {
+            notification_log_type(notification)
+        };
+        let title = MessageFormatter::create_localized_title(
+            notification,
+            wallet_name,
+            language,
+            content_privacy_level,
+        );
         let wallet_checksum = match notification {
             TransactionNotification::Pending(transaction)
             | TransactionNotification::Confirmed(transaction) => &transaction.wallet_checksum,
             TransactionNotification::BalanceAlert(alert) => &alert.wallet_checksum,
         };
-        let transaction = match notification {
+        let detailed_transaction: Option<WebhookTransaction> = match notification {
             TransactionNotification::Pending(transaction)
             | TransactionNotification::Confirmed(transaction) => Some(transaction.into()),
             TransactionNotification::BalanceAlert(_) => None,
         };
-        let balance_alert = match notification {
+        let detailed_balance_alert: Option<WebhookBalanceAlert> = match notification {
             TransactionNotification::BalanceAlert(alert) => Some(alert.into()),
             _ => None,
         };
@@ -150,17 +191,61 @@ impl WebhookPayload {
             title,
             message,
             sent_at: Utc::now().to_rfc3339(),
-            wallet: Some(WebhookWallet {
-                checksum: wallet_checksum.clone(),
-                name: wallet_name.to_string(),
-                balance_sats: wallet_balance_sats,
+            wallet: match content_privacy_level {
+                ContentPrivacyLevel::Minimal => None,
+                ContentPrivacyLevel::Standard => Some(WebhookWallet {
+                    checksum: None,
+                    name: Some(wallet_name.to_string()),
+                    balance_sats: None,
+                }),
+                ContentPrivacyLevel::Detailed => Some(WebhookWallet {
+                    checksum: Some(wallet_checksum.clone()),
+                    name: Some(wallet_name.to_string()),
+                    balance_sats: wallet_balance_sats,
+                }),
+            },
+            contact: (content_privacy_level == ContentPrivacyLevel::Detailed).then(|| {
+                WebhookContact {
+                    id: contact.id.clone(),
+                    name: contact.name.clone(),
+                }
             }),
-            contact: Some(WebhookContact {
-                id: contact.id.clone(),
-                name: contact.name.clone(),
-            }),
-            transaction,
-            balance_alert,
+            transaction: match content_privacy_level {
+                ContentPrivacyLevel::Minimal => None,
+                ContentPrivacyLevel::Standard => {
+                    detailed_transaction.map(|transaction| WebhookTransaction {
+                        direction: transaction.direction,
+                        status: transaction.status,
+                        txid: None,
+                        amount_sats: None,
+                        fee_sats: None,
+                        block_height: None,
+                        first_seen_at: None,
+                        confirmed_at: None,
+                        parent_txid: None,
+                        replaced_by_txid: None,
+                        replaced_at: None,
+                    })
+                }
+                ContentPrivacyLevel::Detailed => detailed_transaction,
+            },
+            balance_alert: match content_privacy_level {
+                ContentPrivacyLevel::Minimal => None,
+                ContentPrivacyLevel::Standard => {
+                    detailed_balance_alert.map(|alert| WebhookBalanceAlert {
+                        alert_type: alert.alert_type,
+                        id: None,
+                        alert_id: None,
+                        threshold_sats: None,
+                        current_balance_sats: None,
+                        threshold_currency: None,
+                        threshold_fiat_amount: None,
+                        exchange_rate_snapshot: None,
+                        current_fiat_amount: None,
+                    })
+                }
+                ContentPrivacyLevel::Detailed => detailed_balance_alert,
+            },
         }
     }
 
@@ -178,23 +263,6 @@ impl WebhookPayload {
             balance_alert: None,
         }
     }
-}
-
-fn localized_title(event: &str, wallet_name: &str, language: &Language) -> String {
-    let locale = language.as_str();
-    let title = match event {
-        "sending" => t!("titles.send.pending", locale = locale).to_string(),
-        "sent" => t!("titles.send.confirmed", locale = locale).to_string(),
-        "receiving" => t!("titles.receive.pending", locale = locale).to_string(),
-        "received" => t!("titles.receive.confirmed", locale = locale).to_string(),
-        "rbf" => t!("titles.rbf", locale = locale).to_string(),
-        "cpfp" => t!("titles.send.cpfp", locale = locale).to_string(),
-        "balance_alert" => t!("titles.balance_alert", locale = locale).to_string(),
-        // Keep delivery resilient if a future notification event is added before
-        // a dedicated localized title ships.
-        _ => event.replace('_', " "),
-    };
-    format!("{} - {}", title, wallet_name)
 }
 
 pub async fn validate_webhook_url(input: &str) -> Result<String, String> {
@@ -356,6 +424,7 @@ impl NotificationProvider for WebhookProvider {
                     &contact,
                     user_language,
                     wallet_balance_sats,
+                    method.content_privacy_level,
                 );
                 let result = self
                     .send_payload(&method.notification_target, &payload)

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -1217,3 +1217,55 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
         .expect("remaining contact alert count");
     assert_eq!(remaining_contact_alert_count, 7);
 }
+
+#[test]
+fn migration_043_preserves_existing_content_and_constrains_privacy_levels() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let db_path = temp_dir.path().join("metadata.sqlite");
+    let migrations_dir = temp_dir.path().join("migrations");
+    fs::create_dir(&migrations_dir).expect("create migrations dir");
+
+    copy_migrations_through(&migrations_dir, 42);
+    MigrationRunner::new(db_path.to_str().expect("db path"))
+        .expect("create migration runner")
+        .run_migrations(migrations_dir.to_str().expect("migrations path"))
+        .expect("run migrations through 042");
+    seed_notification_log_with_method(&db_path);
+
+    copy_migrations_through(&migrations_dir, 43);
+    MigrationRunner::new(db_path.to_str().expect("db path"))
+        .expect("create migration runner")
+        .run_migrations(migrations_dir.to_str().expect("migrations path"))
+        .expect("run migration 043");
+
+    let conn = Connection::open(&db_path).expect("open db");
+    let migrated_level: String = conn
+        .query_row(
+            "SELECT content_privacy_level FROM contact_notification_methods WHERE id = 'method-1'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("migrated privacy level");
+    assert_eq!(migrated_level, "detailed");
+
+    for (id, topic, level) in [
+        ("method-standard", "topic-standard", "standard"),
+        ("method-minimal", "topic-minimal", "minimal"),
+    ] {
+        conn.execute(
+            "INSERT INTO contact_notification_methods
+             (id, contact_id, provider_type, notification_target, wallet_checksum, is_enabled, content_privacy_level)
+             VALUES (?1, 'contact-1', 'ntfy', ?2, 'wallet-1', 1, ?3)",
+            params![id, topic, level],
+        )
+        .expect("insert supported privacy level");
+    }
+    assert!(conn
+        .execute(
+            "INSERT INTO contact_notification_methods
+             (id, contact_id, provider_type, notification_target, wallet_checksum, is_enabled, content_privacy_level)
+             VALUES ('method-invalid', 'contact-1', 'ntfy', 'topic-invalid', 'wallet-1', 1, 'verbose')",
+            [],
+        )
+        .is_err());
+}

--- a/backend/tests/resource_limit_handlers_tests.rs
+++ b/backend/tests/resource_limit_handlers_tests.rs
@@ -658,9 +658,9 @@ async fn test_self_hosted_webhook_provider_validation_reuse_and_redacted_display
 
     let full_url = "https://example.com/hooks/canary?token=secret";
     for _ in 0..2 {
-        let (status, _) =
+        let (status, body) =
             create_contact_with_provider(&app, &token, checksum, "webhook", full_url).await;
-        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(status, StatusCode::CREATED, "{body}");
     }
 
     let contacts_response = app
@@ -690,6 +690,9 @@ async fn test_self_hosted_webhook_provider_validation_reuse_and_redacted_display
     assert!(webhook_methods
         .iter()
         .all(|method| method["display_target"] == "https://example.com"));
+    assert!(webhook_methods
+        .iter()
+        .all(|method| method["content_privacy_level"] == "standard"));
 
     let (status, _) = post_webhook_test(&app, None, full_url).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);

--- a/backend/tests/resource_limit_handlers_tests.rs
+++ b/backend/tests/resource_limit_handlers_tests.rs
@@ -708,6 +708,115 @@ async fn test_self_hosted_webhook_provider_validation_reuse_and_redacted_display
 }
 
 #[tokio::test]
+async fn test_privacy_levels_follow_methods_across_create_and_reordered_update() {
+    let (app, _temp_dir, _db_path) = create_self_hosted_test_app().await;
+    let token = self_hosted_admin_token();
+    let wallet = create_wallet(
+        &app,
+        &token,
+        "Privacy Association Wallet",
+        VALID_TESTNET_DESCRIPTOR,
+    )
+    .await;
+    let checksum = wallet["wallet"]["checksum"].as_str().unwrap();
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/wallets/{checksum}/contacts"))
+                .method("POST")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "Privacy Contact",
+                        "notification_methods": [
+                            {
+                                "provider_type": "ntfy",
+                                "notification_target": "privacy-minimal",
+                                "content_privacy_level": "minimal",
+                            },
+                            {
+                                "provider_type": "ntfy",
+                                "notification_target": "privacy-detailed",
+                                "content_privacy_level": "detailed",
+                            },
+                        ],
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let created = body_to_json(create_response.into_body()).await;
+    let contact_id = created["contact_id"].as_str().unwrap();
+
+    let update_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/wallets/{checksum}/contacts/{contact_id}"))
+                .method("PUT")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "Privacy Contact",
+                        "notification_methods": [
+                            {
+                                "provider_type": "ntfy",
+                                "notification_target": "privacy-detailed",
+                            },
+                            {
+                                "provider_type": "ntfy",
+                                "notification_target": "privacy-minimal",
+                                "content_privacy_level": "standard",
+                            },
+                        ],
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(update_response.status(), StatusCode::OK);
+
+    let contacts_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/wallets/{checksum}/contacts"))
+                .method("GET")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let contacts = body_to_json(contacts_response.into_body()).await;
+    let methods = contacts
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|contact| contact["id"] == contact_id)
+        .unwrap()["notification_methods"]
+        .as_array()
+        .unwrap();
+
+    assert!(methods.iter().any(|method| {
+        method["notification_target"] == "privacy-detailed"
+            && method["content_privacy_level"] == "detailed"
+    }));
+    assert!(methods.iter().any(|method| {
+        method["notification_target"] == "privacy-minimal"
+            && method["content_privacy_level"] == "standard"
+    }));
+}
+
+#[tokio::test]
 async fn test_admin_user_bypasses_wallet_limits() {
     let (app, _temp_dir, _db_path) = create_cloud_test_app().await;
     let token = login_admin_user(&app).await;

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -1283,6 +1283,14 @@
       "notSet": "ikke angivet",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "Indholdsbeskyttelse",
+      "levels": {
+        "minimal": { "label": "Minimal", "description": "Kun generel aktivitet. Skjuler walletnavn, retning, beløb, saldi, adresser og transaktions-id'er." },
+        "standard": { "label": "Standard", "description": "Viser status, retning og walletnavn. Skjuler beløb, saldi, adresser og transaktions-id'er." },
+        "detailed": { "label": "Detaljeret", "description": "Alle detaljer, inklusive beløb og valgfri wallet-saldo." }
+      }
+    },
     "transaction": {
       "title": "Transaktionsnotifikationer",
       "includeBalance": "Inkluder wallet-saldo i transaktionsnotifikationer",

--- a/frontend/messages/de-DE.json
+++ b/frontend/messages/de-DE.json
@@ -1283,6 +1283,14 @@
       "notSet": "nicht festgelegt",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "Inhaltsdatenschutz",
+      "levels": {
+        "minimal": { "label": "Minimal", "description": "Nur allgemeine Aktivität. Wallet-Name, Richtung, Beträge, Guthaben, Adressen und Transaktions-IDs werden ausgeblendet." },
+        "standard": { "label": "Standard", "description": "Zeigt Status, Richtung und Wallet-Name. Beträge, Guthaben, Adressen und Transaktions-IDs werden ausgeblendet." },
+        "detailed": { "label": "Detailliert", "description": "Vollständige Details einschließlich Beträgen und optionalem Wallet-Guthaben." }
+      }
+    },
     "transaction": {
       "title": "Transaktionsbenachrichtigungen",
       "includeBalance": "Wallet-Saldo in Transaktionsbenachrichtigungen einschließen",

--- a/frontend/messages/en-US.json
+++ b/frontend/messages/en-US.json
@@ -1283,6 +1283,14 @@
       "notSet": "not set",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "Content privacy",
+      "levels": {
+        "minimal": { "label": "Minimal", "description": "Generic activity only. Hides wallet name, direction, amounts, balances, addresses, and transaction IDs." },
+        "standard": { "label": "Standard", "description": "Shows status, direction, and wallet name. Hides amounts, balances, addresses, and transaction IDs." },
+        "detailed": { "label": "Detailed", "description": "Full notification details, including amounts and the optional wallet balance." }
+      }
+    },
     "transaction": {
       "title": "Transaction notifications",
       "includeBalance": "Include wallet balance in transaction notifications",

--- a/frontend/messages/es-419.json
+++ b/frontend/messages/es-419.json
@@ -1283,6 +1283,14 @@
       "notSet": "sin configurar",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "Privacidad del contenido",
+      "levels": {
+        "minimal": { "label": "Mínimo", "description": "Solo actividad genérica. Oculta el nombre de la billetera, dirección, montos, saldos, direcciones e ID de transacción." },
+        "standard": { "label": "Estándar", "description": "Muestra estado, dirección y nombre de la billetera. Oculta montos, saldos, direcciones e ID de transacción." },
+        "detailed": { "label": "Detallado", "description": "Detalles completos, incluidos los montos y el saldo opcional de la billetera." }
+      }
+    },
     "transaction": {
       "title": "Notificaciones de transacciones",
       "includeBalance": "Incluir saldo de la billetera en las notificaciones de transacciones",

--- a/frontend/messages/fr-FR.json
+++ b/frontend/messages/fr-FR.json
@@ -1283,6 +1283,14 @@
       "notSet": "non défini",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "Confidentialité du contenu",
+      "levels": {
+        "minimal": { "label": "Minimal", "description": "Activité générique uniquement. Masque le nom du portefeuille, le sens, les montants, soldes, adresses et identifiants de transaction." },
+        "standard": { "label": "Standard", "description": "Affiche l’état, le sens et le nom du portefeuille. Masque les montants, soldes, adresses et identifiants de transaction." },
+        "detailed": { "label": "Détaillé", "description": "Détails complets, y compris les montants et le solde facultatif du portefeuille." }
+      }
+    },
     "transaction": {
       "title": "Notifications de transaction",
       "includeBalance": "Inclure le solde du portefeuille dans les notifications de transaction",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1283,6 +1283,14 @@
       "notSet": "未設定",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "コンテンツのプライバシー",
+      "levels": {
+        "minimal": { "label": "最小", "description": "一般的なアクティビティのみ。ウォレット名、方向、金額、残高、アドレス、トランザクションIDを非表示にします。" },
+        "standard": { "label": "標準", "description": "状態、方向、ウォレット名を表示します。金額、残高、アドレス、トランザクションIDは非表示です。" },
+        "detailed": { "label": "詳細", "description": "金額とオプションのウォレット残高を含む完全な通知詳細です。" }
+      }
+    },
     "transaction": {
       "title": "トランザクション通知",
       "includeBalance": "トランザクション通知にウォレット残高を含める",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -1283,6 +1283,14 @@
       "notSet": "ikke satt",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "Personvern for innhold",
+      "levels": {
+        "minimal": { "label": "Minimal", "description": "Bare generell aktivitet. Skjuler lommeboknavn, retning, beløp, saldoer, adresser og transaksjons-ID-er." },
+        "standard": { "label": "Standard", "description": "Viser status, retning og lommeboknavn. Skjuler beløp, saldoer, adresser og transaksjons-ID-er." },
+        "detailed": { "label": "Detaljert", "description": "Fullstendige varseldetaljer, inkludert beløp og valgfri lommeboksaldo." }
+      }
+    },
     "transaction": {
       "title": "Transaksjonsvarsler",
       "includeBalance": "Inkluder lommeboksaldo i transaksjonsvarsler",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -1283,6 +1283,14 @@
       "notSet": "não definido",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "Privacidade do conteúdo",
+      "levels": {
+        "minimal": { "label": "Mínimo", "description": "Somente atividade genérica. Oculta nome da carteira, direção, valores, saldos, endereços e IDs de transação." },
+        "standard": { "label": "Padrão", "description": "Mostra status, direção e nome da carteira. Oculta valores, saldos, endereços e IDs de transação." },
+        "detailed": { "label": "Detalhado", "description": "Detalhes completos, incluindo valores e o saldo opcional da carteira." }
+      }
+    },
     "transaction": {
       "title": "Notificações de transações",
       "includeBalance": "Incluir saldo da carteira nas notificações de transações",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -1283,6 +1283,14 @@
       "notSet": "inte angivet",
       "summary": "{provider}: {target}"
     },
+    "privacy": {
+      "label": "Innehållsintegritet",
+      "levels": {
+        "minimal": { "label": "Minimal", "description": "Endast generell aktivitet. Döljer plånboksnamn, riktning, belopp, saldon, adresser och transaktions-ID:n." },
+        "standard": { "label": "Standard", "description": "Visar status, riktning och plånboksnamn. Döljer belopp, saldon, adresser och transaktions-ID:n." },
+        "detailed": { "label": "Detaljerad", "description": "Fullständiga detaljer, inklusive belopp och valfritt plånbokssaldo." }
+      }
+    },
     "transaction": {
       "title": "Transaktionsaviseringar",
       "includeBalance": "Inkludera plånbokssaldo i transaktionsaviseringar",

--- a/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/__tests__/page.test.tsx
@@ -169,6 +169,7 @@ function makeContact(overrides: Partial<Contact> = {}): Contact {
         display_target: 'alice-topic',
         created_at: '2024-01-01T00:00:00Z',
         is_enabled: true,
+        content_privacy_level: 'detailed',
       },
     ],
     created_at: '2024-01-01T00:00:00Z',
@@ -398,6 +399,7 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'webhook',
           notification_target: 'http://receiver:8080/hooks/canary?token=secret',
           is_enabled: true,
+          content_privacy_level: 'standard',
         },
       ],
       expect.any(Object)
@@ -442,7 +444,39 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'webhook',
           notification_target: completeUrl,
           is_enabled: true,
+          content_privacy_level: 'detailed',
         },
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('updates the privacy level of an existing delivery method', async () => {
+    const user = userEvent.setup()
+    mockNotificationsResponse([makeContact()])
+
+    await renderLoadedPage()
+    await user.click(screen.getByRole('button', { name: 'Contact actions' }))
+    await user.click(screen.getByText('Edit contact'))
+
+    const privacySelect = screen.getByRole('combobox', { name: 'Content privacy' })
+    expect(privacySelect).toHaveTextContent('Detailed')
+    expect(screen.getByText(/Full notification details/)).toBeInTheDocument()
+    await user.click(privacySelect)
+    await user.click(await screen.findByRole('option', { name: 'Minimal' }))
+    expect(screen.getByText(/Generic activity only/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /Save contact/ }))
+
+    await waitFor(() => expect(mockApi.updateContact).toHaveBeenCalledTimes(1))
+    expect(mockApi.updateContact).toHaveBeenCalledWith(
+      'sq32h3ch',
+      'contact-1',
+      'Alice',
+      [
+        expect.objectContaining({
+          provider_type: 'ntfy',
+          content_privacy_level: 'minimal',
+        }),
       ],
       expect.any(Object)
     )
@@ -537,6 +571,7 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'ntfy',
           notification_target: 'nora-sq32h3ch',
           is_enabled: true,
+          content_privacy_level: 'standard',
         },
       ],
       {
@@ -636,6 +671,7 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'ntfy',
           notification_target: 'alice-topic',
           is_enabled: true,
+          content_privacy_level: 'detailed',
         },
       ],
       {
@@ -681,6 +717,7 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'sms',
           notification_target: '+4792050946',
           is_enabled: true,
+          content_privacy_level: 'detailed',
         },
       ],
       expect.objectContaining({
@@ -715,6 +752,7 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'ntfy',
           notification_target: 'alice-topic',
           is_enabled: true,
+          content_privacy_level: 'detailed',
         },
       ],
       {
@@ -771,6 +809,7 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'ntfy',
           notification_target: 'alice-topic',
           is_enabled: true,
+          content_privacy_level: 'detailed',
         },
       ],
       {
@@ -993,11 +1032,13 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'sms',
           notification_target: '+4799999999',
           is_enabled: true,
+          content_privacy_level: 'detailed',
         },
         {
           provider_type: 'email',
           notification_target: 'alice@example.com',
           is_enabled: true,
+          content_privacy_level: 'standard',
         },
       ],
       expect.any(Object)
@@ -1154,11 +1195,13 @@ describe('WalletNotificationsPage', () => {
           provider_type: 'email',
           notification_target: 'alice@example.com',
           is_enabled: true,
+          content_privacy_level: 'detailed',
         },
         {
           provider_type: 'sms',
           notification_target: '+4799999999',
           is_enabled: true,
+          content_privacy_level: 'standard',
         },
       ],
       expect.any(Object)

--- a/frontend/src/app/wallets/[checksum]/notifications/page.tsx
+++ b/frontend/src/app/wallets/[checksum]/notifications/page.tsx
@@ -68,12 +68,19 @@ import {
 } from "@/lib/utils"
 import { useTranslations } from "next-intl"
 import { parsePhoneNumberFromString } from "libphonenumber-js"
-import type { BalanceAlert, Contact, CreateBalanceAlertRequest, Wallet } from "@/types"
+import type {
+  BalanceAlert,
+  Contact,
+  ContentPrivacyLevel,
+  CreateBalanceAlertRequest,
+  Wallet,
+} from "@/types"
 
 type MethodDraft = {
   provider_type: "email" | "sms" | "ntfy" | "nostr" | "webhook"
   notification_target: string
   is_enabled: boolean
+  content_privacy_level: ContentPrivacyLevel
 }
 
 type ContactDraft = {
@@ -126,6 +133,45 @@ function ProviderIcon({ provider }: { provider: (typeof PROVIDERS)[number] }) {
 
   const Icon = provider.icon
   return <Icon className="h-4 w-4" />
+}
+
+function ContentPrivacyLevelControl({
+  value,
+  onChange,
+  disabled = false,
+}: {
+  value: ContentPrivacyLevel
+  onChange: (value: ContentPrivacyLevel) => void
+  disabled?: boolean
+}) {
+  const tNotifications = useTranslations("walletNotifications")
+
+  return (
+    <div className="space-y-1.5">
+      <label className="block text-xs font-medium text-muted-foreground">
+        {tNotifications("privacy.label")}
+      </label>
+      <Select
+        value={value}
+        onValueChange={(nextValue) => onChange(nextValue as ContentPrivacyLevel)}
+        disabled={disabled}
+      >
+        <SelectTrigger aria-label={tNotifications("privacy.label")}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {(["minimal", "standard", "detailed"] as const).map((level) => (
+            <SelectItem key={level} value={level}>
+              {tNotifications(`privacy.levels.${level}.label`)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs leading-snug text-muted-foreground">
+        {tNotifications(`privacy.levels.${value}.description`)}
+      </p>
+    </div>
+  )
 }
 
 function formatDeliveryTarget(method: MethodDraft) {
@@ -240,6 +286,7 @@ function contactToDraft(contact: Contact): ContactDraft {
           ? method.display_target ?? method.notification_target
           : method.notification_target,
       is_enabled: method.is_enabled ?? true,
+      content_privacy_level: method.content_privacy_level ?? "detailed",
     })),
     notify_sending: contact.notify_sending ?? true,
     notify_sent: contact.notify_sent ?? true,
@@ -388,6 +435,8 @@ function NewContactWizardCard({
     isSelfHostedMode ? "ntfy" : "email"
   )
   const [target, setTarget] = useState("")
+  const [contentPrivacyLevel, setContentPrivacyLevel] =
+    useState<ContentPrivacyLevel>("standard")
   const [ntfyTopic, setNtfyTopic] = useState("")
   const [userEditedNtfyTopic, setUserEditedNtfyTopic] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -568,6 +617,7 @@ function NewContactWizardCard({
                     ? ntfyTopic.trim()
                     : target.trim(),
             is_enabled: true,
+            content_privacy_level: contentPrivacyLevel,
           },
         ],
         txSettingsFromDraft({
@@ -938,7 +988,14 @@ function NewContactWizardCard({
                   onResendCode={() => emailVerification.resendCode()}
                 />
               )}
-          </div>
+              <div className="mt-4 border-t pt-4">
+                <ContentPrivacyLevelControl
+                  value={contentPrivacyLevel}
+                  onChange={setContentPrivacyLevel}
+                  disabled={isCreating}
+                />
+              </div>
+            </div>
           <div className="flex justify-end">
             <Button onClick={createContact} disabled={isCreating}>
               {isCreating ? tCommon("saving") : "Create contact"}
@@ -1093,6 +1150,7 @@ function ContactNotificationCard({
           provider_type: method.provider_type,
           notification_target: method.notification_target.trim(),
           is_enabled: method.is_enabled,
+          content_privacy_level: method.content_privacy_level,
         })),
       txSettingsFromDraft(nextTxDraft)
     )
@@ -1371,152 +1429,168 @@ function ContactNotificationCard({
                     <ProviderIcon provider={provider} />
                     {provider.label}
                   </div>
-                  {method.provider_type === "sms" ? (
-                    <SmsProviderFields
-                      phoneNumber={method.notification_target}
-                      onPhoneNumberChange={(value) => {
-                        setEditDraft((prev) => ({
-                          ...prev,
-                          methods: prev.methods.map((item, methodIndex) =>
-                            methodIndex === index
-                              ? { ...item, notification_target: value }
-                              : item
-                          ),
-                        }))
-                        setContactError(null)
-                        smsVerification.clearPhoneError()
-                        if (
-                          smsVerification.isVerified ||
-                          (smsVerification.verificationPhone &&
-                            value.trim() !== smsVerification.verificationPhone)
-                        ) {
-                          smsVerification.reset()
+                  <div className="space-y-3">
+                    {method.provider_type === "sms" ? (
+                      <SmsProviderFields
+                        phoneNumber={method.notification_target}
+                        onPhoneNumberChange={(value) => {
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            methods: prev.methods.map((item, methodIndex) =>
+                              methodIndex === index
+                                ? { ...item, notification_target: value }
+                                : item
+                            ),
+                          }))
+                          setContactError(null)
+                          smsVerification.clearPhoneError()
+                          if (
+                            smsVerification.isVerified ||
+                            (smsVerification.verificationPhone &&
+                              value.trim() !== smsVerification.verificationPhone)
+                          ) {
+                            smsVerification.reset()
+                          }
+                        }}
+                        phonePlaceholder={phonePlaceholder}
+                        phoneError={smsVerification.phoneError}
+                        disabled={isSaving}
+                        containerClassName="space-y-3"
+                        verificationButtonLayout="inline"
+                        verificationRequired={!hasSavedTarget && !smsVerification.isVerified}
+                        verificationSent={smsVerification.verificationSent}
+                        verificationCode={smsVerification.verificationCode}
+                        onVerificationCodeChange={(code) => {
+                          smsVerification.setVerificationCode(code)
+                          smsVerification.clearVerificationError()
+                        }}
+                        verificationPhone={smsVerification.verificationPhone}
+                        verificationError={smsVerification.verificationError}
+                        isVerified={hasSavedTarget || smsVerification.isVerified}
+                        showSuccess={!hasSavedTarget && smsVerification.showSuccess}
+                        isSending={smsVerification.isSending}
+                        isVerifying={smsVerification.isVerifying}
+                        timeRemaining={smsVerification.timeRemaining}
+                        formatTime={smsVerification.formatTime}
+                        onSendVerification={() =>
+                          smsVerification.sendVerification(method.notification_target.trim())
                         }
-                      }}
-                      phonePlaceholder={phonePlaceholder}
-                      phoneError={smsVerification.phoneError}
-                      disabled={isSaving}
-                      containerClassName="space-y-3"
-                      verificationButtonLayout="inline"
-                      verificationRequired={!hasSavedTarget && !smsVerification.isVerified}
-                      verificationSent={smsVerification.verificationSent}
-                      verificationCode={smsVerification.verificationCode}
-                      onVerificationCodeChange={(code) => {
-                        smsVerification.setVerificationCode(code)
-                        smsVerification.clearVerificationError()
-                      }}
-                      verificationPhone={smsVerification.verificationPhone}
-                      verificationError={smsVerification.verificationError}
-                      isVerified={hasSavedTarget || smsVerification.isVerified}
-                      showSuccess={!hasSavedTarget && smsVerification.showSuccess}
-                      isSending={smsVerification.isSending}
-                      isVerifying={smsVerification.isVerifying}
-                      timeRemaining={smsVerification.timeRemaining}
-                      formatTime={smsVerification.formatTime}
-                      onSendVerification={() =>
-                        smsVerification.sendVerification(method.notification_target.trim())
-                      }
-                      onVerifyCode={() => smsVerification.verifyCode()}
-                      onResendCode={() => smsVerification.resendCode()}
-                    />
-                  ) : method.provider_type === "email" ? (
-                    <EmailProviderFields
-                      emailAddress={method.notification_target}
-                      onEmailAddressChange={(value) => {
-                        setEditDraft((prev) => ({
-                          ...prev,
-                          methods: prev.methods.map((item, methodIndex) =>
-                            methodIndex === index
-                              ? { ...item, notification_target: value }
-                              : item
-                          ),
-                        }))
-                        setContactError(null)
-                        emailVerification.clearEmailError()
-                        if (
-                          emailVerification.isVerified ||
-                          (emailVerification.verificationAddress &&
-                            value.trim() !== emailVerification.verificationAddress)
-                        ) {
-                          emailVerification.reset()
+                        onVerifyCode={() => smsVerification.verifyCode()}
+                        onResendCode={() => smsVerification.resendCode()}
+                      />
+                    ) : method.provider_type === "email" ? (
+                      <EmailProviderFields
+                        emailAddress={method.notification_target}
+                        onEmailAddressChange={(value) => {
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            methods: prev.methods.map((item, methodIndex) =>
+                              methodIndex === index
+                                ? { ...item, notification_target: value }
+                                : item
+                            ),
+                          }))
+                          setContactError(null)
+                          emailVerification.clearEmailError()
+                          if (
+                            emailVerification.isVerified ||
+                            (emailVerification.verificationAddress &&
+                              value.trim() !== emailVerification.verificationAddress)
+                          ) {
+                            emailVerification.reset()
+                          }
+                        }}
+                        emailPlaceholder={tCommon("emailPlaceholder")}
+                        emailError={emailVerification.emailError}
+                        disabled={isSaving}
+                        containerClassName="space-y-3"
+                        verificationButtonLayout="inline"
+                        verificationRequired={!hasSavedTarget && !emailVerification.isVerified}
+                        verificationSent={emailVerification.verificationSent}
+                        verificationCode={emailVerification.verificationCode}
+                        onVerificationCodeChange={(code) => {
+                          emailVerification.setVerificationCode(code)
+                          emailVerification.clearVerificationError()
+                        }}
+                        verificationAddress={emailVerification.verificationAddress}
+                        verificationError={emailVerification.verificationError}
+                        isVerified={hasSavedTarget || emailVerification.isVerified}
+                        showSuccess={!hasSavedTarget && emailVerification.showSuccess}
+                        isSending={emailVerification.isSending}
+                        isVerifying={emailVerification.isVerifying}
+                        timeRemaining={emailVerification.timeRemaining}
+                        formatTime={emailVerification.formatTime}
+                        onSendVerification={() =>
+                          emailVerification.sendVerification(method.notification_target.trim())
                         }
-                      }}
-                      emailPlaceholder={tCommon("emailPlaceholder")}
-                      emailError={emailVerification.emailError}
-                      disabled={isSaving}
-                      containerClassName="space-y-3"
-                      verificationButtonLayout="inline"
-                      verificationRequired={!hasSavedTarget && !emailVerification.isVerified}
-                      verificationSent={emailVerification.verificationSent}
-                      verificationCode={emailVerification.verificationCode}
-                      onVerificationCodeChange={(code) => {
-                        emailVerification.setVerificationCode(code)
-                        emailVerification.clearVerificationError()
-                      }}
-                      verificationAddress={emailVerification.verificationAddress}
-                      verificationError={emailVerification.verificationError}
-                      isVerified={hasSavedTarget || emailVerification.isVerified}
-                      showSuccess={!hasSavedTarget && emailVerification.showSuccess}
-                      isSending={emailVerification.isSending}
-                      isVerifying={emailVerification.isVerifying}
-                      timeRemaining={emailVerification.timeRemaining}
-                      formatTime={emailVerification.formatTime}
-                      onSendVerification={() =>
-                        emailVerification.sendVerification(method.notification_target.trim())
-                      }
-                      onVerifyCode={() => emailVerification.verifyCode()}
-                      onResendCode={() => emailVerification.resendCode()}
-                    />
-                  ) : method.provider_type === "nostr" ? (
-                    <NostrProviderFields
-                      recipient={method.notification_target}
-                      onRecipientChange={(value) => {
+                        onVerifyCode={() => emailVerification.verifyCode()}
+                        onResendCode={() => emailVerification.resendCode()}
+                      />
+                    ) : method.provider_type === "nostr" ? (
+                      <NostrProviderFields
+                        recipient={method.notification_target}
+                        onRecipientChange={(value) => {
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            methods: prev.methods.map((item, methodIndex) =>
+                              methodIndex === index
+                                ? { ...item, notification_target: value }
+                                : item
+                            ),
+                          }))
+                          setContactError(null)
+                        }}
+                        disabled={isSaving}
+                      />
+                    ) : method.provider_type === "webhook" ? (
+                      <WebhookProviderFields
+                        url={method.notification_target}
+                        onUrlChange={(value) => {
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            methods: prev.methods.map((item, methodIndex) =>
+                              methodIndex === index
+                                ? { ...item, notification_target: value }
+                                : item
+                            ),
+                          }))
+                          setContactError(null)
+                        }}
+                        disabled={isSaving}
+                      />
+                    ) : (
+                      <Input
+                        value={method.notification_target}
+                        placeholder={methodPlaceholder(method.provider_type)}
+                        readOnly={method.provider_type !== "ntfy"}
+                        disabled={method.provider_type !== "ntfy"}
+                        onChange={(event) =>
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            methods: prev.methods.map((item, methodIndex) =>
+                              methodIndex === index
+                                ? { ...item, notification_target: event.target.value }
+                                : item
+                            ),
+                          }))
+                        }
+                      />
+                    )}
+                    <ContentPrivacyLevelControl
+                      value={method.content_privacy_level}
+                      onChange={(contentPrivacyLevel) =>
                         setEditDraft((prev) => ({
                           ...prev,
                           methods: prev.methods.map((item, methodIndex) =>
                             methodIndex === index
-                              ? { ...item, notification_target: value }
-                              : item
-                          ),
-                        }))
-                        setContactError(null)
-                      }}
-                      disabled={isSaving}
-                    />
-                  ) : method.provider_type === "webhook" ? (
-                    <WebhookProviderFields
-                      url={method.notification_target}
-                      onUrlChange={(value) => {
-                        setEditDraft((prev) => ({
-                          ...prev,
-                          methods: prev.methods.map((item, methodIndex) =>
-                            methodIndex === index
-                              ? { ...item, notification_target: value }
-                              : item
-                          ),
-                        }))
-                        setContactError(null)
-                      }}
-                      disabled={isSaving}
-                    />
-                  ) : (
-                    <Input
-                      value={method.notification_target}
-                      placeholder={methodPlaceholder(method.provider_type)}
-                      readOnly={method.provider_type !== "ntfy"}
-                      disabled={method.provider_type !== "ntfy"}
-                      onChange={(event) =>
-                        setEditDraft((prev) => ({
-                          ...prev,
-                          methods: prev.methods.map((item, methodIndex) =>
-                            methodIndex === index
-                              ? { ...item, notification_target: event.target.value }
+                              ? { ...item, content_privacy_level: contentPrivacyLevel }
                               : item
                           ),
                         }))
                       }
+                      disabled={isSaving}
                     />
-                  )}
+                  </div>
                   {showDeleteDeliveryMethod && (
                     <Button
                       variant="ghost"
@@ -1584,6 +1658,7 @@ function ContactNotificationCard({
                               )
                             : "",
                         is_enabled: true,
+                        content_privacy_level: "standard",
                       },
                     ],
                   }))

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -197,7 +197,7 @@ class ApiClient {
   async createContact(
     walletChecksum: string,
     name: string,
-    notificationMethods: Array<{ provider_type: NotificationProviderType, notification_target: string, is_enabled?: boolean }>,
+    notificationMethods: Array<{ provider_type: NotificationProviderType, notification_target: string, is_enabled?: boolean, content_privacy_level?: 'minimal' | 'standard' | 'detailed' }>,
     settings?: {
       notify_sending?: boolean
       notify_sent?: boolean
@@ -255,7 +255,7 @@ class ApiClient {
     walletChecksum: string,
     contactId: string,
     name: string,
-    notificationMethods: Array<{ provider_type: NotificationProviderType, notification_target: string, is_enabled?: boolean }>,
+    notificationMethods: Array<{ provider_type: NotificationProviderType, notification_target: string, is_enabled?: boolean, content_privacy_level?: 'minimal' | 'standard' | 'detailed' }>,
     settings?: {
       notify_sending?: boolean
       notify_sent?: boolean

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -71,7 +71,10 @@ export interface NotificationMethod {
   display_target?: string
   created_at: string
   is_enabled: boolean
+  content_privacy_level?: ContentPrivacyLevel
 }
+
+export type ContentPrivacyLevel = 'minimal' | 'standard' | 'detailed'
 
 // Supported notification languages (must match backend Language enum)
 export type NotificationLanguage = 'en-US' | 'nb' | 'es-419' | 'pt-BR' | 'de-DE' | 'fr-FR' | 'ja' | 'da' | 'sv'


### PR DESCRIPTION
## Summary

- add Minimal, Standard, and Detailed content privacy settings per notification delivery method
- migrate existing methods to Detailed while defaulting newly created methods to Standard
- centralize localized privacy-aware formatting across email, SMS, ntfy, Nostr, and webhook deliveries
- omit excluded webhook fields structurally and expose localized controls/previews in notification settings
- cover all locales and transaction, RBF, CPFP, balance-alert, migration, persistence, and UI paths

## Verification

- `.agent-loop/checks.sh quick`
- focused notification privacy formatter, webhook, migration, metadata, handler, and frontend page tests

Closes #468