### PR TITLE
chore(deps): configure Dependabot maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    groups:
+      frontend-minor-and-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "cargo"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    groups:
+      backend-minor-and-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/claude-pull-request-code-review.yml
+++ b/.github/workflows/claude-pull-request-code-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/codex-pull-request-code-review.yml
+++ b/.github/workflows/codex-pull-request-code-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   codex:
-    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codex-pull-request-code-review.yml
+++ b/.github/workflows/codex-pull-request-code-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   codex:
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   gemini-review:
-    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   gemini-review:
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

- add weekly grouped Dependabot updates for frontend npm and backend Cargo dependencies
- group minor and patch version updates to reduce PR volume
- skip Claude, Codex, and Gemini review jobs on Dependabot-authored PRs

## Verification

- `.agent-loop/checks.sh`
- Dependabot YAML parsed successfully