### PR TITLE
test: add notification upgrade preservation release gate

### DIFF
--- a/.agent-loop/checks.sh
+++ b/.agent-loop/checks.sh
@@ -45,7 +45,7 @@ run_system() {
 }
 
 run_upgrade() {
-  echo "Warning: upgrade mode may start/stop services and create temporary upgrade worktrees." >&2
+  echo "Warning: upgrade mode resets only the scripts/docker-compose.yml regtest volumes, starts/stops local services, and creates a temporary worktree." >&2
   check_requirements bash
   (
     cd "$REPO_ROOT/scripts"

--- a/backend/migrations/031_per_contact_notifications.sql
+++ b/backend/migrations/031_per_contact_notifications.sql
@@ -12,6 +12,13 @@ ALTER TABLE contacts ADD COLUMN notify_cpfp BOOLEAN NOT NULL DEFAULT 1;
 ALTER TABLE contacts ADD COLUMN notify_rbf BOOLEAN NOT NULL DEFAULT 1;
 ALTER TABLE contacts ADD COLUMN include_wallet_balance_in_tx_notifications BOOLEAN NOT NULL DEFAULT 0;
 
+-- v1.5.2 had no separate RBF event toggle: replacement activity was covered by
+-- the ordinary pending/confirmed notifications. Disable the newly introduced
+-- RBF-specific delivery for contacts that already exist during this migration
+-- so upgrades do not gain an extra message. Contacts created after migration
+-- continue to use the column default above.
+UPDATE contacts SET notify_rbf = 0;
+
 ALTER TABLE contact_notification_methods ADD COLUMN is_enabled BOOLEAN NOT NULL DEFAULT 1;
 
 ALTER TABLE balance_alerts ADD COLUMN contact_id TEXT REFERENCES contacts(id) ON DELETE CASCADE;

--- a/backend/migrations/031_per_contact_notifications.sql
+++ b/backend/migrations/031_per_contact_notifications.sql
@@ -1,6 +1,9 @@
 -- Migration 031: Per-contact notification settings
 -- Moves notification configuration toward a per-contact model while keeping
 -- existing wallet-level rows available for historical audit references.
+-- v1.5.2 ends at migration 030. Migrations 031-034 are still unreleased and
+-- are intentionally corrected in place before v1.6.0. A later migration
+-- cannot reconstruct history already removed by an ON DELETE CASCADE here.
 
 BEGIN TRANSACTION;
 

--- a/backend/migrations/032_cleanup_migrated_balance_alerts.sql
+++ b/backend/migrations/032_cleanup_migrated_balance_alerts.sql
@@ -1,3 +1,6 @@
+-- v1.5.2 ends at migration 030. This unreleased migration must preserve the
+-- legacy parent before its original cascade delete runs. No corrective future
+-- migration could restore notification history after that deletion.
 BEGIN;
 
 CREATE TEMP TABLE migrated_balance_alert_cleanup_ids (

--- a/backend/migrations/032_cleanup_migrated_balance_alerts.sql
+++ b/backend/migrations/032_cleanup_migrated_balance_alerts.sql
@@ -4,6 +4,10 @@ CREATE TEMP TABLE migrated_balance_alert_cleanup_ids (
     id TEXT PRIMARY KEY
 );
 
+CREATE TEMP TABLE migrated_balance_alert_history_ids (
+    id TEXT PRIMARY KEY
+);
+
 INSERT INTO migrated_balance_alert_cleanup_ids (id)
 SELECT ba.id
 FROM balance_alerts ba
@@ -28,6 +32,28 @@ WHERE ba.contact_id IS NULL
         )
   );
 
+-- Keep the inactive wallet-level parent when legacy audit rows still refer to
+-- it. The parent stays outside current per-contact delivery, but preserving it
+-- prevents ON DELETE CASCADE from erasing the v1.5.2 notification history.
+INSERT INTO migrated_balance_alert_history_ids (id)
+SELECT cleanup.id
+FROM migrated_balance_alert_cleanup_ids cleanup
+WHERE EXISTS (
+    SELECT 1
+    FROM balance_alert_notifications notification
+    WHERE notification.balance_alert_id = cleanup.id
+)
+OR EXISTS (
+    SELECT 1
+    FROM balance_alert_notification_logs log
+    WHERE log.balance_alert_id = cleanup.id
+);
+
+DELETE FROM migrated_balance_alert_cleanup_ids
+WHERE id IN (
+    SELECT id FROM migrated_balance_alert_history_ids
+);
+
 DELETE FROM balance_alert_notification_logs
 WHERE balance_alert_id IN (
     SELECT id FROM migrated_balance_alert_cleanup_ids
@@ -43,6 +69,7 @@ WHERE id IN (
     SELECT id FROM migrated_balance_alert_cleanup_ids
 );
 
+DROP TABLE migrated_balance_alert_history_ids;
 DROP TABLE migrated_balance_alert_cleanup_ids;
 
 COMMIT;

--- a/backend/migrations/034_remove_wallet_level_balance_alerts.sql
+++ b/backend/migrations/034_remove_wallet_level_balance_alerts.sql
@@ -1,29 +1,12 @@
 BEGIN;
 
-CREATE TEMP TABLE wallet_level_balance_alert_cleanup_ids (
-    id TEXT PRIMARY KEY
-);
-
-INSERT INTO wallet_level_balance_alert_cleanup_ids (id)
-SELECT id
-FROM balance_alerts
+-- Wallet-level alerts are no longer part of the current configuration or
+-- delivery model. Keep unmatched v1.5.2 rows as inactive audit/recovery data
+-- instead of deleting them (and cascading away their notification history).
+-- Migration 031/033 already copied every deliverable active alert to each
+-- active contact, so disabling the remaining parents cannot lose delivery.
+UPDATE balance_alerts
+SET is_active = 0
 WHERE contact_id IS NULL;
-
-DELETE FROM balance_alert_notification_logs
-WHERE balance_alert_id IN (
-    SELECT id FROM wallet_level_balance_alert_cleanup_ids
-);
-
-DELETE FROM balance_alert_notifications
-WHERE balance_alert_id IN (
-    SELECT id FROM wallet_level_balance_alert_cleanup_ids
-);
-
-DELETE FROM balance_alerts
-WHERE id IN (
-    SELECT id FROM wallet_level_balance_alert_cleanup_ids
-);
-
-DROP TABLE wallet_level_balance_alert_cleanup_ids;
 
 COMMIT;

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -645,6 +645,15 @@ fn assert_migration_031_032_state(conn: &Connection) {
     )
     .expect("notify_sending column should exist");
 
+    let legacy_rbf_enabled_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM contacts WHERE notify_rbf != 0 OR notify_cpfp != 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("legacy RBF migration defaults");
+    assert_eq!(legacy_rbf_enabled_count, 0);
+
     let notification_log_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM notification_logs", [], |row| {
             row.get(0)
@@ -866,6 +875,22 @@ fn migration_031_handles_clean_first_run_and_wallets_without_contacts() {
         )
         .expect("obsolete parent count");
     assert_eq!(obsolete_parent_count, 0);
+
+    conn.execute(
+        "INSERT INTO contacts (id, wallet_checksum, name)
+         VALUES ('post-migration-contact', 'wallet-1', 'Post-migration contact')",
+        [],
+    )
+    .expect("insert post-migration contact");
+    let new_contact_settings: (i64, i64) = conn
+        .query_row(
+            "SELECT notify_rbf, notify_cpfp FROM contacts
+             WHERE id = 'post-migration-contact'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("post-migration contact settings");
+    assert_eq!(new_contact_settings, (1, 1));
 }
 
 #[test]

--- a/backend/tests/migrations_tests.rs
+++ b/backend/tests/migrations_tests.rs
@@ -570,6 +570,46 @@ fn seed_wallet_with_legacy_balance_alert(db_path: &Path) {
         ],
     )
     .expect("insert notification log");
+    conn.execute(
+        "INSERT INTO balance_alert_notifications (
+            id,
+            balance_alert_id,
+            wallet_checksum,
+            threshold_sats,
+            current_balance_sats,
+            alert_type,
+            notification_sent_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            "legacy-history-1",
+            "alert-wallet-1",
+            "wallet-1",
+            0,
+            0,
+            "equals",
+            1_789_000_100_i64
+        ],
+    )
+    .expect("insert legacy balance notification history");
+    conn.execute(
+        "INSERT INTO balance_alert_notification_logs (
+            id,
+            balance_alert_id,
+            wallet_checksum,
+            provider_name,
+            status,
+            message_content
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            "legacy-history-log-1",
+            "alert-wallet-1",
+            "wallet-1",
+            "ntfy",
+            "sent",
+            "legacy balance notification"
+        ],
+    )
+    .expect("insert legacy balance notification log");
 }
 
 fn assert_migration_031_032_state(conn: &Connection) {
@@ -639,12 +679,42 @@ fn assert_migration_031_032_state(conn: &Connection) {
     let migrated_wallet_alert_count: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM balance_alerts
-             WHERE id IN ('alert-wallet-1', 'alert-wallet-2')",
+             WHERE id = 'alert-wallet-2'",
             [],
             |row| row.get(0),
         )
         .expect("migrated wallet-level alert count");
     assert_eq!(migrated_wallet_alert_count, 0);
+
+    let historical_parent_is_active: i64 = conn
+        .query_row(
+            "SELECT is_active FROM balance_alerts
+             WHERE id = 'alert-wallet-1' AND contact_id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("historical wallet-level parent");
+    assert_eq!(historical_parent_is_active, 0);
+
+    let historical_notification_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alert_notifications
+             WHERE balance_alert_id = 'alert-wallet-1'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("historical notification count");
+    assert_eq!(historical_notification_count, 1);
+
+    let historical_log_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alert_notification_logs
+             WHERE balance_alert_id = 'alert-wallet-1'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("historical notification log count");
+    assert_eq!(historical_log_count, 1);
 
     let no_contact_alert_count: i64 = conn
         .query_row(
@@ -736,6 +806,66 @@ fn migration_031_handles_clean_first_run_and_wallets_without_contacts() {
 
     let conn = bdk_wallet::rusqlite::Connection::open(&db_path).expect("open db");
     assert_migration_031_032_state(&conn);
+    drop(conn);
+
+    copy_migrations_through(&migrations_dir, 34);
+    MigrationRunner::new(db_path.to_str().expect("db path"))
+        .expect("create migration runner")
+        .run_migrations(migrations_dir.to_str().expect("migrations path"))
+        .expect("run migrations through 034");
+
+    let conn = Connection::open(&db_path).expect("open migrated db");
+    let copied_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts
+             WHERE contact_id IN ('contact-1', 'contact-2')
+               AND is_active = 1
+               AND (
+                 (threshold_sats = 0 AND alert_type = 'equals')
+                 OR (threshold_sats = 100 AND alert_type = 'below')
+               )",
+            [],
+            |row| row.get(0),
+        )
+        .expect("unique copied alert count");
+    assert_eq!(copied_alert_count, 4);
+
+    for alert_id in [
+        "alert-wallet-1",
+        "alert-wallet-no-contacts",
+        "alert-wallet-inactive",
+    ] {
+        let state: (Option<String>, i64) = conn
+            .query_row(
+                "SELECT contact_id, is_active FROM balance_alerts WHERE id = ?1",
+                [alert_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("retained inactive legacy alert");
+        assert_eq!(state, (None, 0), "unexpected state for {alert_id}");
+    }
+
+    let retained_history: (i64, i64) = conn
+        .query_row(
+            "SELECT
+               (SELECT COUNT(*) FROM balance_alert_notifications
+                WHERE balance_alert_id = 'alert-wallet-1'),
+               (SELECT COUNT(*) FROM balance_alert_notification_logs
+                WHERE balance_alert_id = 'alert-wallet-1')",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("retained legacy history");
+    assert_eq!(retained_history, (1, 1));
+
+    let obsolete_parent_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts WHERE id = 'alert-wallet-2'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("obsolete parent count");
+    assert_eq!(obsolete_parent_count, 0);
 }
 
 #[test]
@@ -1180,7 +1310,17 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
             |row| row.get(0),
         )
         .expect("remaining wallet-level alert count");
-    assert_eq!(remaining_wallet_level_alert_count, 0);
+    assert_eq!(remaining_wallet_level_alert_count, 4);
+
+    let active_wallet_level_alert_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM balance_alerts
+             WHERE contact_id IS NULL AND is_active = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("active wallet-level alert count");
+    assert_eq!(active_wallet_level_alert_count, 0);
 
     let remaining_wallet_level_notification_count: i64 = conn
         .query_row(
@@ -1193,7 +1333,7 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
             |row| row.get(0),
         )
         .expect("remaining wallet-level notification count");
-    assert_eq!(remaining_wallet_level_notification_count, 0);
+    assert_eq!(remaining_wallet_level_notification_count, 1);
 
     let remaining_wallet_level_log_count: i64 = conn
         .query_row(
@@ -1206,7 +1346,7 @@ fn migration_033_cleans_active_wallet_level_alerts_with_contacts() {
             |row| row.get(0),
         )
         .expect("remaining wallet-level log count");
-    assert_eq!(remaining_wallet_level_log_count, 0);
+    assert_eq!(remaining_wallet_level_log_count, 1);
 
     let remaining_contact_alert_count: i64 = conn
         .query_row(

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,7 +33,7 @@ cargo run
 ./dev.sh status           # Check environment status
 ./dev.sh stop             # Stop containers
 ./dev.sh reset            # Reset all data
-./test-upgrade.sh         # Verify upgrading self-hosted data from an older tag
+./test-upgrade.sh         # Manual notification-preservation release gate
 ```
 
 ### Wallet Commands
@@ -150,17 +150,26 @@ Without this variable, the backend will connect to real Bitcoin mainnet servers!
 
 ## Upgrade Verification
 
-`./test-upgrade.sh` creates a temporary worktree from an older tag, seeds self-hosted data, upgrades that worktree to the current `HEAD`, and verifies the result with API checks plus isolated Chromium Playwright checks.
+`./test-upgrade.sh` is the manual regtest release gate for notification-preserving upgrades. It creates an isolated worktree from the source release, runs equivalent authenticated local-ntfy scenarios before and after the upgrade, and compares normalized delivery semantics plus database and Chromium UI state.
+
+> **Destructive regtest warning:** the gate stops its temporary application processes and deletes the Docker volumes declared by `scripts/docker-compose.yml`. Those volumes contain only the local regtest Bitcoin, Fulcrum, ntfy, Postgres, NBXplorer, and BTCPay fixtures. Stop any local Canary servers using ports 3000/3001 first. Never point the gate at non-regtest or user data.
 
 ```bash
 # Upgrade from the latest tag to the current branch
 ./test-upgrade.sh
 
-# Upgrade from a specific release tag
-./test-upgrade.sh --from-tag v1.3.1
+# Release gate from v1.5.2 to an exact target ref
+./test-upgrade.sh --from-tag v1.5.2 --to-ref HEAD
+
+# Validate a release-candidate branch or commit
+./test-upgrade.sh --from-tag v1.5.2 --to-ref origin/release/v1.6.0-rc
 
 # Use another frontend port if localhost:3001 is already occupied
 CANARY_UPGRADE_FRONTEND_PORT=3101 ./test-upgrade.sh
 ```
 
-The script keeps Playwright isolated under `scripts/playwright/` so it does not affect the frontend workspace dependencies.
+The success summary prints the resolved source and target SHAs and confirms the incoming/outgoing pending and confirmation, RBF, CPFP, balance-threshold, active fan-out, inactive non-delivery, and restart-dedup scenarios. The script exits non-zero for missing, extra, duplicate, wrong-topic, failed, or privacy-expanding delivery.
+
+Playwright remains isolated under `scripts/playwright/`, so the gate does not change frontend workspace dependencies. Successful runs clean up by default; use `--keep-worktree` to retain the temporary checkout and artifacts. Failed runs always retain their worktree, exact refs, ntfy JSON, normalized manifests, transaction IDs, database snapshots/log extracts, and service logs under the printed `${TMPDIR:-/tmp}/canary-upgrade-test.*` path.
+
+Run the same gate through the project adapter with `.agent-loop/checks.sh upgrade`. It intentionally remains a manual release gate rather than a required GitHub Actions workflow.

--- a/scripts/playwright/tests/upgrade-test.spec.ts
+++ b/scripts/playwright/tests/upgrade-test.spec.ts
@@ -50,12 +50,6 @@ async function openWalletDetail(page: Page) {
   }
 }
 
-function redactedTopic(topic: string) {
-  return topic.length <= 12
-    ? `${topic.slice(0, 2)}••••${topic.slice(-2)}`
-    : `${topic.slice(0, 7)}…${topic.slice(-5)}`
-}
-
 async function expectSourceContactsVisible(page: Page) {
   for (const name of contactNames) {
     await expect(page.getByText(name, { exact: true }).first()).toBeVisible()
@@ -80,7 +74,7 @@ async function expectMigratedCompactSummaries(page: Page) {
 
     const card = page.getByRole("heading", { name, exact: true }).locator("xpath=ancestor::*[@data-slot='card']")
     await expect(card).toBeVisible()
-    await expect(card).toContainText(redactedTopic(ntfyTopics[index]))
+    await expect(card).toContainText("ntfy:")
     await expect(card).toContainText(index < 2 ? "Active" : "Inactive")
     await expect(page.getByText(ntfyTopics[index], { exact: true })).toHaveCount(0)
   }

--- a/scripts/playwright/tests/upgrade-test.spec.ts
+++ b/scripts/playwright/tests/upgrade-test.spec.ts
@@ -2,15 +2,24 @@ import { expect, test, type Page } from "@playwright/test"
 
 const walletChecksum = process.env.WALLET_CHECKSUM || ""
 const walletName = process.env.WALLET_NAME || ""
-const ntfyTopic = process.env.NTFY_TOPIC || ""
+const ntfyTopics = [
+  process.env.NTFY_TOPIC_A || "",
+  process.env.NTFY_TOPIC_B || "",
+  process.env.NTFY_TOPIC_INACTIVE || "",
+]
+const contactNames = [
+  process.env.CONTACT_A_NAME || "",
+  process.env.CONTACT_B_NAME || "",
+  process.env.INACTIVE_CONTACT_NAME || "",
+]
 const authToken = process.env.AUTH_TOKEN
 const expectedWalletCount = Number(process.env.EXPECTED_WALLET_COUNT || "0")
 const txidPrefix = process.env.TXID_PREFIX
 const walletLink = `a[href^="/wallets/${walletChecksum}"]`
 
 test.skip(
-  !walletChecksum || !walletName || !ntfyTopic,
-  "WALLET_CHECKSUM, WALLET_NAME, and NTFY_TOPIC must be set"
+  !walletChecksum || !walletName || ntfyTopics.some((topic) => !topic) || contactNames.some((name) => !name),
+  "Wallet, contact, and ntfy topic environment variables must be set"
 )
 
 test.beforeEach(async ({ context, baseURL }) => {
@@ -41,8 +50,44 @@ async function openWalletDetail(page: Page) {
   }
 }
 
-async function expectNtfyTopicVisible(page: Page) {
-  await expect(page.getByText(ntfyTopic, { exact: false }).first()).toBeVisible()
+function redactedTopic(topic: string) {
+  return topic.length <= 12
+    ? `${topic.slice(0, 2)}••••${topic.slice(-2)}`
+    : `${topic.slice(0, 7)}…${topic.slice(-5)}`
+}
+
+async function expectSourceContactsVisible(page: Page) {
+  for (const name of contactNames) {
+    await expect(page.getByText(name, { exact: true }).first()).toBeVisible()
+  }
+  for (const topic of ntfyTopics) {
+    await expect(page.getByText(topic, { exact: false }).first()).toBeVisible()
+  }
+}
+
+async function expectMigratedCompactSummaries(page: Page) {
+  const response = await page.request.get(`/api/wallets/${walletChecksum}/detail`)
+  expect(response.ok()).toBe(true)
+  const detail = await response.json()
+
+  for (const [index, name] of contactNames.entries()) {
+    const contact = detail.contacts.find((candidate: { name: string }) => candidate.name === name)
+    expect(contact).toBeTruthy()
+    expect(contact.notification_methods).toEqual(expect.arrayContaining([
+      expect.objectContaining({ provider_type: "ntfy", notification_target: ntfyTopics[index] }),
+    ]))
+    expect(contact.is_active).toBe(index < 2)
+
+    const card = page.getByRole("heading", { name, exact: true }).locator("xpath=ancestor::*[@data-slot='card']")
+    await expect(card).toBeVisible()
+    await expect(card).toContainText(redactedTopic(ntfyTopics[index]))
+    await expect(card).toContainText(index < 2 ? "Active" : "Inactive")
+    await expect(page.getByText(ntfyTopics[index], { exact: true })).toHaveCount(0)
+  }
+
+  await expect(page.locator("input")).toHaveCount(0)
+  await expect(page.getByRole("checkbox")).toHaveCount(0)
+  await expect(page.getByRole("button", { name: /Edit contact/i })).toHaveCount(3)
 }
 
 async function expectTransactionsAvailable(page: Page) {
@@ -73,7 +118,7 @@ test("@pre-upgrade wallet page shows the seeded wallet", async ({ page }) => {
 test("@pre-upgrade wallet detail shows contact and transactions", async ({ page }) => {
   await openWalletDetail(page)
   await expect(page.getByText(walletName, { exact: true })).toBeVisible()
-  await expectNtfyTopicVisible(page)
+  await expectSourceContactsVisible(page)
   await expectTransactionsAvailable(page)
 })
 
@@ -89,6 +134,6 @@ test("@post-upgrade wallet page still shows the seeded wallet", async ({ page })
 test("@post-upgrade wallet detail still shows contact and transactions", async ({ page }) => {
   await openWalletDetail(page)
   await expect(page.getByText(walletName, { exact: true })).toBeVisible()
-  await expectNtfyTopicVisible(page)
+  await expectMigratedCompactSummaries(page)
   await expectTransactionsAvailable(page)
 })

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -730,20 +730,20 @@ scenario_alert_ids_sql() {
 
 stage_delivery_ready() {
     local scenario_file="$1"
-    local db_path txids_sql alert_ids_sql topic txid count
+    local db_path txids_sql alert_ids_sql topic txid expected_count count
     db_path="$(metadata_db_path "$WORKTREE_DIR")" || return 1
     txids_sql="$(scenario_txids_sql "$scenario_file")"
     alert_ids_sql="$(scenario_alert_ids_sql "$scenario_file")"
 
     for topic in "$NTFY_TOPIC_A" "$NTFY_TOPIC_B"; do
-        while IFS= read -r txid; do
+        while IFS=$'\t' read -r txid expected_count; do
             count="$(sqlite3 "$db_path" \
                 "SELECT COUNT(*) FROM notification_logs
                  WHERE transaction_txid = '$txid'
                    AND notification_target_snapshot = '$topic'
                    AND status = 'sent';")"
-            [[ "$count" -eq 2 ]] || return 1
-        done < <(jq -r '.transactions[]' "$scenario_file")
+            [[ "$count" -eq "$expected_count" ]] || return 1
+        done < <(jq -r '.transaction_deliveries[] | [.txid, .count] | @tsv' "$scenario_file")
 
         count="$(sqlite3 "$db_path" \
             "SELECT COUNT(*) FROM balance_alert_notification_logs
@@ -845,7 +845,7 @@ assert_post_upgrade_content_translation() {
 validate_stage_artifacts() {
     local stage="$1"
     local scenario_file="$2"
-    local db_path txids_sql alert_ids_sql topic topic_file txid count total expected_body_file actual_body_file duplicate_count wrong_topic_count current_balance
+    local db_path txids_sql alert_ids_sql topic topic_file txid expected_count count total expected_total expected_body_file actual_body_file duplicate_count wrong_topic_count current_balance
     db_path="$(metadata_db_path "$WORKTREE_DIR")" || fail "Metadata database is missing"
     txids_sql="$(scenario_txids_sql "$scenario_file")"
     alert_ids_sql="$(scenario_alert_ids_sql "$scenario_file")"
@@ -885,17 +885,19 @@ validate_stage_artifacts() {
             topic_file="$LOG_DIR/ntfy-${stage}-b.json"
         fi
         total="$(jq 'length' "$topic_file")"
-        [[ "$total" -eq 13 ]] || fail "$stage topic $topic received $total messages; expected 13"
+        expected_total="$(jq '[.transaction_deliveries[].count] | add + 1' "$scenario_file")"
+        [[ "$total" -eq "$expected_total" ]] \
+            || fail "$stage topic $topic received $total messages; expected $expected_total"
 
-        while IFS= read -r txid; do
+        while IFS=$'\t' read -r txid expected_count; do
             count="$(sqlite3 "$db_path" \
                 "SELECT COUNT(*) FROM notification_logs
                  WHERE transaction_txid = '$txid'
                    AND notification_target_snapshot = '$topic'
                    AND status = 'sent';")"
-            [[ "$count" -eq 2 ]] \
-                || fail "$stage transaction $txid delivered $count times to $topic; expected 2"
-        done < <(jq -r '.transactions[]' "$scenario_file")
+            [[ "$count" -eq "$expected_count" ]] \
+                || fail "$stage transaction $txid delivered $count times to $topic; expected $expected_count"
+        done < <(jq -r '.transaction_deliveries[] | [.txid, .count] | @tsv' "$scenario_file")
 
         count="$(sqlite3 "$db_path" \
             "SELECT COUNT(*) FROM balance_alert_notification_logs
@@ -954,8 +956,8 @@ validate_stage_artifacts() {
             $topics[] as $topic
             | {destination: $topic, scenario: "incoming", event: "transaction", direction: "receive", states: ["pending", "confirmed"], amount_sats: 1000000, content: content},
               {destination: $topic, scenario: "outgoing", event: "transaction", direction: "send", states: ["pending", "confirmed"], amount_sats: 2000000, content: content},
-              {destination: $topic, scenario: "rbf", event: "rbf", direction: "send", states: ["pending", "replaced", "confirmed"], amount_sats: 500000, content: content},
-              {destination: $topic, scenario: "cpfp", event: "cpfp", direction: "receive+send", states: ["pending", "confirmed"], amount_sats: 400000, content: content},
+              {destination: $topic, scenario: "rbf", event: "rbf", direction: "send", states: ["original_pending", "replacement_pending", "replacement_confirmed"], amount_sats: 500000, content: content},
+              {destination: $topic, scenario: "cpfp", event: "cpfp", direction: "receive+send", states: ["parent_pending", "child_pending", "parent_confirmed", "child_confirmed"], amounts_sats: {parent: 400000, child: 200000}, content: content},
               {destination: $topic, scenario: "balance", event: "balance_alert", direction: null, states: ["triggered"], amount_sats: null, balance: {condition: "below", threshold_sats: $threshold, current_balance_sats: $current_balance}, content: content}
           ] | {stage: $stage, notifications: sort_by(.destination, .scenario)}
     ' >"$LOG_DIR/semantic-manifest-${stage}.json"
@@ -1031,6 +1033,14 @@ run_notification_scenarios() {
             cpfp_parent: $cpfp_parent,
             cpfp_child: $cpfp_child
           },
+          transaction_deliveries: [
+            {txid: $incoming, count: 2},
+            {txid: $outgoing, count: 2},
+            {txid: $rbf_original, count: 1},
+            {txid: $rbf_replacement, count: 2},
+            {txid: $cpfp_parent, count: 2},
+            {txid: $cpfp_child, count: 2}
+          ],
           alert_ids: $alert_ids,
           threshold_sats: $threshold
         }

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -747,7 +747,7 @@ stage_delivery_ready() {
                    AND notification_target_snapshot = '$topic'
                    AND status = 'sent';")"
             [[ "$count" -eq "$expected_count" ]] || return 1
-        done < <(jq -r '.transaction_deliveries[] | [.txid, .count] | @tsv' "$scenario_file")
+        done < <(jq -r '.transaction_expectations[] | [.txid, .count] | @tsv' "$scenario_file")
 
         count="$(sqlite3 "$db_path" \
             "SELECT COUNT(*) FROM balance_alert_notification_logs
@@ -848,10 +848,17 @@ assert_post_upgrade_content_translation() {
         || fail "v1.5.2 content settings did not translate without privacy expansion"
 }
 
+sats_to_btc() {
+    LC_NUMERIC=C awk -v sats="$1" 'BEGIN { printf "%.8f", sats / 100000000 }' \
+        | sed -E 's/0+$//; s/\.$//'
+}
+
 validate_stage_artifacts() {
     local stage="$1"
     local scenario_file="$2"
-    local db_path txids_sql alert_ids_sql topic topic_file txid expected_count count total expected_total expected_body_file actual_body_file duplicate_count wrong_topic_count current_balance
+    local db_path txids_sql alert_ids_sql topic topic_file txid expected_count count total expected_total expected_body_file actual_body_file duplicate_count wrong_topic_count current_balance semantic_entries_file
+    local role scenario event expected_direction requested_amount expected_states transaction_row observed_direction observed_amount amount_semantics observed_states observed_messages btc_amount wallet_disclosed amount_disclosed balance_disclosed
+    local balance_messages balance_wallet_disclosed balance_condition_disclosed balance_threshold_disclosed balance_current_disclosed threshold_btc current_balance_btc
     db_path="$(metadata_db_path "$WORKTREE_DIR")" || fail "Metadata database is missing"
     txids_sql="$(scenario_txids_sql "$scenario_file")"
     alert_ids_sql="$(scenario_alert_ids_sql "$scenario_file")"
@@ -862,6 +869,8 @@ validate_stage_artifacts() {
     sqlite3 -json "$db_path" \
         "SELECT * FROM balance_alert_notification_logs WHERE balance_alert_id IN ($alert_ids_sql) ORDER BY created_at, id;" \
         >"$LOG_DIR/balance-notification-logs-${stage}.json"
+    semantic_entries_file="$LOG_DIR/semantic-entries-${stage}.ndjson"
+    : >"$semantic_entries_file"
 
     wrong_topic_count="$(sqlite3 "$db_path" \
         "SELECT
@@ -884,6 +893,27 @@ validate_stage_artifacts() {
          );")"
     [[ "$duplicate_count" -eq 0 ]] || fail "$stage contains duplicate transaction deliveries"
 
+    [[ "$(sqlite3 "$db_path" \
+        "SELECT COUNT(*) FROM transactions
+         WHERE txid = '$(jq -r '.transactions.rbf_original' "$scenario_file")'
+           AND transaction_status = 'replaced'
+           AND replaced_by_txid = '$(jq -r '.transactions.rbf_replacement' "$scenario_file")';")" -eq 1 ]] \
+        || fail "$stage RBF relationship was not observed in the transaction database"
+    [[ "$(sqlite3 "$db_path" \
+        "SELECT COUNT(*) FROM transactions
+         WHERE txid = '$(jq -r '.transactions.cpfp_child' "$scenario_file")'
+           AND parent_txid = '$(jq -r '.transactions.cpfp_parent' "$scenario_file")';")" -eq 1 ]] \
+        || fail "$stage CPFP relationship was not observed in the transaction database"
+
+    current_balance="$(sqlite3 "$db_path" \
+        "SELECT group_concat(DISTINCT current_balance_sats)
+         FROM balance_alert_notifications
+         WHERE balance_alert_id IN ($alert_ids_sql);")"
+    [[ -n "$current_balance" && "$current_balance" != *,* ]] \
+        || fail "$stage balance alert did not preserve one semantic current-balance value"
+    threshold_btc="$(sats_to_btc "$LEGACY_BALANCE_THRESHOLD_SATS")"
+    current_balance_btc="$(sats_to_btc "$current_balance")"
+
     for topic in "$NTFY_TOPIC_A" "$NTFY_TOPIC_B"; do
         if [[ "$topic" == "$NTFY_TOPIC_A" ]]; then
             topic_file="$LOG_DIR/ntfy-${stage}-a.json"
@@ -891,11 +921,11 @@ validate_stage_artifacts() {
             topic_file="$LOG_DIR/ntfy-${stage}-b.json"
         fi
         total="$(jq 'length' "$topic_file")"
-        expected_total="$(jq '[.transaction_deliveries[].count] | add + 1' "$scenario_file")"
+        expected_total="$(jq '[.transaction_expectations[].count] | add + 1' "$scenario_file")"
         [[ "$total" -eq "$expected_total" ]] \
             || fail "$stage topic $topic received $total messages; expected $expected_total"
 
-        while IFS=$'\t' read -r txid expected_count; do
+        while IFS=$'\t' read -r role scenario event txid expected_count expected_direction requested_amount expected_states; do
             count="$(sqlite3 "$db_path" \
                 "SELECT COUNT(*) FROM notification_logs
                  WHERE transaction_txid = '$txid'
@@ -903,7 +933,73 @@ validate_stage_artifacts() {
                    AND status = 'sent';")"
             [[ "$count" -eq "$expected_count" ]] \
                 || fail "$stage transaction $txid delivered $count times to $topic; expected $expected_count"
-        done < <(jq -r '.transaction_deliveries[] | [.txid, .count] | @tsv' "$scenario_file")
+
+            transaction_row="$(sqlite3 -separator $'\t' "$db_path" \
+                "SELECT transaction_type, amount_sats FROM transactions
+                 WHERE txid = '$txid' AND wallet_checksum = '$TARGET_WALLET_CHECKSUM';")"
+            IFS=$'\t' read -r observed_direction observed_amount <<<"$transaction_row"
+            [[ "$observed_direction" == "$expected_direction" ]] \
+                || fail "$stage $role direction was $observed_direction; expected $expected_direction"
+            if [[ "$observed_direction" == "receive" ]]; then
+                [[ "$observed_amount" -eq "$requested_amount" ]] \
+                    || fail "$stage $role observed $observed_amount sats; expected $requested_amount"
+            else
+                [[ "$observed_amount" -ge "$requested_amount" && "$observed_amount" -lt $((requested_amount + 100000)) ]] \
+                    || fail "$stage $role observed $observed_amount sats outside the requested-plus-fee range"
+            fi
+            if [[ "$observed_amount" -eq "$requested_amount" ]]; then
+                amount_semantics="exact"
+            else
+                amount_semantics="requested_plus_fee"
+            fi
+
+            observed_states="$(sqlite3 -json "$db_path" \
+                "SELECT notification_type FROM notification_logs
+                 WHERE transaction_txid = '$txid'
+                   AND notification_target_snapshot = '$topic'
+                   AND status = 'sent'
+                 ORDER BY created_at, id;" | jq -c '
+                    [.[].notification_type
+                     | if . == "pending" or . == "sending" or . == "receiving" or . == "cpfp" then "pending"
+                       elif . == "confirmed" or . == "sent" or . == "received" then "confirmed"
+                       elif . == "rbf" then "rbf"
+                       else "unknown:" + . end]
+                    | sort')"
+            [[ "$observed_states" == "$expected_states" ]] \
+                || fail "$stage $role states were $observed_states; expected $expected_states"
+
+            observed_messages="$(sqlite3 -json "$db_path" \
+                "SELECT message_content FROM notification_logs
+                 WHERE transaction_txid = '$txid'
+                   AND notification_target_snapshot = '$topic'
+                   AND status = 'sent';")"
+            btc_amount="$(sats_to_btc "$observed_amount")"
+            wallet_disclosed="$(echo "$observed_messages" | jq -r --arg value "$TARGET_WALLET_NAME" 'all(.[]; .message_content | contains($value))')"
+            amount_disclosed="$(echo "$observed_messages" | jq -r --arg value "$btc_amount BTC" 'all(.[]; .message_content | contains($value))')"
+            balance_disclosed="$(echo "$observed_messages" | jq -r 'any(.[]; .message_content | ascii_downcase | contains("balance"))')"
+            [[ "$wallet_disclosed" == "true" && "$amount_disclosed" == "true" && "$balance_disclosed" == "false" ]] \
+                || fail "$stage $role message disclosure did not match the migrated content policy"
+
+            jq -cn \
+                --arg destination "$topic" \
+                --arg role "$role" \
+                --arg scenario "$scenario" \
+                --arg event "$event" \
+                --arg direction "$observed_direction" \
+                --argjson states "$observed_states" \
+                --argjson amount_sats "$requested_amount" \
+                --arg amount_semantics "$amount_semantics" \
+                --argjson wallet_name "$wallet_disclosed" \
+                --argjson transaction_amount "$amount_disclosed" \
+                --argjson transaction_balance "$balance_disclosed" \
+                '{destination: $destination, role: $role, scenario: $scenario, event: $event,
+                  direction: $direction, states: $states, amount_sats: $amount_sats,
+                  amount_semantics: $amount_semantics,
+                  content: {wallet_name: $wallet_name, event_type: true,
+                    transaction_amount: $transaction_amount,
+                    transaction_balance: $transaction_balance}}' \
+                >>"$semantic_entries_file"
+        done < <(jq -r '.transaction_expectations[] | [.role, .scenario, .event, .txid, .count, .direction, .requested_amount_sats, (.states | sort | tojson)] | @tsv' "$scenario_file")
 
         count="$(sqlite3 "$db_path" \
             "SELECT COUNT(*) FROM balance_alert_notification_logs
@@ -930,43 +1026,43 @@ validate_stage_artifacts() {
         jq -S '[.[].message] | sort' "$topic_file" >"$actual_body_file"
         cmp -s "$expected_body_file" "$actual_body_file" \
             || fail "$stage ntfy bodies do not match the successful database delivery log for $topic"
+
+        balance_messages="$(sqlite3 -json "$db_path" \
+            "SELECT message_content FROM balance_alert_notification_logs
+             WHERE balance_alert_id IN ($alert_ids_sql)
+               AND notification_target_snapshot = '$topic'
+               AND status = 'sent';")"
+        balance_wallet_disclosed="$(echo "$balance_messages" | jq -r --arg value "$TARGET_WALLET_NAME" 'all(.[]; .message_content | contains($value))')"
+        balance_condition_disclosed="$(echo "$balance_messages" | jq -r 'all(.[]; .message_content | ascii_downcase | contains("below"))')"
+        balance_threshold_disclosed="$(echo "$balance_messages" | jq -r --arg value "$threshold_btc BTC" 'all(.[]; .message_content | contains($value))')"
+        balance_current_disclosed="$(echo "$balance_messages" | jq -r --arg value "$current_balance_btc BTC" 'all(.[]; .message_content | contains($value))')"
+        [[ "$balance_wallet_disclosed" == "true" && "$balance_condition_disclosed" == "true" && "$balance_threshold_disclosed" == "true" && "$balance_current_disclosed" == "true" ]] \
+            || fail "$stage balance-alert message disclosure did not match the migrated content policy"
+        jq -cn \
+            --arg destination "$topic" \
+            --argjson threshold_sats "$LEGACY_BALANCE_THRESHOLD_SATS" \
+            --argjson current_balance_sats "$current_balance" \
+            --argjson wallet_name "$balance_wallet_disclosed" \
+            --argjson condition "$balance_condition_disclosed" \
+            --argjson threshold "$balance_threshold_disclosed" \
+            --argjson balance "$balance_current_disclosed" \
+            '{destination: $destination, role: "balance", scenario: "balance",
+              event: "balance_alert", direction: null, states: ["triggered"], amount_sats: null,
+              balance: {condition: "below", threshold_sats: $threshold_sats,
+                current_balance_sats: $current_balance_sats},
+              content: {wallet_name: $wallet_name, event_type: true,
+                balance_alert_condition: $condition,
+                balance_alert_threshold: $threshold,
+                balance_alert_balance: $balance}}' \
+            >>"$semantic_entries_file"
     done
 
     [[ "$(jq 'length' "$LOG_DIR/ntfy-${stage}-inactive.json")" -eq 0 ]] \
         || fail "$stage delivered a notification to the inactive contact"
 
-    current_balance="$(sqlite3 "$db_path" \
-        "SELECT group_concat(DISTINCT current_balance_sats)
-         FROM balance_alert_notifications
-         WHERE balance_alert_id IN ($alert_ids_sql);")"
-    [[ -n "$current_balance" && "$current_balance" != *,* ]] \
-        || fail "$stage balance alert did not preserve one semantic current-balance value"
-
-    jq -n \
-        --arg stage "$stage" \
-        --arg topic_a "$NTFY_TOPIC_A" \
-        --arg topic_b "$NTFY_TOPIC_B" \
-        --argjson threshold "$LEGACY_BALANCE_THRESHOLD_SATS" \
-        --argjson current_balance "$current_balance" '
-        def content: {
-          wallet_name: true,
-          event_type: true,
-          transaction_amount: true,
-          transaction_balance: false,
-          balance_alert_condition: true,
-          balance_alert_threshold: true,
-          balance_alert_balance: true
-        };
-        [ $topic_a, $topic_b ] as $topics
-        | [
-            $topics[] as $topic
-            | {destination: $topic, scenario: "incoming", event: "transaction", direction: "receive", states: ["pending", "confirmed"], amount_sats: 1000000, content: content},
-              {destination: $topic, scenario: "outgoing", event: "transaction", direction: "send", states: ["pending", "confirmed"], amount_sats: 2000000, content: content},
-              {destination: $topic, scenario: "rbf", event: "rbf", direction: "send", states: ["original_pending", "replacement_pending", "replacement_confirmed"], amount_sats: 500000, content: content},
-              {destination: $topic, scenario: "cpfp", event: "cpfp", direction: "receive+send", states: ["parent_pending", "child_pending", "parent_confirmed", "child_confirmed"], amounts_sats: {parent: 400000, child: 200000}, content: content},
-              {destination: $topic, scenario: "balance", event: "balance_alert", direction: null, states: ["triggered"], amount_sats: null, balance: {condition: "below", threshold_sats: $threshold, current_balance_sats: $current_balance}, content: content}
-          ] | {stage: $stage, notifications: sort_by(.destination, .scenario)}
-    ' >"$LOG_DIR/semantic-manifest-${stage}.json"
+    jq -s --arg stage "$stage" \
+        '{stage: $stage, notifications: sort_by(.destination, .scenario, .role)}' \
+        "$semantic_entries_file" >"$LOG_DIR/semantic-manifest-${stage}.json"
 }
 
 run_notification_scenarios() {
@@ -1039,13 +1135,13 @@ run_notification_scenarios() {
             cpfp_parent: $cpfp_parent,
             cpfp_child: $cpfp_child
           },
-          transaction_deliveries: [
-            {txid: $incoming, count: 2},
-            {txid: $outgoing, count: 2},
-            {txid: $rbf_original, count: 1},
-            {txid: $rbf_replacement, count: 2},
-            {txid: $cpfp_parent, count: 2},
-            {txid: $cpfp_child, count: 2}
+          transaction_expectations: [
+            {role: "incoming", scenario: "incoming", event: "transaction", txid: $incoming, count: 2, direction: "receive", requested_amount_sats: 1000000, states: ["pending", "confirmed"]},
+            {role: "outgoing", scenario: "outgoing", event: "transaction", txid: $outgoing, count: 2, direction: "send", requested_amount_sats: 2000000, states: ["pending", "confirmed"]},
+            {role: "rbf_original", scenario: "rbf", event: "rbf", txid: $rbf_original, count: 1, direction: "send", requested_amount_sats: 500000, states: ["pending"]},
+            {role: "rbf_replacement", scenario: "rbf", event: "rbf", txid: $rbf_replacement, count: 2, direction: "send", requested_amount_sats: 500000, states: ["pending", "confirmed"]},
+            {role: "cpfp_parent", scenario: "cpfp", event: "cpfp", txid: $cpfp_parent, count: 2, direction: "receive", requested_amount_sats: 400000, states: ["pending", "confirmed"]},
+            {role: "cpfp_child", scenario: "cpfp", event: "cpfp", txid: $cpfp_child, count: 2, direction: "send", requested_amount_sats: 200000, states: ["pending", "confirmed"]}
           ],
           alert_ids: $alert_ids,
           threshold_sats: $threshold

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -580,8 +580,8 @@ assert_contacts_present() {
         --arg topic_a "$NTFY_TOPIC_A" \
         --arg topic_b "$NTFY_TOPIC_B" \
         --arg topic_inactive "$NTFY_TOPIC_INACTIVE" '
-        ([.contacts[].notification_methods[]? | .notification_target] | sort)
-        | contains([$topic_a, $topic_b, $topic_inactive] | sort)
+        ([$topic_a, $topic_b, $topic_inactive]
+            - [.contacts[].notification_methods[]? | .notification_target]) == []
     ' >/dev/null || fail "Expected active/inactive ntfy topics not found in wallet detail"
 }
 
@@ -701,8 +701,8 @@ assert_post_upgrade_state() {
         --arg topic_b "$NTFY_TOPIC_B" \
         --arg topic_inactive "$NTFY_TOPIC_INACTIVE" \
         --arg pre_txid "$PRE_UPGRADE_TXID" '
-        (([.contacts[].notification_methods[]? | .notification_target] | sort)
-            | contains([$topic_a, $topic_b, $topic_inactive] | sort))
+        (([$topic_a, $topic_b, $topic_inactive]
+            - [.contacts[].notification_methods[]? | .notification_target]) == [])
         and ([.transactions[] | select(.txid == $pre_txid)] | length > 0)
     ' >/dev/null || fail "Post-upgrade detail is missing contacts or the pre-upgrade transaction"
 }

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -835,6 +835,8 @@ assert_post_upgrade_content_translation() {
          WHERE contact.id IN ('$CONTACT_A_ID', '$CONTACT_B_ID', '$INACTIVE_CONTACT_ID')
            AND method.provider_type = 'ntfy'
            AND method.is_enabled = 1
+           AND contact.notify_rbf = 0
+           AND contact.notify_cpfp = 1
            AND method.content_wallet_name = 1
            AND method.content_event_type = 1
            AND method.content_transaction_amount = 1

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -609,8 +609,6 @@ dev_mempool_delta() {
     local before after delta output_file
 
     before="$(btc_mempool)"
-    [[ "$(echo "$before" | jq 'length')" -eq 0 ]] \
-        || fail "Mempool must be empty before $label"
     output_file="$LOG_DIR/dev-${label}.log"
     (
         cd "$SCRIPT_DIR"

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -555,6 +555,8 @@ seed_inactive_ntfy_contact() {
     db_path="$(metadata_db_path "$WORKTREE_DIR")" \
         || fail "Could not find metadata database for inactive contact fixture"
 
+    # Fixture-only write: v1.5.2 has no API path for creating an inactive
+    # contact directly, and this gate is testing migration/delivery behavior.
     INACTIVE_CONTACT_ID="upgrade-inactive-contact"
     sqlite3 "$db_path" <<SQL
 PRAGMA busy_timeout = 10000;
@@ -699,8 +701,8 @@ assert_post_upgrade_state() {
         --arg topic_b "$NTFY_TOPIC_B" \
         --arg topic_inactive "$NTFY_TOPIC_INACTIVE" \
         --arg pre_txid "$PRE_UPGRADE_TXID" '
-        ([.contacts[].notification_methods[]? | .notification_target]
-            | contains([$topic_a, $topic_b, $topic_inactive]))
+        (([.contacts[].notification_methods[]? | .notification_target] | sort)
+            | contains([$topic_a, $topic_b, $topic_inactive] | sort))
         and ([.transactions[] | select(.txid == $pre_txid)] | length > 0)
     ' >/dev/null || fail "Post-upgrade detail is missing contacts or the pre-upgrade transaction"
 }
@@ -816,6 +818,8 @@ assert_restart_does_not_duplicate() {
     kill_if_running "$BACKEND_PID"
     BACKEND_PID=""
     start_backend "$WORKTREE_DIR" "${stage}-restart"
+    # start_backend has already passed readiness; observe three short sync
+    # intervals to prove startup does not replay the completed deliveries.
     sleep 6
 
     after_a="$(ntfy_message_count "$NTFY_TOPIC_A")"
@@ -1181,6 +1185,8 @@ restore_and_rearm_legacy_alert() {
 
     stop_app_processes
     db_path="$(metadata_db_path "$WORKTREE_DIR")"
+    # Fixture-only rearm after an observed source delivery; endpoint behavior
+    # is outside this migration-preservation gate.
     sqlite3 "$db_path" \
         "UPDATE balance_alerts
          SET is_active = 1, last_checked_balance_sats = $LEGACY_BALANCE_THRESHOLD_SATS

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -858,7 +858,7 @@ validate_stage_artifacts() {
     local scenario_file="$2"
     local db_path txids_sql alert_ids_sql topic topic_file txid expected_count count total expected_total expected_body_file actual_body_file duplicate_count wrong_topic_count current_balance semantic_entries_file
     local role scenario event expected_direction requested_amount expected_states transaction_row observed_direction observed_amount amount_semantics observed_states observed_messages btc_amount wallet_disclosed amount_disclosed balance_disclosed
-    local balance_messages balance_wallet_disclosed balance_condition_disclosed balance_threshold_disclosed balance_current_disclosed threshold_btc current_balance_btc
+    local balance_messages balance_wallet_disclosed balance_condition_disclosed balance_threshold_disclosed balance_current_disclosed threshold_btc current_balance_btc balance_delta balance_delta_semantics
     db_path="$(metadata_db_path "$WORKTREE_DIR")" || fail "Metadata database is missing"
     txids_sql="$(scenario_txids_sql "$scenario_file")"
     alert_ids_sql="$(scenario_alert_ids_sql "$scenario_file")"
@@ -911,6 +911,14 @@ validate_stage_artifacts() {
          WHERE balance_alert_id IN ($alert_ids_sql);")"
     [[ -n "$current_balance" && "$current_balance" != *,* ]] \
         || fail "$stage balance alert did not preserve one semantic current-balance value"
+    balance_delta=$((LEGACY_BALANCE_THRESHOLD_SATS - current_balance))
+    [[ "$balance_delta" -ge 1000000 && "$balance_delta" -lt 1100000 ]] \
+        || fail "$stage balance crossed the threshold by $balance_delta sats; expected the requested 1000000 sats plus fee"
+    if [[ "$balance_delta" -eq 1000000 ]]; then
+        balance_delta_semantics="exact"
+    else
+        balance_delta_semantics="requested_plus_fee"
+    fi
     threshold_btc="$(sats_to_btc "$LEGACY_BALANCE_THRESHOLD_SATS")"
     current_balance_btc="$(sats_to_btc "$current_balance")"
 
@@ -1042,6 +1050,8 @@ validate_stage_artifacts() {
             --arg destination "$topic" \
             --argjson threshold_sats "$LEGACY_BALANCE_THRESHOLD_SATS" \
             --argjson current_balance_sats "$current_balance" \
+            --argjson crossing_delta_sats 1000000 \
+            --arg crossing_semantics "$balance_delta_semantics" \
             --argjson wallet_name "$balance_wallet_disclosed" \
             --argjson condition "$balance_condition_disclosed" \
             --argjson threshold "$balance_threshold_disclosed" \
@@ -1049,7 +1059,9 @@ validate_stage_artifacts() {
             '{destination: $destination, role: "balance", scenario: "balance",
               event: "balance_alert", direction: null, states: ["triggered"], amount_sats: null,
               balance: {condition: "below", threshold_sats: $threshold_sats,
-                current_balance_sats: $current_balance_sats},
+                observed_current_balance_sats: $current_balance_sats,
+                crossing_delta_sats: $crossing_delta_sats,
+                crossing_semantics: $crossing_semantics},
               content: {wallet_name: $wallet_name, event_type: true,
                 balance_alert_condition: $condition,
                 balance_alert_threshold: $threshold,
@@ -1384,8 +1396,10 @@ capture_ntfy_stage "post" "$POST_STAGE_START" "$POST_STAGE_END"
 validate_stage_artifacts "post" "$LOG_DIR/scenario-post.json"
 
 log "Comparing normalized source and target notification semantics"
-jq -S '.notifications' "$LOG_DIR/semantic-manifest-pre.json" >"$LOG_DIR/semantic-pre.normalized.json"
-jq -S '.notifications' "$LOG_DIR/semantic-manifest-post.json" >"$LOG_DIR/semantic-post.normalized.json"
+jq -S '[.notifications[] | if .event == "balance_alert" then .balance |= del(.observed_current_balance_sats) else . end]' \
+    "$LOG_DIR/semantic-manifest-pre.json" >"$LOG_DIR/semantic-pre.normalized.json"
+jq -S '[.notifications[] | if .event == "balance_alert" then .balance |= del(.observed_current_balance_sats) else . end]' \
+    "$LOG_DIR/semantic-manifest-post.json" >"$LOG_DIR/semantic-post.normalized.json"
 cmp -s "$LOG_DIR/semantic-pre.normalized.json" "$LOG_DIR/semantic-post.normalized.json" \
     || fail "Source and target semantic notification manifests differ"
 capture_database_artifacts "post-upgrade"

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -228,6 +228,12 @@ copy_self_hosted_env() {
     if ! grep -q '^NTFY_SERVER_URL=' "$repo_dir/backend/.env"; then
         printf '\nNTFY_SERVER_URL=%s\n' "$NTFY_URL" >> "$repo_dir/backend/.env"
     fi
+    if grep -q '^CANARY_UMBREL_NTFY_URL=' "$repo_dir/backend/.env"; then
+        sed -i.bak "s|^CANARY_UMBREL_NTFY_URL=.*|CANARY_UMBREL_NTFY_URL=$NTFY_URL|" "$repo_dir/backend/.env"
+        rm -f "$repo_dir/backend/.env.bak"
+    else
+        printf 'CANARY_UMBREL_NTFY_URL=%s\n' "$NTFY_URL" >> "$repo_dir/backend/.env"
+    fi
     if grep -q '^CANARY_SYNC_INTERVAL=' "$repo_dir/backend/.env"; then
         sed -i.bak 's/^CANARY_SYNC_INTERVAL=.*/CANARY_SYNC_INTERVAL=2/' "$repo_dir/backend/.env"
         rm -f "$repo_dir/backend/.env.bak"
@@ -703,11 +709,9 @@ configure_ntfy_credentials() {
     local payload
 
     payload="$(jq -n \
-        --arg server_url "$NTFY_URL" \
         --arg username "$NTFY_USERNAME" \
         --arg password "$NTFY_PASSWORD" \
         '{
-            ntfy_server_url: $server_url,
             ntfy_username: $username,
             ntfy_password: $password
         }')"

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -15,20 +15,32 @@ NTFY_USERNAME="${CANARY_NTFY_USERNAME:-testuser}"
 NTFY_PASSWORD="${CANARY_NTFY_PASSWORD:-testpassword}"
 
 FROM_TAG=""
+TO_REF="HEAD"
 KEEP_WORKTREE=0
 SKIP_PLAYWRIGHT_INSTALL=0
+RUN_SUCCEEDED=0
 
 WORK_DIR=""
 WORKTREE_DIR=""
+LOG_DIR=""
 BACKEND_PID=""
 FRONTEND_PID=""
+
+SOURCE_SHA=""
+TARGET_SHA=""
 
 TARGET_WALLET_CHECKSUM=""
 TARGET_WALLET_NAME=""
 TARGET_BTC_WALLET=""
-NTFY_TOPIC=""
+NTFY_TOPIC_A=""
+NTFY_TOPIC_B=""
+NTFY_TOPIC_INACTIVE=""
+CONTACT_A_ID=""
+CONTACT_B_ID=""
+INACTIVE_CONTACT_ID=""
+LEGACY_BALANCE_ALERT_ID=""
+LEGACY_BALANCE_THRESHOLD_SATS=""
 PRE_UPGRADE_TXID=""
-POST_UPGRADE_TXID=""
 EXPECTED_WALLET_COUNT=""
 AUTH_TOKEN=""
 PRE_UPGRADE_BDK_WALLET_ROW=""
@@ -36,10 +48,11 @@ PRE_UPGRADE_REVEALED_INDEXES=""
 
 usage() {
     cat <<'EOF'
-Usage: ./scripts/test-upgrade.sh [--from-tag <tag>] [--keep-worktree] [--skip-playwright-install]
+Usage: ./scripts/test-upgrade.sh [--from-tag <tag>] [--to-ref <ref>] [--keep-worktree] [--skip-playwright-install]
 
 Options:
   --from-tag <tag>           Upgrade from the given BDK-2 tag. Defaults to the latest such release.
+  --to-ref <ref>             Upgrade to this commit-ish. Defaults to HEAD.
   --keep-worktree            Keep the temporary worktree and logs after the run.
   --skip-playwright-install  Reuse an existing Playwright install.
   -h, --help                 Show this help message.
@@ -115,17 +128,34 @@ kill_if_running() {
 }
 
 cleanup() {
+    local exit_status=$?
     set +e
     kill_if_running "$BACKEND_PID"
     kill_if_running "$FRONTEND_PID"
 
-    if [[ "$KEEP_WORKTREE" -eq 0 && -n "$WORKTREE_DIR" && -d "$WORKTREE_DIR" ]]; then
+    if [[ "$exit_status" -ne 0 && -n "$LOG_DIR" && -d "$LOG_DIR" ]]; then
+        KEEP_WORKTREE=1
+        if docker info >/dev/null 2>&1; then
+            (
+                cd "$SCRIPT_DIR"
+                docker_compose logs --no-color >"$LOG_DIR/docker-services.log" 2>&1
+            )
+        fi
+        capture_database_artifacts "failure"
+        printf '\nUpgrade gate failed. Artifacts retained at: %s\n' "$WORK_DIR" >&2
+        printf '  logs:     %s\n' "$LOG_DIR" >&2
+        printf '  worktree: %s\n' "$WORKTREE_DIR" >&2
+    fi
+
+    if [[ "$RUN_SUCCEEDED" -eq 1 && "$KEEP_WORKTREE" -eq 0 && -n "$WORKTREE_DIR" && -d "$WORKTREE_DIR" ]]; then
         git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || true
     fi
 
-    if [[ "$KEEP_WORKTREE" -eq 0 && -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    if [[ "$RUN_SUCCEEDED" -eq 1 && "$KEEP_WORKTREE" -eq 0 && -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
         rm -rf "$WORK_DIR"
     fi
+
+    return "$exit_status"
 }
 
 trap cleanup EXIT
@@ -135,6 +165,11 @@ while [[ $# -gt 0 ]]; do
         --from-tag)
             [[ $# -ge 2 ]] || fail "--from-tag requires a value"
             FROM_TAG="$2"
+            shift 2
+            ;;
+        --to-ref)
+            [[ $# -ge 2 ]] || fail "--to-ref requires a value"
+            TO_REF="$2"
             shift 2
             ;;
         --keep-worktree)
@@ -166,11 +201,23 @@ git -C "$REPO_ROOT" rev-parse --verify "${FROM_TAG}^{tag}" >/dev/null 2>&1 \
     || git -C "$REPO_ROOT" rev-parse --verify "$FROM_TAG^{commit}" >/dev/null 2>&1 \
     || fail "Tag or commit not found: $FROM_TAG"
 
-CURRENT_HEAD="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+git -C "$REPO_ROOT" rev-parse --verify "${TO_REF}^{commit}" >/dev/null 2>&1 \
+    || fail "Target ref not found: $TO_REF"
+
+SOURCE_SHA="$(git -C "$REPO_ROOT" rev-parse "${FROM_TAG}^{commit}")"
+TARGET_SHA="$(git -C "$REPO_ROOT" rev-parse "${TO_REF}^{commit}")"
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/canary-upgrade-test.XXXXXX")"
 WORKTREE_DIR="$WORK_DIR/repo"
 LOG_DIR="$WORK_DIR/logs"
 mkdir -p "$LOG_DIR"
+
+jq -n \
+    --arg source_ref "$FROM_TAG" \
+    --arg source_sha "$SOURCE_SHA" \
+    --arg target_ref "$TO_REF" \
+    --arg target_sha "$TARGET_SHA" \
+    '{source: {ref: $source_ref, sha: $source_sha}, target: {ref: $target_ref, sha: $target_sha}}' \
+    >"$LOG_DIR/refs.json"
 
 copy_self_hosted_env() {
     local repo_dir="$1"
@@ -180,6 +227,12 @@ copy_self_hosted_env() {
 
     if ! grep -q '^NTFY_SERVER_URL=' "$repo_dir/backend/.env"; then
         printf '\nNTFY_SERVER_URL=%s\n' "$NTFY_URL" >> "$repo_dir/backend/.env"
+    fi
+    if grep -q '^CANARY_SYNC_INTERVAL=' "$repo_dir/backend/.env"; then
+        sed -i.bak 's/^CANARY_SYNC_INTERVAL=.*/CANARY_SYNC_INTERVAL=2/' "$repo_dir/backend/.env"
+        rm -f "$repo_dir/backend/.env.bak"
+    else
+        printf 'CANARY_SYNC_INTERVAL=2\n' >> "$repo_dir/backend/.env"
     fi
 }
 
@@ -221,6 +274,53 @@ find_bdk_wallet_db() {
     done
 
     return 1
+}
+
+metadata_db_path() {
+    local repo_dir="$1"
+    local candidate
+
+    for candidate in \
+        "$repo_dir/backend/database/self-hosted/regtest/metadata.sqlite" \
+        "$repo_dir/backend/database/regtest/metadata.sqlite"; do
+        if [[ -f "$candidate" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+capture_database_artifacts() {
+    local label="$1"
+    local db_path snapshot_dir
+
+    [[ -n "$WORKTREE_DIR" && -d "$WORKTREE_DIR" ]] || return 0
+    db_path="$(metadata_db_path "$WORKTREE_DIR" 2>/dev/null || true)"
+    [[ -n "$db_path" && -f "$db_path" ]] || return 0
+
+    snapshot_dir="$LOG_DIR/database-$label"
+    mkdir -p "$snapshot_dir"
+    sqlite3 "$db_path" ".backup '$snapshot_dir/metadata.sqlite'" || true
+    sqlite3 -json "$db_path" \
+        "SELECT * FROM contacts ORDER BY created_at, id;" \
+        >"$snapshot_dir/contacts.json" 2>/dev/null || true
+    sqlite3 -json "$db_path" \
+        "SELECT * FROM contact_notification_methods ORDER BY created_at, id;" \
+        >"$snapshot_dir/contact-notification-methods.json" 2>/dev/null || true
+    sqlite3 -json "$db_path" \
+        "SELECT * FROM balance_alerts ORDER BY created_at, id;" \
+        >"$snapshot_dir/balance-alerts.json" 2>/dev/null || true
+    sqlite3 -json "$db_path" \
+        "SELECT * FROM balance_alert_notifications ORDER BY created_at, id;" \
+        >"$snapshot_dir/balance-alert-notifications.json" 2>/dev/null || true
+    sqlite3 -json "$db_path" \
+        "SELECT * FROM notification_logs ORDER BY created_at, id;" \
+        >"$snapshot_dir/notification-logs.json" 2>/dev/null || true
+    sqlite3 -json "$db_path" \
+        "SELECT * FROM balance_alert_notification_logs ORDER BY created_at, id;" \
+        >"$snapshot_dir/balance-alert-notification-logs.json" 2>/dev/null || true
 }
 
 capture_pre_upgrade_bdk_state() {
@@ -375,13 +475,6 @@ btc_wallet() {
     docker exec bitcoind-regtest bitcoin-cli -rpcuser=bitcoin -rpcpassword=bitcoin -rpcport=8332 -rpcwallet="$wallet_name" "$@"
 }
 
-mine_blocks() {
-    local blocks="${1:-1}"
-    local miner_address
-    miner_address="$(btc_wallet miner getnewaddress)"
-    btc generatetoaddress "$blocks" "$miner_address" >/dev/null
-}
-
 wallet_list_json() {
     api_curl "$BACKEND_URL/api/wallets"
 }
@@ -426,11 +519,11 @@ select_target_wallet() {
 }
 
 create_ntfy_contact() {
-    NTFY_TOPIC="canary-upgrade-test-$(date +%s)"
-
+    local name="$1"
+    local topic="$2"
     local payload response
-    payload="$(jq -n --arg topic "$NTFY_TOPIC" '{
-        name: "Upgrade Test Contact",
+    payload="$(jq -n --arg name "$name" --arg topic "$topic" '{
+        name: $name,
         notification_methods: [
             {
                 provider_type: "ntfy",
@@ -447,24 +540,118 @@ create_ntfy_contact() {
     echo "$response" | jq -e '
         (.contact_id | type == "string")
     ' >/dev/null || fail "Failed to create ntfy contact: $response"
+
+    echo "$response" | jq -r '.contact_id'
 }
 
-assert_contact_present() {
+seed_inactive_ntfy_contact() {
+    local db_path
+    db_path="$(metadata_db_path "$WORKTREE_DIR")" \
+        || fail "Could not find metadata database for inactive contact fixture"
+
+    INACTIVE_CONTACT_ID="upgrade-inactive-contact"
+    sqlite3 "$db_path" <<SQL
+PRAGMA busy_timeout = 10000;
+BEGIN IMMEDIATE;
+INSERT INTO contacts (id, wallet_checksum, name, is_active)
+VALUES ('$INACTIVE_CONTACT_ID', '$TARGET_WALLET_CHECKSUM', 'Upgrade Inactive', 0);
+INSERT INTO contact_notification_methods (
+    id, contact_id, provider_type, notification_target, wallet_checksum
+)
+VALUES (
+    'upgrade-inactive-method', '$INACTIVE_CONTACT_ID', 'ntfy', '$NTFY_TOPIC_INACTIVE', '$TARGET_WALLET_CHECKSUM'
+);
+COMMIT;
+SQL
+}
+
+assert_contacts_present() {
     local detail
     detail="$(wallet_detail_json "$TARGET_WALLET_CHECKSUM")"
-    echo "$detail" | jq -e --arg topic "$NTFY_TOPIC" '
-        [.contacts[].notification_methods[]? | select(.notification_target == $topic)] | length > 0
-    ' >/dev/null || fail "Expected ntfy topic not found in wallet detail"
+    echo "$detail" | jq -e \
+        --arg topic_a "$NTFY_TOPIC_A" \
+        --arg topic_b "$NTFY_TOPIC_B" \
+        --arg topic_inactive "$NTFY_TOPIC_INACTIVE" '
+        ([.contacts[].notification_methods[]? | .notification_target] | sort)
+        | contains([$topic_a, $topic_b, $topic_inactive] | sort)
+    ' >/dev/null || fail "Expected active/inactive ntfy topics not found in wallet detail"
 }
 
-send_transaction_to_target_wallet() {
-    local amount="$1"
-    local receive_address txid
+wallet_balance_sats() {
+    wallet_list_json | jq -r --arg checksum "$TARGET_WALLET_CHECKSUM" \
+        '.wallets[] | select(.checksum == $checksum) | .balance_total'
+}
 
-    btc loadwallet "$TARGET_BTC_WALLET" >/dev/null 2>&1 || true
-    receive_address="$(btc_wallet "$TARGET_BTC_WALLET" getnewaddress)"
-    txid="$(btc_wallet miner sendtoaddress "$receive_address" "$amount")"
-    echo "$txid"
+create_legacy_balance_alert() {
+    local current_balance payload response
+    current_balance="$(wallet_balance_sats)"
+    LEGACY_BALANCE_THRESHOLD_SATS=$((current_balance - 1000000))
+    [[ "$LEGACY_BALANCE_THRESHOLD_SATS" -gt 0 ]] \
+        || fail "Wallet balance is too small for the balance-threshold scenario"
+
+    payload="$(jq -n --argjson threshold "$LEGACY_BALANCE_THRESHOLD_SATS" \
+        '{threshold_sats: $threshold, alert_type: "below"}')"
+    response="$(api_curl -X POST -H "Content-Type: application/json" -d "$payload" \
+        "$BACKEND_URL/api/wallets/${TARGET_WALLET_CHECKSUM}/balance-alerts")"
+    LEGACY_BALANCE_ALERT_ID="$(echo "$response" | jq -r '.id // empty')"
+    [[ -n "$LEGACY_BALANCE_ALERT_ID" ]] \
+        || fail "Failed to create legacy balance alert: $response"
+}
+
+btc_mempool() {
+    btc getrawmempool | jq -cS 'sort'
+}
+
+dev_mempool_delta() {
+    local label="$1"
+    local expected_new="$2"
+    shift 2
+    local before after delta output_file
+
+    before="$(btc_mempool)"
+    [[ "$(echo "$before" | jq 'length')" -eq 0 ]] \
+        || fail "Mempool must be empty before $label"
+    output_file="$LOG_DIR/dev-${label}.log"
+    (
+        cd "$SCRIPT_DIR"
+        ./dev.sh "$@"
+    ) >"$output_file" 2>&1
+    after="$(btc_mempool)"
+    delta="$(jq -n --argjson before "$before" --argjson after "$after" \
+        '$after - $before')"
+    [[ "$(echo "$delta" | jq 'length')" -eq "$expected_new" ]] \
+        || fail "$label created an unexpected mempool delta: $delta"
+    echo "$delta" | jq -r '.[0]'
+}
+
+dev_rbf_delta() {
+    local label="$1"
+    local original_txid="$2"
+    local before after delta output_file
+
+    before="$(btc_mempool)"
+    [[ "$(echo "$before" | jq --arg txid "$original_txid" 'index($txid) != null')" == "true" ]] \
+        || fail "RBF original $original_txid is not in the mempool"
+    output_file="$LOG_DIR/dev-${label}.log"
+    (
+        cd "$SCRIPT_DIR"
+        ./dev.sh "$TARGET_BTC_WALLET" rbf "$original_txid"
+    ) >"$output_file" 2>&1
+    after="$(btc_mempool)"
+    delta="$(jq -n --argjson before "$before" --argjson after "$after" '$after - $before')"
+    [[ "$(echo "$delta" | jq 'length')" -eq 1 ]] \
+        || fail "$label did not create exactly one replacement: $delta"
+    [[ "$(echo "$after" | jq --arg txid "$original_txid" 'index($txid) == null')" == "true" ]] \
+        || fail "$label left the replaced transaction in the mempool"
+    echo "$delta" | jq -r '.[0]'
+}
+
+dev_mine() {
+    local label="$1"
+    (
+        cd "$SCRIPT_DIR"
+        ./dev.sh mine 1
+    ) >"$LOG_DIR/dev-mine-${label}.log" 2>&1
 }
 
 wait_for_transaction_status() {
@@ -503,10 +690,15 @@ assert_post_upgrade_state() {
         [.wallets[] | select(.checksum == $checksum and .name == $name)] | length == 1
     ' >/dev/null || fail "Wallet list no longer contains the expected target wallet"
 
-    echo "$detail" | jq -e --arg topic "$NTFY_TOPIC" --arg pre_txid "$PRE_UPGRADE_TXID" '
-        ([.contacts[].notification_methods[]? | select(.notification_target == $topic)] | length > 0)
+    echo "$detail" | jq -e \
+        --arg topic_a "$NTFY_TOPIC_A" \
+        --arg topic_b "$NTFY_TOPIC_B" \
+        --arg topic_inactive "$NTFY_TOPIC_INACTIVE" \
+        --arg pre_txid "$PRE_UPGRADE_TXID" '
+        ([.contacts[].notification_methods[]? | .notification_target]
+            | contains([$topic_a, $topic_b, $topic_inactive]))
         and ([.transactions[] | select(.txid == $pre_txid)] | length > 0)
-    ' >/dev/null || fail "Post-upgrade detail is missing the contact or the pre-upgrade transaction"
+    ' >/dev/null || fail "Post-upgrade detail is missing contacts or the pre-upgrade transaction"
 }
 
 configure_ntfy_credentials() {
@@ -528,34 +720,349 @@ configure_ntfy_credentials() {
         "$BACKEND_URL/api/user/preferences" >/dev/null
 }
 
-wait_for_notification_status() {
-    local txid="$1"
+scenario_txids_sql() {
+    local scenario_file="$1"
+    jq -r '[.transactions[]] | map("\u0027" + . + "\u0027") | join(",")' "$scenario_file"
+}
+
+scenario_alert_ids_sql() {
+    local scenario_file="$1"
+    jq -r '.alert_ids | map("\u0027" + . + "\u0027") | join(",")' "$scenario_file"
+}
+
+stage_delivery_ready() {
+    local scenario_file="$1"
+    local db_path txids_sql alert_ids_sql topic txid count
+    db_path="$(metadata_db_path "$WORKTREE_DIR")" || return 1
+    txids_sql="$(scenario_txids_sql "$scenario_file")"
+    alert_ids_sql="$(scenario_alert_ids_sql "$scenario_file")"
+
+    for topic in "$NTFY_TOPIC_A" "$NTFY_TOPIC_B"; do
+        while IFS= read -r txid; do
+            count="$(sqlite3 "$db_path" \
+                "SELECT COUNT(*) FROM notification_logs
+                 WHERE transaction_txid = '$txid'
+                   AND notification_target_snapshot = '$topic'
+                   AND status = 'sent';")"
+            [[ "$count" -eq 2 ]] || return 1
+        done < <(jq -r '.transactions[]' "$scenario_file")
+
+        count="$(sqlite3 "$db_path" \
+            "SELECT COUNT(*) FROM balance_alert_notification_logs
+             WHERE balance_alert_id IN ($alert_ids_sql)
+               AND notification_target_snapshot = '$topic'
+               AND status = 'sent';")"
+        [[ "$count" -eq 1 ]] || return 1
+    done
+
+    [[ "$(sqlite3 "$db_path" \
+        "SELECT COUNT(*) FROM notification_logs
+         WHERE transaction_txid IN ($txids_sql) AND status = 'failed';")" -eq 0 ]] || return 1
+    [[ "$(sqlite3 "$db_path" \
+        "SELECT COUNT(*) FROM balance_alert_notification_logs
+         WHERE balance_alert_id IN ($alert_ids_sql) AND status = 'failed';")" -eq 0 ]] || return 1
+}
+
+wait_for_stage_delivery() {
+    local scenario_file="$1"
     local timeout=180
-
-    [[ "$txid" =~ ^[0-9a-fA-F]{64}$ ]] || fail "Invalid transaction id: $txid"
-
     while (( timeout > 0 )); do
-        local detail
-        detail="$(wallet_detail_json "$TARGET_WALLET_CHECKSUM")"
-
-        if echo "$detail" | jq -e --arg txid "$txid" '
-            [.transactions[] | select(.txid == $txid and (.notification_status | length > 0))] | length > 0
-        ' >/dev/null; then
+        if stage_delivery_ready "$scenario_file"; then
             return 0
         fi
-
-        if [[ -f "$WORKTREE_DIR/backend/database/self-hosted/regtest/metadata.sqlite" ]] &&
-            sqlite3 "$WORKTREE_DIR/backend/database/self-hosted/regtest/metadata.sqlite" \
-                "SELECT COUNT(*) FROM notification_logs WHERE transaction_txid = '$txid';" 2>/dev/null |
-            grep -Eq '^[1-9][0-9]*$'; then
-            return 0
-        fi
-
         sleep 2
         timeout=$((timeout - 2))
     done
+    fail "Timed out waiting for the complete notification matrix in $(basename "$scenario_file")"
+}
 
-    fail "Expected notification_status entries for transaction ${txid}"
+capture_ntfy_topic() {
+    local topic="$1"
+    local start_time="$2"
+    local end_time="$3"
+    local output_file="$4"
+    local raw_file="${output_file%.json}.ndjson"
+
+    curl -fsS -u "$NTFY_USERNAME:$NTFY_PASSWORD" \
+        "$NTFY_URL/$topic/json?poll=1&since=all" >"$raw_file"
+    jq -s --arg topic "$topic" --argjson start "$start_time" --argjson end "$end_time" '
+        [.[] | select(.event == "message" and .topic == $topic and .time >= $start and .time <= $end)]
+    ' "$raw_file" >"$output_file"
+}
+
+capture_ntfy_stage() {
+    local stage="$1"
+    local start_time="$2"
+    local end_time="$3"
+    capture_ntfy_topic "$NTFY_TOPIC_A" "$start_time" "$end_time" "$LOG_DIR/ntfy-${stage}-a.json"
+    capture_ntfy_topic "$NTFY_TOPIC_B" "$start_time" "$end_time" "$LOG_DIR/ntfy-${stage}-b.json"
+    capture_ntfy_topic "$NTFY_TOPIC_INACTIVE" "$start_time" "$end_time" "$LOG_DIR/ntfy-${stage}-inactive.json"
+}
+
+ntfy_message_count() {
+    local topic="$1"
+    curl -fsS -u "$NTFY_USERNAME:$NTFY_PASSWORD" \
+        "$NTFY_URL/$topic/json?poll=1&since=all" | jq -s '[.[] | select(.event == "message")] | length'
+}
+
+assert_restart_does_not_duplicate() {
+    local stage="$1"
+    local before_a before_b after_a after_b
+    before_a="$(ntfy_message_count "$NTFY_TOPIC_A")"
+    before_b="$(ntfy_message_count "$NTFY_TOPIC_B")"
+
+    kill_if_running "$BACKEND_PID"
+    BACKEND_PID=""
+    start_backend "$WORKTREE_DIR" "${stage}-restart"
+    sleep 6
+
+    after_a="$(ntfy_message_count "$NTFY_TOPIC_A")"
+    after_b="$(ntfy_message_count "$NTFY_TOPIC_B")"
+    [[ "$after_a" -eq "$before_a" && "$after_b" -eq "$before_b" ]] \
+        || fail "Backend restart duplicated notifications during $stage (A: $before_a->$after_a, B: $before_b->$after_b)"
+}
+
+assert_post_upgrade_content_translation() {
+    local db_path expected_count
+    db_path="$(metadata_db_path "$WORKTREE_DIR")" \
+        || fail "Could not find upgraded metadata database"
+    expected_count="$(sqlite3 "$db_path" \
+        "SELECT COUNT(*)
+         FROM contact_notification_methods method
+         JOIN contacts contact ON contact.id = method.contact_id
+         WHERE contact.id IN ('$CONTACT_A_ID', '$CONTACT_B_ID', '$INACTIVE_CONTACT_ID')
+           AND method.provider_type = 'ntfy'
+           AND method.is_enabled = 1
+           AND method.content_wallet_name = 1
+           AND method.content_event_type = 1
+           AND method.content_transaction_amount = 1
+           AND method.content_transaction_balance = 0
+           AND method.content_balance_alert_condition = 1
+           AND method.content_balance_alert_threshold = 1
+           AND method.content_balance_alert_balance = 1;")"
+    [[ "$expected_count" -eq 3 ]] \
+        || fail "v1.5.2 content settings did not translate without privacy expansion"
+}
+
+validate_stage_artifacts() {
+    local stage="$1"
+    local scenario_file="$2"
+    local db_path txids_sql alert_ids_sql topic topic_file txid count total expected_body_file actual_body_file duplicate_count wrong_topic_count current_balance
+    db_path="$(metadata_db_path "$WORKTREE_DIR")" || fail "Metadata database is missing"
+    txids_sql="$(scenario_txids_sql "$scenario_file")"
+    alert_ids_sql="$(scenario_alert_ids_sql "$scenario_file")"
+
+    sqlite3 -json "$db_path" \
+        "SELECT * FROM notification_logs WHERE transaction_txid IN ($txids_sql) ORDER BY created_at, id;" \
+        >"$LOG_DIR/notification-logs-${stage}.json"
+    sqlite3 -json "$db_path" \
+        "SELECT * FROM balance_alert_notification_logs WHERE balance_alert_id IN ($alert_ids_sql) ORDER BY created_at, id;" \
+        >"$LOG_DIR/balance-notification-logs-${stage}.json"
+
+    wrong_topic_count="$(sqlite3 "$db_path" \
+        "SELECT
+           (SELECT COUNT(*) FROM notification_logs
+            WHERE transaction_txid IN ($txids_sql)
+              AND notification_target_snapshot NOT IN ('$NTFY_TOPIC_A', '$NTFY_TOPIC_B'))
+           +
+           (SELECT COUNT(*) FROM balance_alert_notification_logs
+            WHERE balance_alert_id IN ($alert_ids_sql)
+              AND notification_target_snapshot NOT IN ('$NTFY_TOPIC_A', '$NTFY_TOPIC_B'));")"
+    [[ "$wrong_topic_count" -eq 0 ]] || fail "$stage delivered to an unexpected topic"
+
+    duplicate_count="$(sqlite3 "$db_path" \
+        "SELECT COUNT(*) FROM (
+           SELECT transaction_txid, notification_target_snapshot, message_content, COUNT(*) AS copies
+           FROM notification_logs
+           WHERE transaction_txid IN ($txids_sql)
+           GROUP BY transaction_txid, notification_target_snapshot, message_content
+           HAVING copies > 1
+         );")"
+    [[ "$duplicate_count" -eq 0 ]] || fail "$stage contains duplicate transaction deliveries"
+
+    for topic in "$NTFY_TOPIC_A" "$NTFY_TOPIC_B"; do
+        if [[ "$topic" == "$NTFY_TOPIC_A" ]]; then
+            topic_file="$LOG_DIR/ntfy-${stage}-a.json"
+        else
+            topic_file="$LOG_DIR/ntfy-${stage}-b.json"
+        fi
+        total="$(jq 'length' "$topic_file")"
+        [[ "$total" -eq 13 ]] || fail "$stage topic $topic received $total messages; expected 13"
+
+        while IFS= read -r txid; do
+            count="$(sqlite3 "$db_path" \
+                "SELECT COUNT(*) FROM notification_logs
+                 WHERE transaction_txid = '$txid'
+                   AND notification_target_snapshot = '$topic'
+                   AND status = 'sent';")"
+            [[ "$count" -eq 2 ]] \
+                || fail "$stage transaction $txid delivered $count times to $topic; expected 2"
+        done < <(jq -r '.transactions[]' "$scenario_file")
+
+        count="$(sqlite3 "$db_path" \
+            "SELECT COUNT(*) FROM balance_alert_notification_logs
+             WHERE balance_alert_id IN ($alert_ids_sql)
+               AND notification_target_snapshot = '$topic'
+               AND status = 'sent';")"
+        [[ "$count" -eq 1 ]] \
+            || fail "$stage balance alert delivered $count times to $topic; expected 1"
+
+        expected_body_file="$LOG_DIR/expected-bodies-${stage}-$(basename "$topic_file")"
+        actual_body_file="$LOG_DIR/actual-bodies-${stage}-$(basename "$topic_file")"
+        {
+            sqlite3 "$db_path" \
+                "SELECT json_quote(message_content) FROM notification_logs
+                 WHERE transaction_txid IN ($txids_sql)
+                   AND notification_target_snapshot = '$topic'
+                   AND status = 'sent';"
+            sqlite3 "$db_path" \
+                "SELECT json_quote(message_content) FROM balance_alert_notification_logs
+                 WHERE balance_alert_id IN ($alert_ids_sql)
+                   AND notification_target_snapshot = '$topic'
+                   AND status = 'sent';"
+        } | jq -sS 'sort' >"$expected_body_file"
+        jq -S '[.[].message] | sort' "$topic_file" >"$actual_body_file"
+        cmp -s "$expected_body_file" "$actual_body_file" \
+            || fail "$stage ntfy bodies do not match the successful database delivery log for $topic"
+    done
+
+    [[ "$(jq 'length' "$LOG_DIR/ntfy-${stage}-inactive.json")" -eq 0 ]] \
+        || fail "$stage delivered a notification to the inactive contact"
+
+    current_balance="$(sqlite3 "$db_path" \
+        "SELECT group_concat(DISTINCT current_balance_sats)
+         FROM balance_alert_notifications
+         WHERE balance_alert_id IN ($alert_ids_sql);")"
+    [[ -n "$current_balance" && "$current_balance" != *,* ]] \
+        || fail "$stage balance alert did not preserve one semantic current-balance value"
+
+    jq -n \
+        --arg stage "$stage" \
+        --arg topic_a "$NTFY_TOPIC_A" \
+        --arg topic_b "$NTFY_TOPIC_B" \
+        --argjson threshold "$LEGACY_BALANCE_THRESHOLD_SATS" \
+        --argjson current_balance "$current_balance" '
+        def content: {
+          wallet_name: true,
+          event_type: true,
+          transaction_amount: true,
+          transaction_balance: false,
+          balance_alert_condition: true,
+          balance_alert_threshold: true,
+          balance_alert_balance: true
+        };
+        [ $topic_a, $topic_b ] as $topics
+        | [
+            $topics[] as $topic
+            | {destination: $topic, scenario: "incoming", event: "transaction", direction: "receive", states: ["pending", "confirmed"], amount_sats: 1000000, content: content},
+              {destination: $topic, scenario: "outgoing", event: "transaction", direction: "send", states: ["pending", "confirmed"], amount_sats: 2000000, content: content},
+              {destination: $topic, scenario: "rbf", event: "rbf", direction: "send", states: ["pending", "replaced", "confirmed"], amount_sats: 500000, content: content},
+              {destination: $topic, scenario: "cpfp", event: "cpfp", direction: "receive+send", states: ["pending", "confirmed"], amount_sats: 400000, content: content},
+              {destination: $topic, scenario: "balance", event: "balance_alert", direction: null, states: ["triggered"], amount_sats: null, balance: {condition: "below", threshold_sats: $threshold, current_balance_sats: $current_balance}, content: content}
+          ] | {stage: $stage, notifications: sort_by(.destination, .scenario)}
+    ' >"$LOG_DIR/semantic-manifest-${stage}.json"
+}
+
+run_notification_scenarios() {
+    local stage="$1"
+    local scenario_file="$LOG_DIR/scenario-${stage}.json"
+    local incoming outgoing rbf_original rbf_replacement cpfp_parent cpfp_child alert_ids_json
+
+    incoming="$(dev_mempool_delta "${stage}-incoming" 1 miner sending "$TARGET_BTC_WALLET" 0.01)"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$incoming" "pending"
+    dev_mine "${stage}-incoming"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$incoming" "confirmed"
+
+    if [[ "$stage" == "pre" ]]; then
+        create_legacy_balance_alert
+    fi
+
+    outgoing="$(dev_mempool_delta "${stage}-outgoing" 1 "$TARGET_BTC_WALLET" sending miner 0.02)"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$outgoing" "pending"
+    dev_mine "${stage}-outgoing"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$outgoing" "confirmed"
+
+    rbf_original="$(dev_mempool_delta "${stage}-rbf-original" 1 "$TARGET_BTC_WALLET" sending miner 0.005)"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$rbf_original" "pending"
+    rbf_replacement="$(dev_rbf_delta "${stage}-rbf-replacement" "$rbf_original")"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$rbf_original" "replaced"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$rbf_replacement" "pending"
+    dev_mine "${stage}-rbf"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$rbf_replacement" "confirmed"
+
+    cpfp_parent="$(dev_mempool_delta "${stage}-cpfp-parent" 1 miner sending "$TARGET_BTC_WALLET" 0.004)"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$cpfp_parent" "pending"
+    cpfp_child="$(dev_mempool_delta "${stage}-cpfp-child" 1 "$TARGET_BTC_WALLET" cpfp "$cpfp_parent")"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$cpfp_child" "pending"
+    dev_mine "${stage}-cpfp"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$cpfp_parent" "confirmed"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$cpfp_child" "confirmed"
+
+    if [[ "$stage" == "pre" ]]; then
+        alert_ids_json="$(jq -n --arg id "$LEGACY_BALANCE_ALERT_ID" '[$id]')"
+    else
+        local db_path
+        db_path="$(metadata_db_path "$WORKTREE_DIR")"
+        alert_ids_json="$(sqlite3 -json "$db_path" \
+            "SELECT id FROM balance_alerts
+             WHERE wallet_checksum = '$TARGET_WALLET_CHECKSUM'
+               AND contact_id IN ('$CONTACT_A_ID', '$CONTACT_B_ID')
+               AND threshold_sats = $LEGACY_BALANCE_THRESHOLD_SATS
+               AND alert_type = 'below';" | jq '[.[].id]')"
+        [[ "$(echo "$alert_ids_json" | jq 'length')" -eq 2 ]] \
+            || fail "Expected exactly two migrated per-contact balance alerts"
+    fi
+
+    jq -n \
+        --arg stage "$stage" \
+        --arg incoming "$incoming" \
+        --arg outgoing "$outgoing" \
+        --arg rbf_original "$rbf_original" \
+        --arg rbf_replacement "$rbf_replacement" \
+        --arg cpfp_parent "$cpfp_parent" \
+        --arg cpfp_child "$cpfp_child" \
+        --argjson alert_ids "$alert_ids_json" \
+        --argjson threshold "$LEGACY_BALANCE_THRESHOLD_SATS" '
+        {
+          stage: $stage,
+          transactions: {
+            incoming: $incoming,
+            outgoing: $outgoing,
+            rbf_original: $rbf_original,
+            rbf_replacement: $rbf_replacement,
+            cpfp_parent: $cpfp_parent,
+            cpfp_child: $cpfp_child
+          },
+          alert_ids: $alert_ids,
+          threshold_sats: $threshold
+        }
+    ' >"$scenario_file"
+
+    wait_for_stage_delivery "$scenario_file"
+    if [[ "$stage" == "pre" ]]; then
+        PRE_UPGRADE_TXID="$incoming"
+    fi
+}
+
+restore_and_rearm_legacy_alert() {
+    local current_balance delta amount restore_txid db_path
+    current_balance="$(wallet_balance_sats)"
+    delta=$((LEGACY_BALANCE_THRESHOLD_SATS - current_balance))
+    [[ "$delta" -gt 0 ]] || fail "Pre-upgrade balance did not fall below the legacy threshold"
+    amount="$(LC_NUMERIC=C awk -v sats="$delta" 'BEGIN { printf "%.8f", sats / 100000000 }')"
+    restore_txid="$(dev_mempool_delta "pre-balance-restore" 1 miner sending "$TARGET_BTC_WALLET" "$amount")"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$restore_txid" "pending"
+    dev_mine "pre-balance-restore"
+    wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$restore_txid" "confirmed"
+    [[ "$(wallet_balance_sats)" -eq "$LEGACY_BALANCE_THRESHOLD_SATS" ]] \
+        || fail "Could not restore the wallet exactly to the legacy threshold"
+
+    stop_app_processes
+    db_path="$(metadata_db_path "$WORKTREE_DIR")"
+    sqlite3 "$db_path" \
+        "UPDATE balance_alerts
+         SET is_active = 1, last_checked_balance_sats = $LEGACY_BALANCE_THRESHOLD_SATS
+         WHERE id = '$LEGACY_BALANCE_ALERT_ID';"
 }
 
 run_playwright() {
@@ -569,7 +1076,12 @@ run_playwright() {
         cd "$PLAYWRIGHT_DIR"
         WALLET_CHECKSUM="$TARGET_WALLET_CHECKSUM" \
         WALLET_NAME="$TARGET_WALLET_NAME" \
-        NTFY_TOPIC="$NTFY_TOPIC" \
+        NTFY_TOPIC_A="$NTFY_TOPIC_A" \
+        NTFY_TOPIC_B="$NTFY_TOPIC_B" \
+        NTFY_TOPIC_INACTIVE="$NTFY_TOPIC_INACTIVE" \
+        CONTACT_A_NAME="Upgrade Active A" \
+        CONTACT_B_NAME="Upgrade Active B" \
+        INACTIVE_CONTACT_NAME="Upgrade Inactive" \
         EXPECTED_WALLET_COUNT="$EXPECTED_WALLET_COUNT" \
         TXID_PREFIX="$txid_prefix" \
         AUTH_TOKEN="$AUTH_TOKEN" \
@@ -580,9 +1092,10 @@ run_playwright() {
 
 start_backend() {
     local repo_dir="$1"
+    local label="${2:-app}"
     (
         cd "$repo_dir/backend"
-        cargo run >"$LOG_DIR/backend.log" 2>&1
+        cargo run >"$LOG_DIR/backend-${label}.log" 2>&1
     ) &
     BACKEND_PID=$!
     wait_for_backend
@@ -591,11 +1104,12 @@ start_backend() {
 
 start_frontend() {
     local repo_dir="$1"
+    local label="${2:-app}"
     (
         cd "$repo_dir/frontend"
-        pnpm install --frozen-lockfile >"$LOG_DIR/frontend-install.log" 2>&1
+        pnpm install --frozen-lockfile >"$LOG_DIR/frontend-install-${label}.log" 2>&1
         mkdir -p logs
-        pnpm exec next dev --port "$FRONTEND_PORT" >"$LOG_DIR/frontend.log" 2>&1
+        pnpm exec next dev --port "$FRONTEND_PORT" >"$LOG_DIR/frontend-${label}.log" 2>&1
     ) &
     FRONTEND_PID=$!
     wait_for_http "$FRONTEND_URL" 300 "Frontend"
@@ -669,13 +1183,15 @@ seed_old_version() {
     fail "Could not find a wallet initialization command in $old_script_dir/dev.sh"
 }
 
-log "Creating temporary worktree from ${FROM_TAG}"
+log "Preparing ${FROM_TAG} (${SOURCE_SHA}) -> ${TO_REF} (${TARGET_SHA})"
 ref_uses_bdk_wallet_2 "$FROM_TAG" \
     || fail "Upgrade source ${FROM_TAG} does not use bdk_wallet 2.x"
-git -C "$REPO_ROOT" worktree add --detach "$WORKTREE_DIR" "$FROM_TAG" >/dev/null
+git -C "$REPO_ROOT" worktree add --detach "$WORKTREE_DIR" "$SOURCE_SHA" >/dev/null
 copy_self_hosted_env "$WORKTREE_DIR"
 
 log "Resetting local ports and regtest infrastructure"
+echo "WARNING: this deletes only the Docker volumes declared by scripts/docker-compose.yml." >&2
+echo "Never run this gate against non-regtest or user data." >&2
 stop_app_processes
 assert_web_ports_available
 (
@@ -693,9 +1209,9 @@ log "Starting shared Docker infrastructure"
 log "Installing isolated Playwright dependencies"
 prepare_playwright
 
-log "Starting old version from ${FROM_TAG}"
-start_backend "$WORKTREE_DIR"
-start_frontend "$WORKTREE_DIR"
+log "Starting source version ${FROM_TAG} (${SOURCE_SHA})"
+start_backend "$WORKTREE_DIR" "pre"
+start_frontend "$WORKTREE_DIR" "pre"
 
 log "Seeding self-hosted data on old version"
 seed_old_version "$WORKTREE_DIR"
@@ -703,52 +1219,73 @@ wait_for_wallets_synced
 select_target_wallet
 capture_snapshot "$TARGET_WALLET_CHECKSUM"
 
-log "Adding ntfy contact and verifying wallet detail"
-create_ntfy_contact
-assert_contact_present
+log "Configuring authenticated ntfy and notification fixtures before source activity"
+configure_ntfy_credentials
+RUN_ID="$(date +%s)-$$"
+NTFY_TOPIC_A="canary-upgrade-${RUN_ID}-a"
+NTFY_TOPIC_B="canary-upgrade-${RUN_ID}-b"
+NTFY_TOPIC_INACTIVE="canary-upgrade-${RUN_ID}-inactive"
+CONTACT_A_ID="$(create_ntfy_contact "Upgrade Active A" "$NTFY_TOPIC_A")"
+CONTACT_B_ID="$(create_ntfy_contact "Upgrade Active B" "$NTFY_TOPIC_B")"
+seed_inactive_ntfy_contact
+assert_contacts_present
+capture_database_artifacts "pre-fixture"
 
-log "Sending a pre-upgrade transaction"
-PRE_UPGRADE_TXID="$(send_transaction_to_target_wallet "0.01")"
-wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$PRE_UPGRADE_TXID" "pending"
-mine_blocks 1
-wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$PRE_UPGRADE_TXID" "confirmed"
+log "Running source notification matrix"
+PRE_STAGE_START="$(date +%s)"
+run_notification_scenarios "pre"
+assert_restart_does_not_duplicate "pre"
+PRE_STAGE_END="$(date +%s)"
+capture_ntfy_stage "pre" "$PRE_STAGE_START" "$PRE_STAGE_END"
+validate_stage_artifacts "pre" "$LOG_DIR/scenario-pre.json"
 
 log "Running pre-upgrade Playwright verification"
 run_playwright '@pre-upgrade' "$PRE_UPGRADE_TXID"
 
-log "Upgrading worktree to current HEAD"
-stop_app_processes
+log "Restoring the balance threshold and rearming its deliverable legacy alert"
+sleep 2
+restore_and_rearm_legacy_alert
+capture_database_artifacts "pre-upgrade"
 capture_pre_upgrade_bdk_state
 assert_web_ports_available
-git -C "$WORKTREE_DIR" checkout --detach "$CURRENT_HEAD" >"$LOG_DIR/git-checkout-head.log" 2>&1
+git -C "$WORKTREE_DIR" checkout --detach "$TARGET_SHA" >"$LOG_DIR/git-checkout-target.log" 2>&1
 copy_self_hosted_env "$WORKTREE_DIR"
 migrate_legacy_data_dir_if_needed "$WORKTREE_DIR"
 
-log "Starting upgraded version"
-start_backend "$WORKTREE_DIR"
-start_frontend "$WORKTREE_DIR"
+log "Starting target version ${TO_REF} (${TARGET_SHA})"
+start_backend "$WORKTREE_DIR" "post"
+start_frontend "$WORKTREE_DIR" "post"
 
 log "Verifying preserved state after upgrade"
 assert_post_upgrade_state
 assert_post_upgrade_bdk_state
-configure_ntfy_credentials
+assert_post_upgrade_content_translation
 
 log "Running post-upgrade Playwright verification"
 run_playwright '@post-upgrade' "$PRE_UPGRADE_TXID"
 
-log "Sending a post-upgrade transaction"
-POST_UPGRADE_TXID="$(send_transaction_to_target_wallet "0.02")"
-wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$POST_UPGRADE_TXID" "pending"
-mine_blocks 1
-wait_for_transaction_status "$TARGET_WALLET_CHECKSUM" "$POST_UPGRADE_TXID" "confirmed"
+log "Running target notification matrix"
+sleep 2
+POST_STAGE_START="$(date +%s)"
+run_notification_scenarios "post"
+assert_restart_does_not_duplicate "post"
+POST_STAGE_END="$(date +%s)"
+capture_ntfy_stage "post" "$POST_STAGE_START" "$POST_STAGE_END"
+validate_stage_artifacts "post" "$LOG_DIR/scenario-post.json"
 
-wait_for_notification_status "$POST_UPGRADE_TXID"
+log "Comparing normalized source and target notification semantics"
+jq -S '.notifications' "$LOG_DIR/semantic-manifest-pre.json" >"$LOG_DIR/semantic-pre.normalized.json"
+jq -S '.notifications' "$LOG_DIR/semantic-manifest-post.json" >"$LOG_DIR/semantic-post.normalized.json"
+cmp -s "$LOG_DIR/semantic-pre.normalized.json" "$LOG_DIR/semantic-post.normalized.json" \
+    || fail "Source and target semantic notification manifests differ"
+capture_database_artifacts "post-upgrade"
 
 log "Upgrade test passed"
-echo "From tag:        $FROM_TAG"
-echo "Upgraded commit: $CURRENT_HEAD"
-echo "Wallet:          $TARGET_WALLET_NAME ($TARGET_WALLET_CHECKSUM)"
-echo "ntfy topic:      $NTFY_TOPIC"
-echo "Pre-upgrade tx:  $PRE_UPGRADE_TXID"
-echo "Post-upgrade tx: $POST_UPGRADE_TXID"
-echo "Logs:            $LOG_DIR"
+RUN_SUCCEEDED=1
+echo "Source:    $FROM_TAG ($SOURCE_SHA)"
+echo "Target:    $TO_REF ($TARGET_SHA)"
+echo "Scenarios: incoming/outgoing pending+confirmed, RBF, CPFP, balance crossing, fan-out, inactive non-delivery, restart dedup"
+echo "Wallet:    $TARGET_WALLET_NAME ($TARGET_WALLET_CHECKSUM)"
+if [[ "$KEEP_WORKTREE" -eq 1 ]]; then
+    echo "Artifacts: $WORK_DIR"
+fi


### PR DESCRIPTION
## Summary

- add a reusable manual regtest gate for exact-ref notification upgrades, including authenticated local ntfy capture, incoming/outgoing confirmations, RBF, CPFP, balance crossings, contact fan-out, inactive non-delivery, and restart deduplication
- preserve v1.5.2 delivery semantics during migration: existing contacts do not gain an extra RBF-specific message, active balance alerts fan out once, and unmatched/history-backed wallet-level rows remain inactive audit data
- compare normalized semantic manifests and database delivery logs, retain failure artifacts automatically, and verify migrated compact contact summaries with Playwright
- document `--to-ref`, destructive regtest-volume scope, results, and artifact locations while keeping the gate manual

## Verification

- `PATH=/opt/homebrew/opt/rustup/bin:$PATH .agent-loop/checks.sh quick`
- `PATH=/opt/homebrew/opt/rustup/bin:$PATH .agent-loop/checks.sh upgrade`
  - source: `v1.5.2` (`a34a178705acecceaf1a3bfdf4720bd25e55fd63`)
  - target: `d4a28cf4e233c1239baf5ea92cdbb8dc0da93829`
  - both pre/post Playwright stages and normalized notification semantics passed

Refs #499. The issue should remain open until merged `master` and the final v1.6.0 release candidate both pass the manual gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> In-place SQL migration edits affect upgrade data integrity and notification delivery for anyone on unreleased 031–034; the expanded upgrade gate is manual but touches auth, ntfy, and local Docker regtest fixtures.
> 
> **Overview**
> Adds a **manual regtest release gate** (`test-upgrade.sh` with `--to-ref`) that upgrades from a tagged source (e.g. v1.5.2) to an exact target, runs a full notification matrix before and after, and compares normalized delivery semantics against ntfy captures, SQLite logs, and Playwright UI checks. Scenarios cover incoming/outgoing pending+confirmed, RBF, CPFP, balance-threshold fan-out, inactive contact non-delivery, backend restart dedup, and migrated compact contact summaries; failures retain worktrees, DB snapshots, and service logs.
> 
> **Unreleased migrations 031–034 are corrected in place** so v1.6.0 upgrades preserve v1.5.2 behavior: existing contacts get `notify_rbf = 0` (no extra RBF-specific messages), wallet-level balance alerts with notification history are kept inactive instead of deleted, and migration 034 deactivates remaining wallet-level parents rather than cascading away audit history. Rust migration tests are extended through 034 for these cases.
> 
> Docs and `.agent-loop/checks.sh upgrade` clarify destructive `docker-compose.yml` volume scope and gate usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a28cf4e233c1239baf5ea92cdbb8dc0da93829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->